### PR TITLE
Renderer mode support

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.3.6--fix-store-6",
+  "version": "0.3.6",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.3.6",
+  "version": "0.3.6--fix-store-6",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -52,6 +52,10 @@ export interface IGWProps {
         extra?: ToolbarItemProps[];
         exclude?: string[];
     };
+    autoSize?: {
+        width: number;
+        height: number;
+    };
 }
 
 const App = observer<IGWProps>(function App(props) {
@@ -67,6 +71,7 @@ const App = observer<IGWProps>(function App(props) {
         dark = 'media',
         toolbar,
         mode = 'editor',
+        autoSize,
     } = props;
     const { commonStore, vizStore } = useGlobalStore();
 
@@ -125,12 +130,12 @@ const App = observer<IGWProps>(function App(props) {
     const renderer = (
         <>
             {datasets.length > 0 && (
-                <ReactiveRenderer ref={rendererRef} themeKey={themeKey} dark={dark} />
+                <ReactiveRenderer ref={rendererRef} themeKey={themeKey} dark={dark} autoSize={autoSize} />
             )}
         </>
     );
 
-    if (mode === 'editor') {
+    if (mode === 'renderer') {
         return (
             <div
                 className={`${

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import { IDarkMode, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
+import { IDarkMode, IKeepAlive, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
 import PosFields from './fields/posFields';
@@ -28,7 +28,16 @@ export interface IGWProps {
     hideDataSourceConfig?: boolean;
     i18nLang?: string;
     i18nResources?: { [lang: string]: Record<string, string | any> };
-    keepAlive?: boolean;
+    /**
+     * - `"single-instance"`: Keep-alive when only one instance of GraphicWalker is mounted.
+     * - `"always"`: Keep-alive all instances of GraphicWalker. An `id` prop must be provided.
+     * - `"never"`: Do not keep-alive.
+     * - `true` or `"true"`: Equals to `"single-instance"`.
+     * - `false` or `"false"`: Equals to `"never"`.
+     * @default "single-instance"
+     */
+    keepAlive?: IKeepAlive;
+    id?: string;
     /**
      * auto parse field key into a safe string. default is true
      */

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import { IDarkMode, IKeepAlive, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
+import { IDarkMode, IDisplayMode, IKeepAlive, IMutField, IRow, ISegmentKey, IThemeKey, Specification } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
 import PosFields from './fields/posFields';
@@ -38,6 +38,8 @@ export interface IGWProps {
      */
     keepAlive?: IKeepAlive;
     id?: string;
+    /** @default "editor" */
+    mode?: IDisplayMode;
     /**
      * auto parse field key into a safe string. default is true
      */
@@ -64,6 +66,7 @@ const App = observer<IGWProps>(function App(props) {
         themeKey = 'vega',
         dark = 'media',
         toolbar,
+        mode = 'editor',
     } = props;
     const { commonStore, vizStore } = useGlobalStore();
 
@@ -119,6 +122,26 @@ const App = observer<IGWProps>(function App(props) {
 
     const rendererRef = useRef<IReactVegaHandler>(null);
 
+    const renderer = (
+        <>
+            {datasets.length > 0 && (
+                <ReactiveRenderer ref={rendererRef} themeKey={themeKey} dark={dark} />
+            )}
+        </>
+    );
+
+    if (mode === 'editor') {
+        return (
+            <div
+                className={`${
+                    darkMode === 'dark' ? 'dark' : ''
+                } App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}
+            >
+                {renderer}
+            </div>
+        );
+    }
+
     return (
         <div
             className={`${
@@ -164,9 +187,7 @@ const App = observer<IGWProps>(function App(props) {
                                     //     vizEmbededMenu.show && commonStore.closeEmbededMenu();
                                     // }}
                                 >
-                                    {datasets.length > 0 && (
-                                        <ReactiveRenderer ref={rendererRef} themeKey={themeKey} dark={dark} />
-                                    )}
+                                    {renderer}
                                     {/* {vizEmbededMenu.show && (
                                         <ClickMenu x={vizEmbededMenu.position[0]} y={vizEmbededMenu.position[1]}>
                                             <div

--- a/packages/graphic-walker/src/index.tsx
+++ b/packages/graphic-walker/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useMemo, useRef, useState } from "react";
+import React, { type HTMLAttributes, createContext, useEffect, useRef, useState, useMemo } from "react";
 import { StyleSheetManager } from "styled-components";
 import root from "react-shadow";
 import { DOM } from "@kanaries/react-beautiful-dnd";
@@ -14,10 +14,11 @@ import style from "./index.css?inline";
 
 export const ShadowDomContext = createContext<{ root: ShadowRoot | null }>({ root: null });
 
-export const GraphicWalker: React.FC<IGWProps> = observer((props) => {
+export const GraphicWalker = observer<IGWProps & Omit<HTMLAttributes<HTMLDivElement>, keyof IGWProps>>((props) => {
     const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
     const rootRef = useRef<HTMLDivElement>(null);
-    const { storeRef, keepAlive: ka = 'single-instance', id } = props;
+    const { storeRef, keepAlive: ka = 'single-instance', id, className, style: divStyle } = props;
+    const attrs = { className, style: divStyle };
 
     useEffect(() => {
         if (rootRef.current) {
@@ -48,8 +49,8 @@ export const GraphicWalker: React.FC<IGWProps> = observer((props) => {
     }, [ka, id]);
 
     return (
-        <StoreWrapper keepAlive={keepAlive} storeRef={storeRef} id={id}>
-            <root.div mode="open" ref={rootRef}>
+        <StoreWrapper keepAlive={keepAlive} storeRef={storeRef}>
+            <root.div mode="open" ref={rootRef} {...attrs}>
                 <style>{tailwindStyle}</style>
                 <style>{style}</style>
                 {shadowRoot && (

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -220,3 +220,4 @@ export type IThemeKey = 'vega' | 'g2';
 export type IDarkMode = 'media' | 'light' | 'dark';
 export type IKeepAlive = boolean | `${boolean}` | 'always' | 'single-instance' | 'never';
 export type IKeepAliveMode = 'always' | 'single-instance' | 'never';
+export type IDisplayMode = 'editor' | 'renderer';

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -218,3 +218,5 @@ export enum ISegmentKey {
 
 export type IThemeKey = 'vega' | 'g2';
 export type IDarkMode = 'media' | 'light' | 'dark';
+export type IKeepAlive = boolean | `${boolean}` | 'always' | 'single-instance' | 'never';
+export type IKeepAliveMode = 'always' | 'single-instance' | 'never';

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -14,9 +14,13 @@ import { getMeaAggKey } from '../utils';
 interface RendererProps {
     themeKey?: IThemeKey;
     dark?: IDarkMode;
+    autoSize?: {
+        width: number;
+        height: number;
+    };
 }
 const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, ref) {
-    const { themeKey, dark } = props;
+    const { themeKey, dark, autoSize } = props;
     const [waiting, setWaiting] = useState<boolean>(false);
     const { vizStore, commonStore } = useGlobalStore();
     const { allFields, viewFilters, viewDimensions, viewMeasures } = vizStore;
@@ -77,6 +81,7 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
             dark={dark}
             draggableFieldState={encodings}
             visualConfig={viewConfig}
+            autoSize={autoSize}
         />
     );
 });

--- a/packages/graphic-walker/src/renderer/specRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/specRenderer.tsx
@@ -14,9 +14,13 @@ interface SpecRendererProps {
     loading: boolean;
     draggableFieldState: DeepReadonly<DraggableFieldState>;
     visualConfig: IVisualConfig;
+    autoSize?: {
+        width: number;
+        height: number;
+    };
 }
 const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
-    { themeKey, dark, data, loading, draggableFieldState, visualConfig },
+    { themeKey, dark, data, loading, draggableFieldState, visualConfig, autoSize },
     ref
 ) {
     const { vizStore, commonStore } = useGlobalStore();
@@ -53,7 +57,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
         },
         []
     );
-    const enableResize = size.mode === 'fixed' && !hasFacet;
+    const enableResize = !autoSize && size.mode === 'fixed' && !hasFacet;
 
     return (
         <Resizable
@@ -111,6 +115,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                 onGeomClick={handleGeomClick}
                 themeKey={themeKey}
                 dark={dark}
+                autoSize={autoSize}
             />
         </Resizable>
     );

--- a/packages/graphic-walker/src/store/index.tsx
+++ b/packages/graphic-walker/src/store/index.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import React, { type FC, useCallback, useContext, useEffect, useState, useMemo } from 'react';
+import type { IKeepAliveMode } from '../interfaces';
 import { CommonStore } from './commonStore'
 import { VizSpecStore } from './visualSpecStore'
 
@@ -7,56 +8,98 @@ export interface IGlobalStore {
     vizStore: VizSpecStore;
 }
 
-const commonStore = new CommonStore();
-const vizStore = new VizSpecStore(commonStore);
-
-const initStore: IGlobalStore = {
-    commonStore,
-    vizStore
+const KeepAliveSingleInstanceFlag: unique symbol = Symbol('KeepAliveSingleInstanceFlag');
+interface IStoreKeepAliveMeta {
+    value: IGlobalStore;
+    reset(): void;
+    refCount: number;
 }
+const keepAliveStoreMap = new Map<string | typeof KeepAliveSingleInstanceFlag, IStoreKeepAliveMeta>();
+
+export const clearStoreCache = () => {
+    for (const [key, meta] of keepAliveStoreMap.entries()) {
+        if (meta.refCount === 0) {
+            meta.reset();
+            keepAliveStoreMap.delete(key);
+        }
+    }
+    keepAliveStoreMap.clear();
+};
 
 const StoreContext = React.createContext<IGlobalStore>(null!);
 
-export function destroyGWStore() {
-    initStore.commonStore.destroy();
-    initStore.vizStore.destroy();
+interface StoreWrapperProps {
+    keepAlive: IKeepAliveMode;
+    storeRef?: React.MutableRefObject<IGlobalStore | null>;
+    id?: string | undefined;
 }
 
-export function rebootGWStore() {
+const createGWStores = (): IGlobalStore => {
     const cs = new CommonStore();
     const vs = new VizSpecStore(cs);
-    initStore.commonStore = cs;
-    initStore.vizStore = vs;
-}
+    return {
+        commonStore: cs,
+        vizStore: vs,
+    };
+};
 
-interface StoreWrapperProps {
-    keepAlive?: boolean;
-    storeRef?: React.MutableRefObject<IGlobalStore | null>;
-}
-export class StoreWrapper extends React.Component<StoreWrapperProps> {
-    constructor(props: StoreWrapperProps) {
-        super(props)
-        if (props.storeRef) {
-            props.storeRef.current = initStore;
-        }
-        if (props.keepAlive) {
-            rebootGWStore();
-        }
-    }
-    componentWillUnmount() {
-        if (!this.props.keepAlive) {
-            if (this.props.storeRef) {
-                this.props.storeRef.current = null;
+export const StoreWrapper: FC<StoreWrapperProps> = ({ children, storeRef, keepAlive, id }) => {
+    // init stores with keep-alive policy
+    const storeMeta = useMemo<IStoreKeepAliveMeta | null>(() => {
+        const key = keepAlive === 'single-instance' ? KeepAliveSingleInstanceFlag : id;
+        if (keepAlive !== 'never' && key) {
+            let meta = keepAliveStoreMap.get(key);
+            if (!meta) {
+                const value = createGWStores();
+                meta = {
+                    value,
+                    reset() {
+                        value.commonStore.destroy();
+                        value.vizStore.destroy();
+                    },
+                    refCount: 0,
+                };
+                keepAliveStoreMap.set(key, meta);
             }
-            destroyGWStore();
+            return meta!;
         }
-    }
-    render() {
-        return <StoreContext.Provider value={initStore}>
-            { this.props.children }
+        return null;
+    }, [keepAlive, id]);
+    const initStores = useCallback((): IGlobalStore => {
+        return storeMeta?.value ?? createGWStores();
+    }, [storeMeta]);
+    const [stores, setStores] = useState(initStores);
+    useEffect(() => {
+        setStores(initStores());
+    }, [initStores]);
+
+    // ref count
+    useEffect(() => {
+        if (!storeMeta) {
+            return;
+        }
+        storeMeta.refCount += 1;
+        return () => {
+            storeMeta.refCount -= 1;
+        };
+    }, [storeMeta]);
+
+    // post ref
+    useEffect(() => {
+        if (storeRef) {
+            storeRef.current = stores;
+            return () => {
+                storeRef.current = storeMeta?.value ?? null;
+            };
+        }
+    }, [storeMeta, storeRef, stores]);
+
+    return (
+        <StoreContext.Provider value={stores}>
+            {children}
         </StoreContext.Provider>
-    }
-}
+    );
+};
 
 export function useGlobalStore() {
     return useContext(StoreContext);

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -698,6 +698,7 @@ export class VizSpecStore {
         return stringifyGWContent({
             datasets: toJS(this.commonStore.datasets),
             dataSources: this.commonStore.dataSources,
+            visIndex: this.visIndex,
             specList: pureVisList,
         });
     }
@@ -707,7 +708,7 @@ export class VizSpecStore {
     }
     public importStoInfo (stoInfo: IStoInfo) {
         this.visList = parseGWPureSpec(forwardVisualConfigs(stoInfo.specList));
-        this.visIndex = 0;
+        this.visIndex = stoInfo.visIndex ?? this.visList.length - 1;
         this.commonStore.datasets = stoInfo.datasets;
         this.commonStore.dataSources = stoInfo.dataSources;
         this.commonStore.dsIndex = Math.max(stoInfo.datasets.length - 1, 0);

--- a/packages/graphic-walker/src/utils/save.ts
+++ b/packages/graphic-walker/src/utils/save.ts
@@ -65,7 +65,7 @@ export function parseGWContent(raw: string): IStoInfo {
     return produce(specRaw, draft => {
         for (const spec of draft.specList) {
             const filtersArr = spec.encodings.filters;
-            const filtersSet = new Set(filtersArr.map<IFilterField>(f => {
+            const filtersSet = filtersArr.map<IFilterField>(f => {
                 if (f.rule?.type === 'one of') {
                     return {
                         ...f,
@@ -76,7 +76,7 @@ export function parseGWContent(raw: string): IStoInfo {
                     };
                 }
                 return f as IFilterField;
-            }));
+            });
             // @ts-expect-error
             spec.encodings.filters = filtersSet;
         }

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -51,6 +51,10 @@ interface ReactVegaProps {
   /** @default "vega" */
   themeKey?: IThemeKey;
   dark?: IDarkMode;
+  autoSize?: {
+    width: number;
+    height: number;
+};
 }
 
 const click$ = new Subject<ScenegraphEvent>();
@@ -100,7 +104,8 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     details = [],
     themeKey = 'vega',
     dark = 'media',
-    format
+    format,
+    autoSize,
   } = props;
   const [viewPlaceholders, setViewPlaceholders] = useState<React.MutableRefObject<HTMLDivElement>[]>([]);
   const { i18n } = useTranslation();
@@ -188,7 +193,14 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
       })
     }
     if (rowRepeatFields.length <= 1 && colRepeatFields.length <= 1) {
-      if (layoutMode === 'fixed') {
+      if (autoSize) {
+        spec.autosize = {
+          type: 'fit',
+          contains: 'padding'
+        };
+        spec.width = autoSize.width;
+        spec.height = autoSize.height;
+      } else if (layoutMode === 'fixed') {
         if (rowFacetField === NULL_FIELD && colFacetField === NULL_FIELD) {
           spec.autosize = 'fit'
         }
@@ -236,7 +248,14 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
         });
       }
     } else {
-      if (layoutMode === 'fixed') {
+      if (autoSize) {
+        spec.autosize = {
+          type: 'fit',
+          contains: 'padding'
+        };
+        spec.width = autoSize.width;
+        spec.height = autoSize.height;
+      } else if (layoutMode === 'fixed') {
         spec.width = Math.floor(width / colRepeatFields.length) - 5;
         spec.height = Math.floor(height / rowRepeatFields.length) - 5;
         spec.autosize = 'fit'
@@ -375,7 +394,8 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     height,
     vegaConfig,
     details,
-    text
+    text,
+    autoSize,
   ]);
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
1. Support for multiple GraphicWalker instances compatible with prop `keepAlive`. (from #82 )
2. Renderer mode - display only the canvas by setting prop `mode="renderer"`.