### PR TITLE
feat(store): support multiple instances

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.3.6",
+  "version": "0.3.6--fix-store-6",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import { IDarkMode, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
+import { IDarkMode, IKeepAlive, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
 import PosFields from './fields/posFields';
@@ -28,7 +28,16 @@ export interface IGWProps {
     hideDataSourceConfig?: boolean;
     i18nLang?: string;
     i18nResources?: { [lang: string]: Record<string, string | any> };
-    keepAlive?: boolean;
+    /**
+     * - `"single-instance"`: Keep-alive when only one instance of GraphicWalker is mounted.
+     * - `"always"`: Keep-alive all instances of GraphicWalker. An `id` prop must be provided.
+     * - `"never"`: Do not keep-alive.
+     * - `true` or `"true"`: Equals to `"single-instance"`.
+     * - `false` or `"false"`: Equals to `"never"`.
+     * @default "single-instance"
+     */
+    keepAlive?: IKeepAlive;
+    id?: string;
     /**
      * auto parse field key into a safe string. default is true
      */

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -218,3 +218,5 @@ export enum ISegmentKey {
 
 export type IThemeKey = 'vega' | 'g2';
 export type IDarkMode = 'media' | 'light' | 'dark';
+export type IKeepAlive = boolean | `${boolean}` | 'always' | 'single-instance' | 'never';
+export type IKeepAliveMode = 'always' | 'single-instance' | 'never';

--- a/packages/graphic-walker/src/store/index.tsx
+++ b/packages/graphic-walker/src/store/index.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import React, { type FC, useCallback, useContext, useEffect, useState, useMemo } from 'react';
+import type { IKeepAliveMode } from '../interfaces';
 import { CommonStore } from './commonStore'
 import { VizSpecStore } from './visualSpecStore'
 
@@ -7,56 +8,98 @@ export interface IGlobalStore {
     vizStore: VizSpecStore;
 }
 
-const commonStore = new CommonStore();
-const vizStore = new VizSpecStore(commonStore);
-
-const initStore: IGlobalStore = {
-    commonStore,
-    vizStore
+const KeepAliveSingleInstanceFlag: unique symbol = Symbol('KeepAliveSingleInstanceFlag');
+interface IStoreKeepAliveMeta {
+    value: IGlobalStore;
+    reset(): void;
+    refCount: number;
 }
+const keepAliveStoreMap = new Map<string | typeof KeepAliveSingleInstanceFlag, IStoreKeepAliveMeta>();
+
+export const clearStoreCache = () => {
+    for (const [key, meta] of keepAliveStoreMap.entries()) {
+        if (meta.refCount === 0) {
+            meta.reset();
+            keepAliveStoreMap.delete(key);
+        }
+    }
+    keepAliveStoreMap.clear();
+};
 
 const StoreContext = React.createContext<IGlobalStore>(null!);
 
-export function destroyGWStore() {
-    initStore.commonStore.destroy();
-    initStore.vizStore.destroy();
+interface StoreWrapperProps {
+    keepAlive: IKeepAliveMode;
+    storeRef?: React.MutableRefObject<IGlobalStore | null>;
+    id?: string | undefined;
 }
 
-export function rebootGWStore() {
+const createGWStores = (): IGlobalStore => {
     const cs = new CommonStore();
     const vs = new VizSpecStore(cs);
-    initStore.commonStore = cs;
-    initStore.vizStore = vs;
-}
+    return {
+        commonStore: cs,
+        vizStore: vs,
+    };
+};
 
-interface StoreWrapperProps {
-    keepAlive?: boolean;
-    storeRef?: React.MutableRefObject<IGlobalStore | null>;
-}
-export class StoreWrapper extends React.Component<StoreWrapperProps> {
-    constructor(props: StoreWrapperProps) {
-        super(props)
-        if (props.storeRef) {
-            props.storeRef.current = initStore;
-        }
-        if (props.keepAlive) {
-            rebootGWStore();
-        }
-    }
-    componentWillUnmount() {
-        if (!this.props.keepAlive) {
-            if (this.props.storeRef) {
-                this.props.storeRef.current = null;
+export const StoreWrapper: FC<StoreWrapperProps> = ({ children, storeRef, keepAlive, id }) => {
+    // init stores with keep-alive policy
+    const storeMeta = useMemo<IStoreKeepAliveMeta | null>(() => {
+        const key = keepAlive === 'single-instance' ? KeepAliveSingleInstanceFlag : id;
+        if (keepAlive !== 'never' && key) {
+            let meta = keepAliveStoreMap.get(key);
+            if (!meta) {
+                const value = createGWStores();
+                meta = {
+                    value,
+                    reset() {
+                        value.commonStore.destroy();
+                        value.vizStore.destroy();
+                    },
+                    refCount: 0,
+                };
+                keepAliveStoreMap.set(key, meta);
             }
-            destroyGWStore();
+            return meta!;
         }
-    }
-    render() {
-        return <StoreContext.Provider value={initStore}>
-            { this.props.children }
+        return null;
+    }, [keepAlive, id]);
+    const initStores = useCallback((): IGlobalStore => {
+        return storeMeta?.value ?? createGWStores();
+    }, [storeMeta]);
+    const [stores, setStores] = useState(initStores);
+    useEffect(() => {
+        setStores(initStores());
+    }, [initStores]);
+
+    // ref count
+    useEffect(() => {
+        if (!storeMeta) {
+            return;
+        }
+        storeMeta.refCount += 1;
+        return () => {
+            storeMeta.refCount -= 1;
+        };
+    }, [storeMeta]);
+
+    // post ref
+    useEffect(() => {
+        if (storeRef) {
+            storeRef.current = stores;
+            return () => {
+                storeRef.current = storeMeta?.value ?? null;
+            };
+        }
+    }, [storeMeta, storeRef, stores]);
+
+    return (
+        <StoreContext.Provider value={stores}>
+            {children}
         </StoreContext.Provider>
-    }
-}
+    );
+};
 
 export function useGlobalStore() {
     return useContext(StoreContext);


### PR DESCRIPTION
This change extends the feature of `keepAlive` prop to support multiple store sets