### PR TITLE
[Feat] gw ref update

### DIFF
--- a/packages/graphic-walker/src/components/appRoot.tsx
+++ b/packages/graphic-walker/src/components/appRoot.tsx
@@ -49,6 +49,22 @@ const AppRoot = forwardRef<IGWHandlerInsider, { children: any }>(({ children }, 
                     charts: [],
                 };
             }) as IGWHandler['exportChart'],
+            exportChartList: (async function * exportChartList (mode: IChartExportResult['mode'] = 'svg') {
+                yield {
+                    mode,
+                    total: 1,
+                    completed: 0,
+                    index: 0,
+                    data: {
+                        mode,
+                        title: '',
+                        nCols: 0,
+                        nRows: 0,
+                        charts: [],
+                    },
+                    hasNext: false,
+                };
+            }) as IGWHandler['exportChartList'],
         };
     }, []);
 

--- a/packages/graphic-walker/src/components/appRoot.tsx
+++ b/packages/graphic-walker/src/components/appRoot.tsx
@@ -47,6 +47,7 @@ const AppRoot = forwardRef<IGWHandlerInsider, { children: any }>(({ children }, 
                     nCols: 0,
                     nRows: 0,
                     charts: [],
+                    container: () => null,
                 };
             }) as IGWHandler['exportChart'],
             exportChartList: (async function * exportChartList (mode: IChartExportResult['mode'] = 'svg') {
@@ -61,6 +62,7 @@ const AppRoot = forwardRef<IGWHandlerInsider, { children: any }>(({ children }, 
                         nCols: 0,
                         nRows: 0,
                         charts: [],
+                        container: () => null,
                     },
                     hasNext: false,
                 };

--- a/packages/graphic-walker/src/components/appRoot.tsx
+++ b/packages/graphic-walker/src/components/appRoot.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, forwardRef, useImperativeHandle, type ForwardedRef, useContext } from "react";
-import type { IGWHandler } from "../interfaces";
+import type { IChartExportResult, IGWHandler } from "../interfaces";
 
 const AppRootContext = createContext<ForwardedRef<IGWHandler>>(null!);
 
@@ -10,7 +10,7 @@ export const useAppRootContext = () => {
 const AppRoot = forwardRef<IGWHandler, { children: any }>(({ children }, ref) => {
     useImperativeHandle(ref, () => {
         return {
-            exportChart: (async mode => {
+            exportChart: (async (mode: IChartExportResult['mode']) => {
                 return {
                     mode,
                     title: '',

--- a/packages/graphic-walker/src/components/appRoot.tsx
+++ b/packages/graphic-walker/src/components/appRoot.tsx
@@ -1,19 +1,46 @@
-import React, { createContext, forwardRef, useImperativeHandle, type ForwardedRef, useContext } from "react";
-import type { IChartExportResult, IGWHandler } from "../interfaces";
+import React, { createContext, forwardRef, useImperativeHandle, type ForwardedRef, useContext, type ComponentType, type RefObject } from "react";
+import type { IChartExportResult, IGWHandler, IGWHandlerInsider, IRenderStatus } from "../interfaces";
 
-const AppRootContext = createContext<ForwardedRef<IGWHandler>>(null!);
+const AppRootContext = createContext<ForwardedRef<IGWHandlerInsider>>(null);
 
-export const useAppRootContext = () => {
-    return useContext(AppRootContext);
+export const useAppRootContext = (): RefObject<IGWHandlerInsider> => {
+    const context = useContext(AppRootContext);
+    if (context && 'current' in context) {
+        return context;
+    }
+    return {
+        current: null,
+    };
 };
 
-const AppRoot = forwardRef<IGWHandler, { children: any }>(({ children }, ref) => {
+const AppRoot = forwardRef<IGWHandlerInsider, { children: any }>(({ children }, ref) => {
     useImperativeHandle(ref, () => {
+        let renderStatus: IRenderStatus = 'idle';
+        let onRenderStatusChangeHandlers: ((status: IRenderStatus) => void)[] = [];
+        const addRenderStatusChangeListener = (cb: typeof onRenderStatusChangeHandlers[number]): (() => void) => {
+            onRenderStatusChangeHandlers.push(cb);
+            const dispose = () => {
+                onRenderStatusChangeHandlers = onRenderStatusChangeHandlers.filter(which => which !== cb);
+            };
+            return dispose;
+        };
+        const updateRenderStatus = (status: IRenderStatus) => {
+            if (renderStatus === status) {
+                return;
+            }
+            renderStatus = status;
+            onRenderStatusChangeHandlers.forEach(cb => cb(renderStatus));
+        };
         return {
+            get renderStatus() {
+                return renderStatus;
+            },
+            onRenderStatusChange: addRenderStatusChangeListener,
+            updateRenderStatus,
             chartCount: 1,
             chartIndex: 0,
             openChart() {},
-            exportChart: (async (mode: IChartExportResult['mode']) => {
+            exportChart: (async (mode: IChartExportResult['mode'] = 'svg') => {
                 return {
                     mode,
                     title: '',
@@ -31,5 +58,15 @@ const AppRoot = forwardRef<IGWHandler, { children: any }>(({ children }, ref) =>
         </AppRootContext.Provider>
     );
 });
+
+export const withAppRoot = <P extends object>(Component: ComponentType<any>) => {
+    return (props: P) => {
+        return (
+            <AppRoot>
+                <Component {...props} />
+            </AppRoot>
+        );
+    };
+};
 
 export default AppRoot;

--- a/packages/graphic-walker/src/components/appRoot.tsx
+++ b/packages/graphic-walker/src/components/appRoot.tsx
@@ -10,6 +10,9 @@ export const useAppRootContext = () => {
 const AppRoot = forwardRef<IGWHandler, { children: any }>(({ children }, ref) => {
     useImperativeHandle(ref, () => {
         return {
+            chartCount: 1,
+            chartIndex: 0,
+            openChart() {},
             exportChart: (async (mode: IChartExportResult['mode']) => {
                 return {
                     mode,

--- a/packages/graphic-walker/src/index.tsx
+++ b/packages/graphic-walker/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { type ForwardedRef, forwardRef } from "react";
 import { DOM } from "@kanaries/react-beautiful-dnd";
 import { observer } from "mobx-react-lite";
 import App, { IGWProps } from "./App";
@@ -6,7 +6,7 @@ import { StoreWrapper } from "./store/index";
 import { FieldsContextWrapper } from "./fields/fieldsContext";
 import { ShadowDom } from "./shadow-dom";
 import AppRoot from "./components/appRoot";
-import type { IGWHandler } from "./interfaces";
+import type { IGWHandler, IGWHandlerInsider } from "./interfaces";
 
 import "./empty_sheet.css";
 
@@ -24,7 +24,7 @@ export const GraphicWalker = observer(forwardRef<IGWHandler, IGWProps>((props, r
 
     return (
         <StoreWrapper keepAlive={props.keepAlive} storeRef={storeRef}>
-            <AppRoot ref={ref}>
+            <AppRoot ref={ref as ForwardedRef<IGWHandlerInsider>}>
                 <ShadowDom onMount={handleMount} onUnmount={handleUnmount}>
                     <FieldsContextWrapper>
                         <App {...props} />

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -256,6 +256,19 @@ interface IExportChart {
     <T extends IChartExportResult['mode']>(mode: T): Promise<IChartExportResult<T>>;
 }
 
+export interface IChartListExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data-url'> {
+    mode: T;
+    total: number;
+    index: number;
+    data: IChartExportResult<T>;
+    hasNext: boolean;
+}
+
+interface IExportChartList {
+    <T extends Extract<IChartExportResult['mode'], 'svg'>>(mode?: T): AsyncGenerator<IChartListExportResult<T>, void, unknown>;
+    <T extends IChartExportResult['mode']>(mode: T): AsyncGenerator<IChartListExportResult<T>, void, unknown>;
+}
+
 export type IRenderStatus = 'computing' | 'rendering' | 'idle' | 'error';
 
 export interface IGWHandler {
@@ -265,6 +278,7 @@ export interface IGWHandler {
     get renderStatus(): IRenderStatus;
     onRenderStatusChange: (cb: (renderStatus: IRenderStatus) => void) => (() => void);
     exportChart: IExportChart;
+    exportChartList: IExportChartList;
 }
 
 export interface IGWHandlerInsider extends IGWHandler {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -272,15 +272,57 @@ interface IExportChartList {
     <T extends IChartExportResult['mode']>(mode: T): AsyncGenerator<IChartListExportResult<T>, void, unknown>;
 }
 
+/**
+ * The status of the current chart.
+ * * `computing`: _GraphicWalker_ is computing the data view.
+ * * `rendering`: _GraphicWalker_ is rendering the chart.
+ * * `idle`: rendering is finished.
+ * * `error`: an error occurs during the process above.
+ */
 export type IRenderStatus = 'computing' | 'rendering' | 'idle' | 'error';
 
 export interface IGWHandler {
+    /** length of the "chart" tab list */
     chartCount: number;
+    /** current selected chart index */
     chartIndex: number;
+    /** Switches to the specified chart */
     openChart: (index: number) => void;
+    /**
+     * Returns the status of the current chart.
+     * 
+     * It is computed by the following rules:
+     * - If _GraphicWalker_ is computing the data view, it returns `computing`.
+     * - If _GraphicWalker_ is rendering the chart, it returns `rendering`.
+     * - If rendering is finished, it returns `idle`.
+     * - If an error occurs during the process above, it returns `error`.
+     */
     get renderStatus(): IRenderStatus;
+    /**
+     * Registers a callback function to listen to the status change of the current chart.
+     * 
+     * @param {(renderStatus: IRenderStatus) => void} cb - the callback function
+     * @returns {() => void} a dispose function to remove this callback
+     */
     onRenderStatusChange: (cb: (renderStatus: IRenderStatus) => void) => (() => void);
+    /**
+     * Exports the current chart.
+     * 
+     * @param {IChartExportResult['mode']} [mode='svg'] - the export mode, either `svg` or `data-url`
+     */
     exportChart: IExportChart;
+    /**
+     * Exports all charts.
+     * 
+     * @param {IChartExportResult['mode']} [mode='svg'] - the export mode, either `svg` or `data-url`
+     * @returns {AsyncGenerator<IChartListExportResult, void, unknown>} an async generator to iterate over all charts
+     * @example
+     * ```ts
+     * for await (const chart of gwRef.current.exportChartList()) {
+     *     console.log(chart);
+     * }
+     * ```
+     */
     exportChartList: IExportChartList;
 }
 

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -1,4 +1,4 @@
-import {Config as VgConfig} from 'vega';
+import {Config as VgConfig, View} from 'vega';
 import {Config as VlConfig} from 'vega-lite';
 
 export type DeepReadonly<T extends Record<keyof any, any>> = {
@@ -225,6 +225,16 @@ export type IDarkMode = 'media' | 'light' | 'dark';
 
 export type VegaGlobalConfig = VgConfig | VlConfig;
 
+export interface IVegaChartRef {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    innerWidth: number;
+    innerHeight: number;
+    view: View;
+}
+
 export interface IChartExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data-url'> {
     mode: T;
     title: string;
@@ -235,6 +245,8 @@ export interface IChartExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data
         rowIndex: number;
         width: number;
         height: number;
+        canvasWidth: number;
+        canvasHeight: number;
         data: string;
     }[];
 }

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -233,6 +233,7 @@ export interface IVegaChartRef {
     innerWidth: number;
     innerHeight: number;
     view: View;
+    canvas: HTMLCanvasElement | null;
 }
 
 export interface IChartExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data-url'> {
@@ -248,7 +249,9 @@ export interface IChartExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data
         canvasWidth: number;
         canvasHeight: number;
         data: string;
+        canvas(): HTMLCanvasElement | null;
     }[];
+    container(): HTMLDivElement | null;
 }
 
 interface IExportChart {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -257,5 +257,8 @@ interface IExportChart {
 }
 
 export interface IGWHandler {
+    chartCount: number;
+    chartIndex: number;
+    openChart: (index: number) => void;
     exportChart: IExportChart;
 }

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -256,9 +256,17 @@ interface IExportChart {
     <T extends IChartExportResult['mode']>(mode: T): Promise<IChartExportResult<T>>;
 }
 
+export type IRenderStatus = 'computing' | 'rendering' | 'idle' | 'error';
+
 export interface IGWHandler {
     chartCount: number;
     chartIndex: number;
     openChart: (index: number) => void;
+    get renderStatus(): IRenderStatus;
+    onRenderStatusChange: (cb: (renderStatus: IRenderStatus) => void) => (() => void);
     exportChart: IExportChart;
+}
+
+export interface IGWHandlerInsider extends IGWHandler {
+    updateRenderStatus: (renderStatus: IRenderStatus) => void;
 }

--- a/packages/graphic-walker/src/renderer/hooks.ts
+++ b/packages/graphic-walker/src/renderer/hooks.ts
@@ -3,6 +3,7 @@ import { unstable_batchedUpdates } from 'react-dom';
 import type { DeepReadonly, IFilterField, IRow, IViewField } from '../interfaces';
 import { applyFilter, applyViewQuery, transformDataService } from '../services';
 import { getMeaAggKey } from '../utils';
+import { useAppRootContext } from '../components/appRoot';
 
 
 interface UseRendererProps {
@@ -26,8 +27,11 @@ export const useRenderer = (props: UseRendererProps): UseRendererResult => {
 
     const [viewData, setViewData] = useState<IRow[]>([]);
 
+    const appRef = useAppRootContext();
+
     useEffect(() => {
         const taskId = ++taskIdRef.current;
+        appRef.current?.updateRenderStatus('computing');
         setComputing(true);
         applyFilter(data, filters)
             .then((data) => {
@@ -53,6 +57,7 @@ export const useRenderer = (props: UseRendererProps): UseRendererResult => {
                 if (taskId !== taskIdRef.current) {
                     return;
                 }
+                appRef.current?.updateRenderStatus('rendering');
                 unstable_batchedUpdates(() => {
                     setComputing(false);
                     setViewData(data);
@@ -61,6 +66,7 @@ export const useRenderer = (props: UseRendererProps): UseRendererResult => {
                 if (taskId !== taskIdRef.current) {
                     return;
                 }
+                appRef.current?.updateRenderStatus('error');
                 console.error(err);
                 unstable_batchedUpdates(() => {
                     setComputing(false);

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -8,6 +8,7 @@ import { IReactVegaHandler } from '../vis/react-vega';
 import { unstable_batchedUpdates } from 'react-dom';
 import { useRenderer } from './hooks';
 import { initEncoding, initVisualConfig } from '../store/visualSpecStore';
+import { useChartIndexControl } from '../utils/chartIndexControl';
 
 interface RendererProps {
     themeKey?: IThemeKey;
@@ -59,6 +60,12 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
             });
         }
     }, [waiting, vizStore]);
+
+    useChartIndexControl({
+        count: visList.length,
+        index: visIndex,
+        onChange: idx => vizStore.selectVisualization(idx),
+    });
 
     const handleGeomClick = useCallback(
         (values: any, e: any) => {

--- a/packages/graphic-walker/src/renderer/pureRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/pureRenderer.tsx
@@ -3,7 +3,7 @@ import { unstable_batchedUpdates } from 'react-dom';
 import { toJS } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { ShadowDom } from '../shadow-dom';
-import AppRoot from '../components/appRoot';
+import { withAppRoot } from '../components/appRoot';
 import type { IDarkMode, IViewField, IRow, IThemeKey, DraggableFieldState, IVisualConfig } from '../interfaces';
 import type { IReactVegaHandler } from '../vis/react-vega';
 import SpecRenderer from './specRenderer';
@@ -79,23 +79,21 @@ const PureRenderer = forwardRef<IReactVegaHandler, IPureRendererProps>(function 
     }, [waiting]);
 
     return (
-        <AppRoot>
-            <ShadowDom>
-                <div className="relative">
-                    <SpecRenderer
-                        name={name}
-                        loading={waiting}
-                        data={viewData}
-                        ref={ref}
-                        themeKey={themeKey}
-                        dark={dark}
-                        draggableFieldState={visualState}
-                        visualConfig={visualConfig}
-                    />
-                </div>
-            </ShadowDom>
-        </AppRoot>
+        <ShadowDom>
+            <div className="relative">
+                <SpecRenderer
+                    name={name}
+                    loading={waiting}
+                    data={viewData}
+                    ref={ref}
+                    themeKey={themeKey}
+                    dark={dark}
+                    draggableFieldState={visualState}
+                    visualConfig={visualConfig}
+                />
+            </div>
+        </ShadowDom>
     );
 });
 
-export default observer(PureRenderer);
+export default observer(withAppRoot(PureRenderer));

--- a/packages/graphic-walker/src/utils/chartIndexControl.ts
+++ b/packages/graphic-walker/src/utils/chartIndexControl.ts
@@ -12,7 +12,7 @@ export const useChartIndexControl = (options: IUseChartIndexControlOptions): voi
     const appRef = useAppRootContext();
     
     useEffect(() => {
-        if (appRef && 'current' in appRef && appRef.current) {
+        if (appRef.current) {
             appRef.current.chartCount = options.count;
             appRef.current.chartIndex = options.index;
             appRef.current.openChart = function (index: number) {
@@ -29,7 +29,7 @@ export const useChartIndexControl = (options: IUseChartIndexControlOptions): voi
 
     useEffect(() => {
         return () => {
-            if (appRef && 'current' in appRef && appRef.current) {
+            if (appRef.current) {
                 appRef.current.chartCount = 1;
                 appRef.current.chartIndex = 0;
                 appRef.current.openChart = () => {};

--- a/packages/graphic-walker/src/utils/chartIndexControl.ts
+++ b/packages/graphic-walker/src/utils/chartIndexControl.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useAppRootContext } from "../components/appRoot";
+
+
+interface IUseChartIndexControlOptions {
+    count: number;
+    index: number;
+    onChange: (index: number) => void;
+}
+
+export const useChartIndexControl = (options: IUseChartIndexControlOptions): void => {
+    const appRef = useAppRootContext();
+    
+    useEffect(() => {
+        if (appRef && 'current' in appRef && appRef.current) {
+            appRef.current.chartCount = options.count;
+            appRef.current.chartIndex = options.index;
+            appRef.current.openChart = function (index: number) {
+                if (index === this.chartIndex) {
+                    return;
+                } else if (Number.isInteger(index) && index >= 0 && index < this.chartCount) {
+                    options.onChange(index);
+                } else {
+                    console.warn(`Invalid chart index: ${index}`);
+                }
+            };
+        }
+    });
+
+    useEffect(() => {
+        return () => {
+            if (appRef && 'current' in appRef && appRef.current) {
+                appRef.current.chartCount = 1;
+                appRef.current.chartIndex = 0;
+                appRef.current.openChart = () => {};
+            }
+        };
+    }, []);
+};

--- a/packages/graphic-walker/src/utils/vegaApiExport.ts
+++ b/packages/graphic-walker/src/utils/vegaApiExport.ts
@@ -90,7 +90,7 @@ export const useVegaExportApi = (name: string | undefined, viewsRef: MutableRefO
     useEffect(() => {
         return () => {
             if (appRef && 'current' in appRef && appRef.current) {
-                appRef.current.exportChart = async mode => ({
+                appRef.current.exportChart = async (mode: IChartExportResult['mode'] = 'svg') => ({
                     mode,
                     title: '',
                     nCols: 0,

--- a/packages/graphic-walker/src/utils/vegaApiExport.ts
+++ b/packages/graphic-walker/src/utils/vegaApiExport.ts
@@ -1,11 +1,10 @@
 import { useImperativeHandle, type ForwardedRef, type MutableRefObject, useEffect } from "react";
-import type { View } from "vega";
 import { useAppRootContext } from "../components/appRoot";
 import type { IReactVegaHandler } from "../vis/react-vega";
-import type { IChartExportResult } from "../interfaces";
+import type { IChartExportResult, IVegaChartRef } from "../interfaces";
 
 
-export const useVegaExportApi = (name: string | undefined, viewsRef: MutableRefObject<{ x: number; y: number; w: number; h: number; view: View }[]>, ref: ForwardedRef<IReactVegaHandler>) => {
+export const useVegaExportApi = (name: string | undefined, viewsRef: MutableRefObject<IVegaChartRef[]>, ref: ForwardedRef<IReactVegaHandler>) => {
     const renderHandle = {
         getSVGData() {
             return Promise.all(viewsRef.current.map(item => item.view.toSVG()));
@@ -63,6 +62,8 @@ export const useVegaExportApi = (name: string | undefined, viewsRef: MutableRefO
                         colIndex: item.x,
                         width: item.w,
                         height: item.h,
+                        canvasWidth: item.innerWidth,
+                        canvasHeight: item.innerHeight,
                         data: '',
                     })),
                 };

--- a/packages/graphic-walker/src/utils/vegaApiExport.ts
+++ b/packages/graphic-walker/src/utils/vegaApiExport.ts
@@ -1,4 +1,4 @@
-import { useImperativeHandle, type ForwardedRef, type MutableRefObject, useEffect } from "react";
+import { useImperativeHandle, type ForwardedRef, type MutableRefObject, useEffect, RefObject } from "react";
 import { useAppRootContext } from "../components/appRoot";
 import type { IReactVegaHandler } from "../vis/react-vega";
 import type { IChartExportResult, IVegaChartRef } from "../interfaces";
@@ -9,6 +9,7 @@ export const useVegaExportApi = (
     viewsRef: MutableRefObject<IVegaChartRef[]>,
     ref: ForwardedRef<IReactVegaHandler>,
     renderTaskRefs: MutableRefObject<Promise<unknown>[]>,
+    containerRef: RefObject<HTMLDivElement>,
 ) => {
     const renderHandle = {
         getSVGData() {
@@ -131,7 +132,13 @@ export const useVegaExportApi = (
                         canvasWidth: item.innerWidth,
                         canvasHeight: item.innerHeight,
                         data: '',
+                        canvas() {
+                            return item.canvas;
+                        },
                     })),
+                    container() {
+                        return containerRef.current;
+                    },
                 };
                 if (mode === 'data-url') {
                     const imgData = await renderHandle.getCanvasData();
@@ -183,6 +190,9 @@ export const useVegaExportApi = (
                     nCols: 0,
                     nRows: 0,
                     charts: [],
+                    container() {
+                        return null;
+                    },
                 });
                 appRef.current.exportChartList = async function * exportChartList (mode: IChartExportResult['mode'] = 'svg') {
                     yield {
@@ -196,6 +206,9 @@ export const useVegaExportApi = (
                             nCols: 0,
                             nRows: 0,
                             charts: [],
+                            container() {
+                                return null;
+                            },
                         },
                         hasNext: false,
                     };

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -224,7 +224,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
       if (viewPlaceholders.length > 0 && viewPlaceholders[0].current) {
         const task = embed(viewPlaceholders[0].current, spec, { mode: 'vega-lite', actions: showActions, timeFormatLocale: getVegaTimeFormatRules(i18n.language), config: vegaConfig }).then(res => {
           const container = res.view.container();
-          const canvas = container?.querySelector('canvas');
+          const canvas = container?.querySelector('canvas') ?? null;
           vegaRefs.current = [{
             w: container?.clientWidth ?? res.view.width(),
             h: container?.clientHeight ?? res.view.height(),
@@ -233,6 +233,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
             x: 0,
             y: 0,
             view: res.view,
+            canvas,
           }];
           try {
             res.view.addEventListener('click', (e) => {
@@ -302,7 +303,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
             const id = index;
             const task = embed(node, ans, { mode: 'vega-lite', actions: showActions, timeFormatLocale: getVegaTimeFormatRules(i18n.language), config: vegaConfig }).then(res => {
               const container = res.view.container();
-              const canvas = container?.querySelector('canvas');
+              const canvas = container?.querySelector('canvas') ?? null;
               vegaRefs.current[id] = {
                 w: container?.clientWidth ?? res.view.width(),
                 h: container?.clientHeight ?? res.view.height(),
@@ -311,6 +312,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
                 x: j,
                 y: i,
                 view: res.view,
+                canvas,
               };
               const paramStores = (res.vgSpec.data?.map(d => d.name) ?? []).filter(
                 name => [BRUSH_SIGNAL_NAME, POINT_SIGNAL_NAME].map(p => `${p}_store`).includes(name)
@@ -407,9 +409,11 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     text
   ]);
 
-  useVegaExportApi(name, vegaRefs, ref, renderTaskRefs);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  return <CanvaContainer rowSize={Math.max(rowRepeatFields.length, 1)} colSize={Math.max(colRepeatFields.length, 1)}>
+  useVegaExportApi(name, vegaRefs, ref, renderTaskRefs, containerRef);
+
+  return <CanvaContainer rowSize={Math.max(rowRepeatFields.length, 1)} colSize={Math.max(colRepeatFields.length, 1)} ref={containerRef}>
     {/* <div ref={container}></div> */}
     {
       viewPlaceholders.map((view, i) => <div key={i} ref={view}></div>)

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState, useMemo, forwardRef, useRef } from 'react';
 import embed from 'vega-embed';
 import { Subject, Subscription } from 'rxjs'
 import * as op from 'rxjs/operators';
-import type { ScenegraphEvent, View } from 'vega';
+import type { ScenegraphEvent } from 'vega';
 import styled from 'styled-components';
 
 import { useVegaExportApi } from '../utils/vegaApiExport';
-import { IViewField, IRow, IStackMode, VegaGlobalConfig } from '../interfaces';
+import { IViewField, IRow, IStackMode, VegaGlobalConfig, IVegaChartRef } from '../interfaces';
 import { useTranslation } from 'react-i18next';
 import { getVegaTimeFormatRules } from './temporalFormat';
 import { getSingleView } from './spec/view';
@@ -153,7 +153,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     })
   }, [rowRepeatFields, colRepeatFields])
 
-  const vegaRefs = useRef<{ x: number; y: number; w: number; h: number; view: View }[]>([]);
+  const vegaRefs = useRef<IVegaChartRef[]>([]);
 
   useEffect(() => {
     vegaRefs.current = [];
@@ -221,9 +221,13 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
 
       if (viewPlaceholders.length > 0 && viewPlaceholders[0].current) {
         embed(viewPlaceholders[0].current, spec, { mode: 'vega-lite', actions: showActions, timeFormatLocale: getVegaTimeFormatRules(i18n.language), config: vegaConfig }).then(res => {
+          const container = res.view.container();
+          const canvas = container?.querySelector('canvas');
           vegaRefs.current = [{
-            w: res.view.container()?.clientWidth ?? res.view.width(),
-            h: res.view.container()?.clientHeight ?? res.view.height(),
+            w: container?.clientWidth ?? res.view.width(),
+            h: container?.clientHeight ?? res.view.height(),
+            innerWidth: canvas?.clientWidth ?? res.view.width(),
+            innerHeight: canvas?.clientHeight ?? res.view.height(),
             x: 0,
             y: 0,
             view: res.view,
@@ -294,9 +298,13 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
           if (node) {
             const id = index;
             embed(node, ans, { mode: 'vega-lite', actions: showActions, timeFormatLocale: getVegaTimeFormatRules(i18n.language), config: vegaConfig }).then(res => {
+              const container = res.view.container();
+              const canvas = container?.querySelector('canvas');
               vegaRefs.current[id] = {
-                w: res.view.container()?.clientWidth ?? res.view.width(),
-                h: res.view.container()?.clientHeight ?? res.view.height(),
+                w: container?.clientWidth ?? res.view.width(),
+                h: container?.clientHeight ?? res.view.height(),
+                innerWidth: canvas?.clientWidth ?? res.view.width(),
+                innerHeight: canvas?.clientHeight ?? res.view.height(),
                 x: j,
                 y: i,
                 view: res.view,


### PR DESCRIPTION
# More Information Given in `IGWHandler`

No breaking changes.
The fields with docs are those added in this PR.

## New fields added to `IGWHandler`

```typescript
interface IGWHandler {
    /** length of the "chart" tab list */
    chartCount: number;
    /** current selected chart index */
    chartIndex: number;
    /** Switches to the specified chart */
    openChart: (index: number) => void;
    /**
     * Returns the status of the current chart.
     * 
     * It is computed by the following rules:
     * - If _GraphicWalker_ is computing the data view, it returns `computing`.
     * - If _GraphicWalker_ is rendering the chart, it returns `rendering`.
     * - If rendering is finished, it returns `idle`.
     * - If an error occurs during the process above, it returns `error`.
     */
    get renderStatus(): IRenderStatus;
    /**
     * Registers a callback function to listen to the status change of the current chart.
     * 
     * @param {(renderStatus: IRenderStatus) => void} cb - the callback function
     * @returns {() => void} a dispose function to remove this callback
     */
    onRenderStatusChange: (cb: (renderStatus: IRenderStatus) => void) => (() => void);
    exportChart: IExportChart;
    /**
     * Exports all charts.
     * 
     * @param {IChartExportResult['mode']} [mode='svg'] - the export mode, either `svg` or `data-url`
     * @returns {AsyncGenerator<IChartListExportResult, void, unknown>} an async generator to iterate over all charts
     * @example
     * ```ts
     * for await (const chart of gwRef.current.exportChartList()) {
     *     console.log(chart);
     * }
     * ```
     */
    exportChartList: IExportChartList;
}
```

## More Detailed Information Provided in the Chart Export Results

DOM refs are added when exporting a chart. Provide canvas size attributes.

```typescript
interface IChartExportResult<T extends 'svg' | 'data-url' = 'svg' | 'data-url'> {
    mode: T;
    title: string;
    nCols: number;
    nRows: number;
    charts: {
        colIndex: number;
        rowIndex: number;
        // these are the box size of the container <div> element
        width: number;
        height: number;
        // these new fields are the box size of the <canvas> element generated by Vega-Lite
        canvasWidth: number;
        canvasHeight: number;
        data: string;
        /** Returns the <canvas> element generated by Vega-Lite. */
        canvas(): HTMLCanvasElement | null;
    }[];
    /** Returns the <div> element contains all canvases. The real box size can be accessed by `container().scrollWidth()` and `container().scrollHeight()` */
    container(): HTMLDivElement | null;
}
```