### PR TITLE
feat(): customize toolbar settings

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -19,6 +19,7 @@ import DatasetConfig from './dataSource/datasetConfig';
 import { useCurrentMediaTheme } from './utils/media';
 import CodeExport from './components/codeExport';
 import VisualConfig from './components/visualConfig';
+import type { ToolbarItemProps } from './components/toolbar';
 
 export interface IGWProps {
     dataSource?: IRow[];
@@ -36,6 +37,10 @@ export interface IGWProps {
     themeKey?: IThemeKey;
     dark?: IDarkMode;
     storeRef?: React.MutableRefObject<IGlobalStore | null>;
+    toolbar?: {
+        extra?: ToolbarItemProps[];
+        exclude?: string[];
+    };
 }
 
 const App = observer<IGWProps>(function App(props) {
@@ -49,6 +54,7 @@ const App = observer<IGWProps>(function App(props) {
         fieldKeyGuard = true,
         themeKey = 'vega',
         dark = 'media',
+        toolbar,
     } = props;
     const { commonStore, vizStore } = useGlobalStore();
 
@@ -124,7 +130,7 @@ const App = observer<IGWProps>(function App(props) {
                         style={{ marginTop: '0em', borderTop: 'none' }}
                         className="m-4 p-4 border border-gray-200 dark:border-gray-700"
                     >
-                        <VisualSettings rendererHandler={rendererRef} darkModePreference={dark} />
+                        <VisualSettings rendererHandler={rendererRef} darkModePreference={dark} exclude={toolbar?.exclude} extra={toolbar?.extra} />
                         <CodeExport />
                         <VisualConfig />
                         <div className="md:grid md:grid-cols-12 xl:grid-cols-6">
@@ -187,3 +193,5 @@ const App = observer<IGWProps>(function App(props) {
 });
 
 export default App;
+
+export type { ToolbarItemProps };

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -148,7 +148,8 @@
                     "descending": "Sort in Descending Order",
                     "transpose": "Transpose",
                     "export_chart": "Export",
-                    "export_chart_as": "Export as {{type}}"
+                    "export_chart_as": "Export as {{type}}",
+                    "export_code": "Export Code"
                 },
                 "size": "Resize",
                 "size_setting": {

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -147,7 +147,8 @@
                     "descending": "降順に並べ替える",
                     "transpose": "転置",
                     "export_chart": "エクスポート",
-                    "export_chart_as": "{{type}}としてエクスポート"
+                    "export_chart_as": "{{type}}としてエクスポート",
+                    "export_code": "コードをエクスポート"
                 },
                 "size": "サイズ変更",
                 "size_setting": {

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -148,7 +148,8 @@
                     "descending": "降序排序",
                     "transpose": "转置",
                     "export_chart": "导出",
-                    "export_chart_as": "导出 {{type}}"
+                    "export_chart_as": "导出 {{type}}",
+                    "export_code": "导出代码"
                 },
                 "size": "调整尺寸",
                 "size_setting": {

--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -61,9 +61,11 @@ const FormContainer = styled.div`
 interface IVisualSettings {
     darkModePreference: IDarkMode;
     rendererHandler?: React.RefObject<IReactVegaHandler>;
+    exclude?: string[];
+    extra?: ToolbarItemProps[];
 }
 
-const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePreference }) => {
+const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePreference, extra = [], exclude = [] }) => {
     const { vizStore, commonStore } = useGlobalStore();
     const { visualConfig, canUndo, canRedo } = vizStore;
     const { t: tGlobal } = useTranslation();
@@ -85,7 +87,7 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
     const dark = useCurrentMediaTheme(darkModePreference) === 'dark';
 
     const items = useMemo<ToolbarItemProps[]>(() => {
-        return [
+        const builtInItems = [
             {
                 key: 'undo',
                 label: 'undo (Ctrl + Z)',
@@ -296,9 +298,20 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
                 onClick: () => {
                     commonStore.setShowCodeExportPanel(true);
                 }
-            }
+            },
         ] as ToolbarItemProps[];
-    }, [vizStore, canUndo, canRedo, defaultAggregated, markType, stack, interactiveScale, sizeMode, width, height, showActions, downloadPNG, downloadSVG, dark]);
+
+        const items = builtInItems.filter(item => typeof item === 'string' || !exclude.includes(item.key));
+
+        if (extra.length > 0) {
+            items.push(
+                '-',
+                ...extra,
+            );
+        }
+
+        return items;
+    }, [vizStore, canUndo, canRedo, defaultAggregated, markType, stack, interactiveScale, sizeMode, width, height, showActions, downloadPNG, downloadSVG, dark, extra, exclude]);
 
     return <div style={{ margin: '0.38em 0.28em 0.2em 0.18em' }}>
         <Toolbar


### PR DESCRIPTION
A new optional `toolbar` prop can be set to
1. add custom toolbar items,
2. hide default toolbar items.
Developers could use this prop to modify items of the toolbar to insert their own controls - instead of creating a patch and develop changes to GraphicWalker package.