### PR TITLE
fix: make eaiser to import old format data

### DIFF
--- a/packages/graphic-walker/src/index.tsx
+++ b/packages/graphic-walker/src/index.tsx
@@ -65,7 +65,6 @@ export { embedGraphicWalker } from './vanilla';
 export type { IGWProps };
 export { ISegmentKey, ColorSchemes } from './interfaces';
 export { resolveChart, convertChart } from './models/visSpecHistory';
-export { resolveVisSpec } from './utils/save';
 export { getGlobalConfig } from './config';
 
 export { getComputation } from './computation/clientComputation';

--- a/packages/graphic-walker/src/renderer/pureRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/pureRenderer.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { ShadowDom } from '../shadow-dom';
 import LeafletRenderer, { LEAFLET_DEFAULT_HEIGHT } from '../components/leafletRenderer';
 import { withAppRoot } from '../components/appRoot';
-import type { IDarkMode, IViewField, IRow, IThemeKey, DraggableFieldState, IVisualConfigNew, IComputationFunction, IVisualLayout, IChannelScales } from '../interfaces';
+import type { IDarkMode, IViewField, IRow, IThemeKey, DraggableFieldState, IVisualConfig, IVisualConfigNew, IComputationFunction, IVisualLayout, IChannelScales } from '../interfaces';
 import type { IReactVegaHandler } from '../vis/react-vega';
 import SpecRenderer from './specRenderer';
 import { useRenderer } from './hooks';
@@ -19,8 +19,8 @@ type IPureRendererProps =
           themeConfig?: GWGlobalConfig;
           dark?: IDarkMode;
           visualState: DraggableFieldState;
-          visualConfig: IVisualConfigNew;
-          visualLayout: IVisualLayout;
+          visualConfig: IVisualConfigNew | IVisualConfig;
+          visualLayout?: IVisualLayout;
           locale?: string;
           channelScales?: IChannelScales;
       } & (
@@ -39,13 +39,15 @@ type IPureRendererProps =
  * This is a pure component, which means it will not depend on any global state.
  */
 const PureRenderer = forwardRef<IReactVegaHandler, IPureRendererProps>(function PureRenderer(props, ref) {
-    const { name, themeKey, dark, visualState, visualConfig, visualLayout, locale, type, themeConfig, channelScales } = props;
+    const { name, themeKey, dark, visualState, visualConfig, visualLayout: layout, locale, type, themeConfig, channelScales } = props;
     const computation = useMemo(() => {
         if (props.type === 'remote') {
             return props.computation;
         }
         return getComputation(props.rawData);
     }, [type, type === 'remote' ? props.computation : props.rawData]);
+
+    const visualLayout = layout ?? (visualConfig as IVisualConfig);
 
     const sort = getSort(visualState);
     const limit = visualConfig.limit ?? -1;

--- a/packages/graphic-walker/src/store/dataStore.ts
+++ b/packages/graphic-walker/src/store/dataStore.ts
@@ -2,7 +2,7 @@ import { computed, makeAutoObservable, toJS } from 'mobx';
 import { DataSet, IAnalyticType, IDataSource, IMutField, IRow, ISemanticType } from '../interfaces';
 import { VizSpecStore } from './visualSpecStore';
 import { getComputation } from '../computation/clientComputation';
-import { IStoInfo, IStoInfoV2, IStoInfoV2SchemaUrl, forwardVisualConfigs, visSpecDecoder } from '../utils/save';
+import { IStoInfo, IStoInfoV2, IStoInfoV2SchemaUrl } from '../utils/save';
 import { uniqueId } from '../models/utils';
 
 const emptyMeta: IMutField[] = [];

--- a/packages/graphic-walker/src/utils/save.ts
+++ b/packages/graphic-walker/src/utils/save.ts
@@ -1,4 +1,14 @@
-import { DraggableFieldState, IDataSet, IDataSource, IMutField, IVisSpec, IVisSpecForExport, IVisualConfig, IVisualConfigNew, IVisualLayout } from '../interfaces';
+import {
+    DraggableFieldState,
+    IDataSet,
+    IDataSource,
+    IMutField,
+    IVisSpec,
+    IVisSpecForExport,
+    IVisualConfig,
+    IVisualConfigNew,
+    IVisualLayout,
+} from '../interfaces';
 import { GLOBAL_CONFIG } from '../config';
 
 export function initEncoding(): DraggableFieldState {
@@ -15,7 +25,7 @@ export function initEncoding(): DraggableFieldState {
         theta: [],
         longitude: [],
         latitude: [],
-        geoId: [],    
+        geoId: [],
         details: [],
         filters: [],
         text: [],
@@ -23,7 +33,7 @@ export function initEncoding(): DraggableFieldState {
 }
 
 export function initVisualConfig(): IVisualConfig {
-    const [ geom ] = GLOBAL_CONFIG.GEOM_TYPES.generic;
+    const [geom] = GLOBAL_CONFIG.GEOM_TYPES.generic;
     return {
         defaultAggregated: true,
         geoms: [geom],
@@ -113,46 +123,38 @@ export const emptyEncodings: DraggableFieldState = {
     text: [],
 };
 
-export function visSpecDecoder(visList: IVisSpecForExport[]): IVisSpec[] {
-    const updatedVisList = visList.map((visSpec) => {
-        const updatedFilters = visSpec.encodings.filters.map((filter) => {
-            if (filter.rule?.type === 'one of' && Array.isArray(filter.rule.value)) {
-                return {
-                    ...filter,
-                    rule: {
-                        ...filter.rule,
-                        value: new Set(filter.rule.value),
-                    },
-                };
-            }
-            return filter;
-        });
-        return {
-            ...visSpec,
-            encodings: {
-                ...initEncoding(),
-                ...visSpec.encodings,
-                filters: updatedFilters,
-            },
-        } as IVisSpec;
+export function visSpecDecoder(visSpec: IVisSpecForExport): IVisSpec {
+    const updatedFilters = visSpec.encodings.filters.map((filter) => {
+        if (filter.rule?.type === 'one of' && Array.isArray(filter.rule.value)) {
+            return {
+                ...filter,
+                rule: {
+                    ...filter.rule,
+                    value: new Set(filter.rule.value),
+                },
+            };
+        }
+        return filter;
     });
-    return updatedVisList;
+    return {
+        ...visSpec,
+        encodings: {
+            ...initEncoding(),
+            ...visSpec.encodings,
+            filters: updatedFilters,
+        },
+    } as IVisSpec;
 }
 
-export const forwardVisualConfigs = (backwards: IStoInfoOld['specList']): IVisSpecForExport[] => {
-    return backwards.map((content) => ({
+export const forwardVisualConfigs = (content: IStoInfoOld['specList'][number]): IVisSpecForExport => {
+    return {
         ...content,
         config: {
             ...initVisualConfig(),
             ...content.config,
         },
-    }));
+    };
 };
-
-export const resolveVisSpec = (a: IVisSpecForExport[]): IVisSpec[] => {
-    return visSpecDecoder(forwardVisualConfigs(a))
-}
-
 export interface IStoInfoOld {
     $schema: undefined;
     datasets: IDataSet[];
@@ -163,11 +165,11 @@ export interface IStoInfoOld {
 export const IStoInfoV2SchemaUrl = 'https://graphic-walker.kanaries.net/stoinfo_v2.json';
 
 export interface IStoInfoV2 {
-    $schema: typeof IStoInfoV2SchemaUrl,
-    metaDict: Record<string, IMutField[]>,
-    datasets: Required<IDataSource>[],
-    specDict: Record<string, string[]>,
-};
+    $schema: typeof IStoInfoV2SchemaUrl;
+    metaDict: Record<string, IMutField[]>;
+    datasets: Required<IDataSource>[];
+    specDict: Record<string, string[]>;
+}
 
 export type IStoInfo = IStoInfoOld | IStoInfoV2;
 


### PR DESCRIPTION
replace "importOld" method to "importCode", so you can use this function to initial visStore and don't have to care what is version of visSpec.