### PR TITLE
Feat gw controllable and vega params yzd 1105

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { LightBulbIcon } from '@heroicons/react/24/outline'
 import { toJS } from 'mobx';
 import { useTranslation } from 'react-i18next';
-import { IMutField, IRow } from './interfaces';
+import { IMutField, IRow, ViewContentEntry } from './interfaces';
 import VisualSettings from './visualSettings';
 import { Container, NestContainer } from './components/container';
 import ClickMenu from './components/clickMenu';
@@ -20,6 +20,7 @@ import VisNav from './segments/visNav';
 import { mergeLocaleRes, setLocaleLanguage } from './locales/i18n';
 import Menubar from './visualSettings/menubar';
 import FilterField from './fields/filterField';
+import { fromViewData } from './utils/viewContent';
 import "tailwindcss/tailwind.css"
 import './index.css'
 
@@ -32,10 +33,11 @@ export interface EditorProps {
 	i18nLang?: string;
 	i18nResources?: { [lang: string]: Record<string, string | any> };
 	keepAlive?: boolean;
+	onViewContentChange?: (dataName: string, entry: ViewContentEntry) => void;
 }
 
 const App: React.FC<EditorProps> = props => {
-	const { dataSource = [], rawFields = [], spec, i18nLang = 'en-US', i18nResources, hideDataSourceConfig } = props;
+	const { dataSource = [], rawFields = [], spec, i18nLang = 'en-US', i18nResources, hideDataSourceConfig, onViewContentChange } = props;
 	const { commonStore, vizStore } = useGlobalStore();
 	const [insightReady, setInsightReady] = useState<boolean>(true);
 
@@ -87,6 +89,24 @@ const App: React.FC<EditorProps> = props => {
 			destroyWorker();
 		}
 	}, [currentDataset, spec]);
+
+	// fire callback
+	const { draggableFieldState, visualConfig: { defaultAggregated, stack } } = vizStore;
+	useEffect(() => {
+		if (onViewContentChange) {
+			const entry = fromViewData(
+				currentDataset.rawFields,
+				commonStore.binnedFields,
+				draggableFieldState,
+				defaultAggregated,
+				stack,
+			);
+			onViewContentChange(
+				currentDataset.name,
+				entry,
+			);
+		}
+	}, [commonStore, currentDataset, draggableFieldState, onViewContentChange, defaultAggregated, stack]);
 
 	return (
 		<div className="App">

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { LightBulbIcon } from '@heroicons/react/24/outline'
 import { toJS } from 'mobx';
 import { useTranslation } from 'react-i18next';
-import { IMutField, IRow, ViewContentEntry } from './interfaces';
+import { IMutField, IRow, IGWViewData } from './interfaces';
 import VisualSettings from './visualSettings';
 import { Container, NestContainer } from './components/container';
 import ClickMenu from './components/clickMenu';
@@ -33,7 +33,8 @@ export interface EditorProps {
 	i18nLang?: string;
 	i18nResources?: { [lang: string]: Record<string, string | any> };
 	keepAlive?: boolean;
-	onViewContentChange?: (dataName: string, entry: ViewContentEntry) => void;
+	/** @experimental works when `hideDataSourceConfig` is `false` */
+	onViewContentChange?: (data: IGWViewData) => void;
 }
 
 const App: React.FC<EditorProps> = props => {
@@ -91,22 +92,20 @@ const App: React.FC<EditorProps> = props => {
 	}, [currentDataset, spec]);
 
 	// fire callback
-	const { draggableFieldState, visualConfig: { defaultAggregated, stack } } = vizStore;
+	const { draggableFieldState, visualConfig: { defaultAggregated, stack, geoms } } = vizStore;
 	useEffect(() => {
-		if (onViewContentChange) {
+		if (onViewContentChange && hideDataSourceConfig) {
 			const entry = fromViewData(
 				currentDataset.rawFields,
 				commonStore.binnedFields,
 				draggableFieldState,
 				defaultAggregated,
 				stack,
+				geoms[0],
 			);
-			onViewContentChange(
-				currentDataset.name,
-				entry,
-			);
+			onViewContentChange(entry);
 		}
-	}, [commonStore, currentDataset, draggableFieldState, onViewContentChange, defaultAggregated, stack]);
+	}, [commonStore, currentDataset, draggableFieldState, onViewContentChange, defaultAggregated, stack, hideDataSourceConfig, geoms[0]]);
 
 	return (
 		<div className="App">

--- a/packages/graphic-walker/src/config.ts
+++ b/packages/graphic-walker/src/config.ts
@@ -25,6 +25,18 @@ export const CHART_LAYOUT_TYPE: Readonly<string[]> = [
     'fixed',
 ] as const;
 
+export const EXPLORATION_TYPES = [
+    'none',
+    'brush',
+    'point',
+] as const;
+
+export const BRUSH_DIRECTIONS = [
+    'default',
+    'x',
+    'y',
+] as const;
+
 export const COLORS = {
     // tableau style
     // dimension: 'rgb(73, 150, 178)',

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -1,6 +1,7 @@
 import { StatFuncName } from "visual-insights/build/esm/statistics";
 import { AggFC } from 'cube-core/built/types';
 import { IAnalyticType, IMutField as VIMutField, ISemanticType } from 'visual-insights';
+import type { AnyMark } from "vega-lite/build/src/mark";
 
 export type DeepReadonly<T extends Record<keyof any, any>> = {
     readonly [K in keyof T]: T[K] extends Record<keyof any, any> ? DeepReadonly<T[K]> : T[K];
@@ -131,23 +132,27 @@ export type IFilterRule = {
 
 
 export type IStackMode = 'none' | 'stack' | 'normalize';
+export type ISortMode = 'none' | 'ascending' | 'descending';
+export type ISizeMode = 'auto' | 'fixed';
+export type IExplorationMode = 'none' | 'brush' | 'point';
+export type IBrushDirection = 'default' | 'x' | 'y';
 
 export interface IVisualConfig {
     defaultAggregated: boolean;
     geoms:  string[];        
-    stack: 'none' | 'stack' | 'normalize';
+    stack: IStackMode;
     showActions: boolean;
     interactiveScale: boolean;
-    sorted: 'none' | 'ascending' | 'descending';
+    sorted: ISortMode;
     size: {
-        mode: 'auto' | 'fixed';
+        mode: ISizeMode;
         width: number;
         height: number;
-    }
+    };
     exploration: {
-        mode: 'none' | 'brush' | 'point';
+        mode: IExplorationMode;
         /** works when mode is 'brush' */
-        brushDirection: 'default' | 'x' | 'y';
+        brushDirection: IBrushDirection;
     };
 }
 
@@ -170,23 +175,34 @@ type IFilter = {
     range: [number, number];
 };
 
-interface IFieldEncode {
-    field?: string;
-    title?: string;
-    type?: ISemanticType;
-    aggregate?: string;
-    bin?: boolean;
-    scale?: any;
-    stack?: any;
+export interface IEncodedChannel {
+    field: string;
+    title: string;
+    type: ISemanticType;
+    aggregate?: string | undefined;
+    /**
+     * only applicable for x, y, theta, and radius channels with continuous domains.
+     * @default
+     * /** zero for plots with all of the following conditions are true:
+     * (1) the mark is bar, area, or arc;
+     * (2) the stacked measure channel (x or y) has a linear scale;
+     * (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y.
+     * Otherwise, null by default. *\/
+     * @see https://vega.github.io/vega-lite/docs/stack.html#encoding
+     */
+    stack?: IStackMode | undefined;
+    bin?: boolean | undefined;
+    order?: IViewField['sort'];
 }
 
-export interface ViewContentEntry {
+export type VegaEncodingKey = 'x' | 'y' | 'color' | 'opacity' | 'row' | 'column' | 'size' | 'shape';
+
+export interface IGWViewData {
+    markType?: (AnyMark & string) | undefined;
     fields: IField[];
     filters: IFilter[];
-    encodes: IFieldEncode[];
+    encoding: Partial<Record<
+        VegaEncodingKey,
+        IEncodedChannel | undefined
+    >>;
 }
-
-export type ViewContentChangeEvent = {
-    dataName: string;
-    entry: ViewContentEntry;
-};

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -144,6 +144,11 @@ export interface IVisualConfig {
         width: number;
         height: number;
     }
+    exploration: {
+        mode: 'none' | 'brush' | 'point';
+        /** works when mode is 'brush' */
+        brushDirection: 'default' | 'x' | 'y';
+    };
 }
 
 export interface IVisSpec {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -152,3 +152,36 @@ export interface IVisSpec {
     readonly encodings: DeepReadonly<DraggableFieldState>;
     readonly config: DeepReadonly<IVisualConfig>;
 }
+
+type IFilter = {
+    fid: string;
+    disable?: boolean;
+    type: 'set';
+    values: any[];
+} | {
+    fid: string;
+    disable?: boolean;
+    type: 'range';
+    range: [number, number];
+};
+
+interface IFieldEncode {
+    field?: string;
+    title?: string;
+    type?: ISemanticType;
+    aggregate?: string;
+    bin?: boolean;
+    scale?: any;
+    stack?: any;
+}
+
+export interface ViewContentEntry {
+    fields: IField[];
+    filters: IFilter[];
+    encodes: IFieldEncode[];
+}
+
+export type ViewContentChangeEvent = {
+    dataName: string;
+    entry: ViewContentEntry;
+};

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -30,6 +30,18 @@
             "auto": "Auto",
             "fixed": "Fixed"
         },
+        "exploration_mode": {
+            "__enum__": "Exploration Mode",
+            "none": "Off",
+            "brush": "Brush",
+            "point": "Point"
+        },
+        "brush_mode": {
+            "__enum__": "Brush Direction",
+            "default": "Both",
+            "x": "X-Only",
+            "y": "Y-Only"
+        },
         "draggable_key": {
             "fields": "Fields",
             "columns": "Columns",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -24,6 +24,18 @@
             "auto": "自动",
             "fixed": "固定"
         },
+        "exploration_mode": {
+            "__enum__": "探索交互",
+            "none": "关",
+            "brush": "范围",
+            "point": "目标"
+        },
+        "brush_mode": {
+            "__enum__": "框选方向",
+            "default": "所有",
+            "x": "仅 X 轴",
+            "y": "仅 Y 轴"
+        },
         "stack_mode": {
             "__enum__": "堆叠模式",
             "none": "关闭",

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -10,7 +10,7 @@ import ReactVega from '../vis/react-vega';
 const ReactiveRenderer: React.FC = props => {
     const { vizStore, commonStore } = useGlobalStore();
     const { draggableFieldState, visualConfig } = vizStore;
-    const { geoms, interactiveScale, defaultAggregated, stack, showActions, size } = visualConfig;
+    const { geoms, interactiveScale, defaultAggregated, stack, showActions, size, exploration } = visualConfig;
     const { currentDataset } = commonStore;
     const { filters } = draggableFieldState;
 
@@ -27,13 +27,17 @@ const ReactiveRenderer: React.FC = props => {
     const colLeftFacetFields = columns.slice(0, -1).filter(f => f.analyticType === 'dimension');
 
     const hasFacet = rowLeftFacetFields.length > 0 || colLeftFacetFields.length > 0;
+
+    const shouldTriggerMenu = exploration.mode === 'none';
     
-    const onGeomClick = useCallback((values: any, e: any) => {
-        runInAction(() => {
-            commonStore.showEmbededMenu([e.pageX, e.pageY])
-            commonStore.setFilters(values);
-        })
-    }, [])
+    const handleGeomClick = useCallback((values: any, e: any) => {
+        if (shouldTriggerMenu) {
+            runInAction(() => {
+                commonStore.showEmbededMenu([e.pageX, e.pageY])
+                commonStore.setFilters(values);
+            });
+        }
+    }, [shouldTriggerMenu]);
 
     // apply filters
     const { dataSource } = currentDataset;
@@ -93,10 +97,12 @@ const ReactiveRenderer: React.FC = props => {
         shape={shape[0]}
         opacity={opacity[0]}
         size={sizeChannel[0]}
-        onGeomClick={onGeomClick}
         showActions={showActions}
         width={size.width - 12 * 4}
         height={size.height - 12 * 4}
+        brushEncoding={exploration.mode === 'brush' ? exploration.brushDirection : 'none'}
+        selectEncoding={exploration.mode === 'point' ? 'default' : 'none'}
+        onGeomClick={handleGeomClick}
     />
     </Resizable>
 }

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -97,7 +97,7 @@ const ReactiveRenderer: React.FC = props => {
         shape={shape[0]}
         opacity={opacity[0]}
         size={sizeChannel[0]}
-        showActions={showActions || true}
+        showActions={showActions}
         width={size.width - 12 * 4}
         height={size.height - 12 * 4}
         brushEncoding={exploration.mode === 'brush' ? exploration.brushDirection : 'none'}

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -97,7 +97,7 @@ const ReactiveRenderer: React.FC = props => {
         shape={shape[0]}
         opacity={opacity[0]}
         size={sizeChannel[0]}
-        showActions={showActions}
+        showActions={showActions || true}
         width={size.width - 12 * 4}
         height={size.height - 12 * 4}
         brushEncoding={exploration.mode === 'brush' ? exploration.brushDirection : 'none'}

--- a/packages/graphic-walker/src/store/commonStore.ts
+++ b/packages/graphic-walker/src/store/commonStore.ts
@@ -9,6 +9,8 @@ export class CommonStore {
     public dsIndex: number = 0;
     public tmpDSName: string = '';
     public tmpDSRawFields: IMutField[] = [];
+    /** binField.fid -> originField.fid */
+    public binnedFields = new Map<string, string>();
     public tmpDataSource: IRow[] = [];
     public showDSPanel: boolean = false;
     public showInsightBoard: boolean = false;
@@ -21,7 +23,8 @@ export class CommonStore {
         makeAutoObservable(this, {
             dataSources: observable.ref,
             tmpDataSource: observable.ref,
-            filters: observable.ref
+            filters: observable.ref,
+            binnedFields: false,
         });
     }
     public get currentDataset (): DataSet {

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -452,6 +452,7 @@ export class VizSpecStore {
                 analyticType: 'dimension',
             };
             encodings.dimensions.push(binField);
+            this.commonStore.binnedFields.set(binField.fid, originField.fid);
             this.commonStore.currentDataset.dataSource = makeBinField(this.commonStore.currentDataset.dataSource, originField.fid, binField.fid)
         });
     }

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -2,7 +2,7 @@ import { IReactionDisposer, makeAutoObservable, observable, reaction, toJS } fro
 import produce from 'immer';
 import { v4 as uuidv4 } from 'uuid';
 import { Specification } from "visual-insights";
-import { DataSet, DraggableFieldState, IFilterRule, IViewField, IVisualConfig } from "../interfaces";
+import { DataSet, DraggableFieldState, IFilterRule, IViewField, IVisSpec, IVisualConfig } from "../interfaces";
 import { CHANNEL_LIMIT, GEMO_TYPES, MetaFieldKeys } from "../config";
 import { makeBinField, makeLogField } from "../utils/normalization";
 import { VisSpecWithHistory } from "../models/visSpecHistory";
@@ -69,12 +69,26 @@ function initVisualConfig (): IVisualConfig {
             mode: 'auto',
             width: 320,
             height: 200
-        }
+        },
+        exploration: {
+            mode: 'brush',
+            brushDirection: 'default',
+        },
     }
 }
 
 type DeepReadonly<T extends Record<keyof any, any>> = {
     readonly [K in keyof T]: T[K] extends Record<keyof any, any> ? DeepReadonly<T[K]> : T[K];
+};
+
+const forwardVisualConfigs = (backwards: ReturnType<typeof parseGWContent>['specList']): IVisSpec[] => {
+    return backwards.map(content => ({
+        ...content,
+        config: {
+            ...initVisualConfig(),
+            ...content.config,
+        },
+    }));
 };
 
 
@@ -363,6 +377,16 @@ export class VizSpecStore {
             config.size.height = height;
         });
     }
+    public setExploration(value: Partial<IVisualConfig['exploration']>) {
+        this.useMutable(({ config }) => {
+            if (value.mode) {
+                config.exploration.mode = value.mode;
+            }
+            if (value.brushDirection) {
+                config.exploration.brushDirection = value.brushDirection;
+            }
+        });
+    }
     public reorderField(stateKey: keyof DraggableFieldState, sourceIndex: number, destinationIndex: number) {
         if (MetaFieldKeys.includes(stateKey)) return;
         if (sourceIndex === destinationIndex) return;
@@ -581,7 +605,8 @@ export class VizSpecStore {
         this.commonStore.datasets = content.datasets;
         this.commonStore.dataSources = content.dataSources;
         this.commonStore.dsIndex = Math.max(content.datasets.length - 1, 0);
-        this.visList = parseGWPureSpec(content.specList)
+        // 补上初始化新版本特性
+        this.visList = parseGWPureSpec(forwardVisualConfigs(content.specList));
         this.visIndex = 0;
     }
 }

--- a/packages/graphic-walker/src/utils/save.ts
+++ b/packages/graphic-walker/src/utils/save.ts
@@ -12,7 +12,10 @@ export function parseGWPureSpec (list: IVisSpec[]): VisSpecWithHistory[] {
 
 interface IStoInfo {
     datasets: IDataSet[];
-    specList: IVisSpec[];
+    specList: ({
+        /** 由于 gw 内部实现暂时未锁版本，这里获取到的信息可能会与当前实例内容有偏差，需要用初始值合入 */
+        [K in keyof IVisSpec]: K extends 'config' ? Partial<IVisSpec[K]> : IVisSpec[K];
+    })[];
     dataSources: IDataSource[]
 }
 

--- a/packages/graphic-walker/src/utils/viewContent.ts
+++ b/packages/graphic-walker/src/utils/viewContent.ts
@@ -1,0 +1,74 @@
+import { COUNT_FIELD_ID } from "../constants";
+import type { IMutField, IStackMode, ViewContentEntry } from "../interfaces";
+import type { VizSpecStore } from "../store/visualSpecStore";
+
+
+export const fromViewData = (
+  rawFields: IMutField[],
+  binnedFields: Map<string, string>,
+  schema: VizSpecStore['draggableFieldState'],
+  aggregationEnabled: boolean,
+  stackMode: IStackMode,
+): ViewContentEntry => {
+  const fields = rawFields.filter(f => f.fid !== COUNT_FIELD_ID);
+
+  return {
+    fields: fields.map(f => ({
+      fid: f.fid,
+      name: f.name ?? '',
+      semanticType: f.semanticType,
+      analyticType: f.analyticType,
+    })),
+    filters: schema.filters.map<undefined | ViewContentEntry['filters'][number]>(filter => {
+      const rule = filter.rule;
+      if (!rule) {
+        return undefined;
+      }
+      const isBinned = binnedFields.has(filter.fid);
+      const fid = isBinned ? binnedFields.get(filter.fid) : filter.fid;
+      const f = fields.find(which => which.fid === fid);
+
+      return fid && f ? rule.type === 'one of' ? {
+        fid,
+        type: 'set',
+        values: [...rule.value],
+      } : {
+        fid,
+        type: 'range',
+        range: [rule.value[0], rule.value[1]],
+      } : undefined;
+    }).filter(Boolean) as ViewContentEntry['filters'],
+    encodes: (
+      ['columns', 'rows', 'color', 'opacity', 'size', 'shape'] as const
+    ).map(key => schema[key].map(item => {
+      const isBinned = binnedFields.has(item.fid);
+      const fid = isBinned ? binnedFields.get(item.fid) : item.fid;
+      const f = fields.find(which => which.fid === fid);
+
+      return f ? {
+        field: f.fid,
+        title: item.name,
+        type: item.semanticType,
+        aggregate: aggregationEnabled ? item.aggName : undefined,
+        bin: isBinned,
+        /**
+         * only applicable for x, y, theta, and radius channels with continuous domains.
+         * @default
+         * /** zero for plots with all of the following conditions are true:
+         * (1) the mark is bar, area, or arc;
+         * (2) the stacked measure channel (x or y) has a linear scale;
+         * (3) At least one of non-position channels mapped to an unaggregated field that is different from x and y.
+         * Otherwise, null by default. *\/
+         * @see https://vega.github.io/vega-lite/docs/stack.html#encoding
+         */
+        stack: ['columns', 'rows', 'theta', 'radius'].includes(key) ? stackMode : undefined,
+      } : fid === COUNT_FIELD_ID ? {
+        title: item.name,
+        type: item.semanticType,
+        aggregate: 'count',
+        bin: isBinned,
+        stack: ['columns', 'rows', 'theta', 'radius'].includes(key) ? stackMode : undefined,
+      } : undefined;
+    }).filter(Boolean) as ViewContentEntry['encodes']).flat(),
+  };
+};

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -401,11 +401,10 @@ const ReactVega: React.FC<ReactVegaProps> = props => {
         selectEncoding,
         brushEncoding,
       });
-      // console.log('!!!', singleView, { ...spec, ...singleView })
-      if (layoutMode === 'fixed') {
-        spec.width = 800;
-        spec.height = 600;
-      }
+      // if (layoutMode === 'fixed') {
+      //   spec.width = 800;
+      //   spec.height = 600;
+      // }
       spec.mark = singleView.mark;
       if ('encoding' in singleView) {
         spec.encoding = singleView.encoding;

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -232,9 +232,9 @@ function getSingleView(props: SingleViewProps) {
                 ...encoding.color,
                 test: 'false',
               },
-              value: '#8882',
+              value: '#888',
             } : {
-              value: '#8882',
+              value: '#888',
             },
           },
         },
@@ -264,7 +264,7 @@ function getSingleView(props: SingleViewProps) {
             ...encoding.color,
             param: BRUSH_SIGNAL_NAME,
           },
-          value: '#8882',
+          value: '#888',
         },
       },
     };
@@ -284,7 +284,7 @@ function getSingleView(props: SingleViewProps) {
           ...encoding.color,
           param: POINT_SIGNAL_NAME,
         },
-        value: '#8882',
+        value: '#888',
       },
     },
   };
@@ -442,7 +442,7 @@ const ReactVega: React.FC<ReactVegaProps> = props => {
       }
       const combinedParamStore$ = new Subject<ParamStoreEntry>();
       const throttledParamStore$ = combinedParamStore$.pipe(
-        op.throttleTime(Math.log1p(dataSource.length) * rowRepeatFields.length * colRepeatFields.length)
+        op.throttleTime(dataSource.length / 64 * rowRepeatFields.length * colRepeatFields.length)
       );
       const subscriptions: Subscription[] = [];
       const subscribe = (cb: (entry: ParamStoreEntry) => void) => {

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -211,10 +211,10 @@ function getSingleView(props: SingleViewProps) {
     opacity: 0.96,
     tooltip: true
   };
-  const multipleLayers = brushEncoding !== 'none' && Object.values(encoding).some(channel => {
-    return Boolean(channel.aggregate);
+  const shouldUseMultipleLayers = brushEncoding !== 'none' && Object.values(encoding).some(channel => {
+    return typeof channel.aggregate === 'string' && /* 这种 case 对应行数 */ typeof channel.field === 'string';
   });
-  if (multipleLayers) {
+  if (shouldUseMultipleLayers) {
     return {
       layer: [
         {

--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -6,7 +6,7 @@ import { ArrowPathIcon } from '@heroicons/react/24/solid';
 import { useTranslation } from 'react-i18next';
 import { LiteForm } from '../components/liteForm';
 import SizeSetting from '../components/sizeSetting';
-import { CHART_LAYOUT_TYPE, GEMO_TYPES, STACK_MODE } from '../config';
+import { BRUSH_DIRECTIONS, CHART_LAYOUT_TYPE, EXPLORATION_TYPES, GEMO_TYPES, STACK_MODE } from '../config';
 import { useGlobalStore } from '../store';
 import { IStackMode } from '../interfaces';
 
@@ -225,6 +225,68 @@ const VisualSettings: React.FC = () => {
                 >
                     {t('size')}
                 </label>
+            </div>
+            <div className="item">
+                <label
+                    id="dropdown:exploration_mode:label"
+                    htmlFor="dropdown:exploration_mode"
+                >
+                    {tGlobal(`constant.exploration_mode.__enum__`)}
+                </label>
+                <select
+                    className="border border-gray-500 rounded-sm text-xs pt-0.5 pb-0.5 pl-2 pr-2 cursor-pointer"
+                    id="dropdown:exploration_mode"
+                    aria-describedby="dropdown:exploration_mode:label"
+                    value={visualConfig.exploration.mode}
+                    onChange={e => {
+                        vizStore.setExploration({
+                            mode: e.target.value as (typeof EXPLORATION_TYPES)[number]
+                        });
+                    }}
+                >
+                    {EXPLORATION_TYPES.map(g => (
+                        <option
+                            key={g}
+                            value={g}
+                            className="cursor-pointer"
+                            aria-selected={visualConfig.exploration.mode === g}
+                        >
+                            {tGlobal(`constant.exploration_mode.${g}`)}
+                        </option>
+                    ))}
+                </select>
+            </div>
+            <div className="item" style={{ opacity: visualConfig.exploration.mode !== 'brush' ? 0.3 : undefined }}>
+                <label
+                    id="dropdown:brush_mode:label"
+                    htmlFor="dropdown:brush_mode"
+                >
+                    {tGlobal(`constant.brush_mode.__enum__`)}
+                </label>
+                <select
+                    className="border border-gray-500 rounded-sm text-xs pt-0.5 pb-0.5 pl-2 pr-2 cursor-pointer"
+                    id="dropdown:brush_mode"
+                    aria-describedby="dropdown:brush_mode:label"
+                    disabled={visualConfig.exploration.mode !== 'brush'}
+                    aria-disabled={visualConfig.exploration.mode !== 'brush'}
+                    value={visualConfig.exploration.brushDirection}
+                    onChange={e => {
+                        vizStore.setExploration({
+                            brushDirection: e.target.value as (typeof BRUSH_DIRECTIONS)[number]
+                        });
+                    }}
+                >
+                    {BRUSH_DIRECTIONS.map(g => (
+                        <option
+                            key={g}
+                            value={g}
+                            className="cursor-pointer"
+                            aria-selected={visualConfig.exploration.brushDirection === g}
+                        >
+                            {tGlobal(`constant.brush_mode.${g}`)}
+                        </option>
+                    ))}
+                </select>
             </div>
             <div className="item">
                 <input


### PR DESCRIPTION
1. **GraphicWalker** will trigger an `onViewContentChange()` call when visualization data changed if this optional property is provided.
2. Brushing and Pointing interactions applied to create filters across sub-charts are supported as configurable settings. _As a side effect, Data Interpreting is now enabled ONLY WHEN this feature is toggled `OFF`._