### PR TITLE
fix: graph didn't disappear when changing tab

### DIFF
--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -76,7 +76,7 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
                 setViewConfig(latestFromRef.current.visualConfig);
             });
         }
-    }, [waiting, vizStore]);
+    }, [waiting, data, vizStore]);
 
     useChartIndexControl({
         count: visList.length,


### PR DESCRIPTION
When creating new chart, dataQueryServer returns immediately so 'waiting' won't change when render function executes.
Added 'data' to dependency to make sure to setViewData.