### PR TITLE
fix(aggr): field unmatched when fid duplicated

### DIFF
--- a/packages/graphic-walker/src/vis/spec/aggregate.ts
+++ b/packages/graphic-walker/src/vis/spec/aggregate.ts
@@ -2,9 +2,12 @@ import { COUNT_FIELD_ID } from '../../constants';
 import { IViewField } from '../../interfaces';
 import { getMeaAggKey } from '../../utils';
 
-export function channelAggregate(encoding: { [key: string]: any }, fields: IViewField[]) {
+export function channelAggregate(encoding: { [key: string]: any }, channels: WeakMap<object, IViewField>) {
     Object.values(encoding).forEach((c) => {
-        const targetField = fields.find((f) => f.fid === c.field && !('aggregate' in c));
+        if ('aggregate' in c) {
+            return;
+        }
+        const targetField = channels.get(c);
         if (targetField && targetField.fid === COUNT_FIELD_ID) {
             c.title = 'Count';
             c.field = getMeaAggKey(targetField.fid, targetField.aggName)

--- a/packages/graphic-walker/src/vis/spec/encode.ts
+++ b/packages/graphic-walker/src/vis/spec/encode.ts
@@ -26,7 +26,8 @@ export function availableChannels(geomType: string): Set<string> {
     }
     return new Set(['column', 'opacity', 'color', 'row', 'size', 'x', 'y', 'xOffset', 'yOffset', 'shape']);
 }
-export function channelEncode(props: IEncodeProps) {
+export function channelEncode(props: IEncodeProps): [{ [key: string]: any }, WeakMap<object, IViewField>] {
+    const channels = new WeakMap<object, IViewField>();
     const avcs = availableChannels(props.geomType);
     const encoding: { [key: string]: any } = {};
     Object.keys(props)
@@ -46,6 +47,7 @@ export function channelEncode(props: IEncodeProps) {
                 if (props[c].analyticType === 'measure') {
                     encoding[c].type = 'quantitative';
                 }
+                channels.set(encoding[c], props[c]);
             }
         });
     // FIXME: temporal fix, only for x and y relative order
@@ -70,5 +72,5 @@ export function channelEncode(props: IEncodeProps) {
             }
         }
     }
-    return encoding;
+    return [encoding, channels];
 }

--- a/packages/graphic-walker/src/vis/spec/view.ts
+++ b/packages/graphic-walker/src/vis/spec/view.ts
@@ -1,4 +1,4 @@
-import { ISemanticType, IStackMode, IViewField } from '../../interfaces';
+import { ISemanticType, IStackMode } from '../../interfaces';
 import { autoMark } from './mark';
 import { NULL_FIELD } from './field';
 import { channelAggregate } from './aggregate';
@@ -32,7 +32,6 @@ export function getSingleView(props: SingleViewProps) {
         geomType,
         hideLegend = false,
     } = props;
-    const fields: IViewField[] = [x, y, color, opacity, size, shape, row, column, xOffset, yOffset, theta, radius, text];
     let markType = geomType;
     let config: any = {};
     if (hideLegend) {
@@ -47,7 +46,7 @@ export function getSingleView(props: SingleViewProps) {
         markType = autoMark(types);
     }
 
-    let encoding = channelEncode({
+    let [encoding, mapping] = channelEncode({
         geomType: markType,
         x,
         y,
@@ -65,7 +64,7 @@ export function getSingleView(props: SingleViewProps) {
         text
     });
     if (defaultAggregated) {
-        channelAggregate(encoding, fields);
+        channelAggregate(encoding, mapping);
     }
     addTooltipEncode(encoding, details, defaultAggregated);
     channelStack(encoding, stack);


### PR DESCRIPTION
The method `channelAggregate()` used to search the field (referenced by the key **"field"** in `encoding`) in an array so that if there're more than one pills of a same field, e.g.:
```json
[
    { "fid": "foo", "analyticType": "dimension" },
    { "fid": "foo", "analyticType": "measure", "aggName": "sum" }
]
```
In the case above, any pills with fid `"foo"` would match the first `IViewField`, which will make the aggregation ignored, though it's named "sum(foo)".

There's a real case -
![image](https://github.com/Kanaries/graphic-walker/assets/126073370/d9fa666b-c27e-4bfe-97dc-16196af0752c)
The data in the vega-lite config looks like -
```json
{
  "data": {
    "values": [
      {"gwc_3": 0, "gwc_3_sum": 0},
      {"gwc_3": 1, "gwc_3_sum": 724},
      {"gwc_3": 2, "gwc_3_sum": 1430},
      // ...
      {"gwc_3": 22, "gwc_3_sum": 16016},
      {"gwc_3": 23, "gwc_3_sum": 16744}
    ]
  }
}
```
Which is expected to be -
![image](https://github.com/Kanaries/graphic-walker/assets/126073370/f0ab41a2-f23d-4696-969d-e66907f7c03d)
