### PR TITLE
feat: change temporal range

### DIFF
--- a/packages/graphic-walker/src/lib/inferMeta.ts
+++ b/packages/graphic-walker/src/lib/inferMeta.ts
@@ -9,6 +9,7 @@ const COMMON_TIME_FORMAT: RegExp[] = [
     /^\d{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[12][0-9]|3[01])$/, // YYYY.MM.DD
     /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])\s\d{2}:\d{2}:\d{2}$/, // YYYY-MM-DD HH:MM:SS
     /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T\d{2}:\d{2}:\d{2}$/, // YYYY-MM-DDTHH:MM:SS (ISO-8601)
+    /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T\d{2}:\d{2}:\d{2}.\d{3}Z$/, // YYYY-MM-DDTHH:MM:SS.gggZ (ISO-8601)
 ];
 
 const TIME_FORMAT = [
@@ -19,6 +20,7 @@ const TIME_FORMAT = [
     '%Y.%m.%d',
     '%Y-%m-%d %H:%M:%S',
     '%Y-%m-%dT%H:%M:%S',
+    '%Y-%m-%dT%H:%M:%S.%gZ'
 ]
 
 export function getTimeFormat(data: string | number) {

--- a/packages/graphic-walker/src/lib/interfaces.ts
+++ b/packages/graphic-walker/src/lib/interfaces.ts
@@ -3,7 +3,7 @@ import { IAggregator } from "../interfaces";
 export interface IAggQuery {
     op: 'aggregate';
     groupBy: string[];
-    measures: { field: string; agg: IAggregator; asFieldKey: string }[];
+    measures: { field: string; agg: IAggregator; asFieldKey: string; format?: string; }[];
 }
 
 // interface IFilterQuery {

--- a/packages/graphic-walker/src/lib/op/aggregate.ts
+++ b/packages/graphic-walker/src/lib/op/aggregate.ts
@@ -41,7 +41,14 @@ export function aggregate (data: IRow[], query: IAggQuery): IRow[] {
             if (aggRow[aggMeaKey] === undefined) {
                 aggRow[aggMeaKey] = 0;
             }
-            const values: number[] = subGroup.map((r) => r[mea.field]) ?? [];
+            const values: number[] = subGroup
+                .map((r) => r[mea.field])
+                .map((x) => {
+                    if (mea.format) {
+                        return new Date(x).getTime();
+                    }
+                    return x;
+                });
             const aggregator = aggregatorMap[mea.agg] ?? sum;
             aggRow[aggMeaKey] = aggregator(values);
         }


### PR DESCRIPTION
fixes #181 .
change the method to get temporal range from "get first 1000 lines of values, and calc max & min" to "require computation to return a max/min value of temporal".
Notice: The Computation Function should be compatible with workflow like:
```
{
    op: 'aggregate',
    groupBy: [],
    measures: [{ field: "datetime", agg: 'min', asFieldKey: 'MIN', format: '%Y-%m-%d %H:%M:%S' }],
 }
```