### PR TITLE
fix: chart history cursor overflow

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -130,6 +130,7 @@ export class VisSpecWithHistory {
 
     public clone () {
         const nextVSWH = new VisSpecWithHistory(this.frame);
+        nextVSWH.snapshots = this.snapshots.slice().map(s => ({ ...s }));
         nextVSWH.cursor = this.cursor;
         return nextVSWH;
     }


### PR DESCRIPTION
## Version

`@kanaries/graphic-walker = 0.2.15`

**Fix**: 0.2.15 -> **0.2.16 ↑**

## Issue Discription

Method `VisSpecWithHistory.clone()` brought an issue:

The copied instance has a cursor to be the same value as the source instance, however the list of snapshots was not synchronized. Accessing the current frame will get an `undefined`.

## Reproduction and Troubleshooting

https://graphic-walker-gssrfazjk-kanaries.vercel.app/

* Edit a chart (make the length of snapshots > 1), edit its name.
* Or, let there be only one chart, edit it (make the length of snapshots > 1), switch to the **Data** tab, and then switch back to the **Visualization** tab.
 
![output](https://user-images.githubusercontent.com/126073370/228711717-d7851c9c-f987-4ef4-93d4-a06248f8af25.png)

_I used `JSON.parse(JSON.stringify())` to generate a deep copy in the log so actually the snapshot list was `[<object> x m, empty x n]`, while the cursor is `m + n`, partially updated._

## Preview of Fix

https://graphic-walker-git-fork-antoineyang-fix-history-6ad2a7-kanaries.vercel.app/
