### PR TITLE
feat: pivot sorting

### DIFF
--- a/packages/graphic-walker/src/components/pivotTable/index.tsx
+++ b/packages/graphic-walker/src/components/pivotTable/index.tsx
@@ -5,6 +5,7 @@ import { dataQuery } from '../../computation';
 import { useAppRootContext } from '../../components/appRoot';
 import LeftTree from './leftTree';
 import TopTree from './topTree';
+import { observer } from 'mobx-react-lite';
 import {
     DeepReadonly,
     DraggableFieldState,
@@ -34,7 +35,7 @@ interface PivotTableProps {
 
 const emptyMap = new Map();
 
-const PivotTable: React.FC<PivotTableProps> = function PivotTableComponent(props) {
+const PivotTable: React.FC<PivotTableProps> = observer(function PivotTableComponent(props) {
     const { data, visualConfig, loading, layout, draggableFieldState } = props;
     const computation = useCompututaion();
     const appRef = useAppRootContext();
@@ -256,6 +257,6 @@ const PivotTable: React.FC<PivotTableProps> = function PivotTableComponent(props
             </div>
         </div>
     );
-};
+});
 
 export default PivotTable;

--- a/packages/graphic-walker/src/components/pivotTable/inteface.ts
+++ b/packages/graphic-walker/src/components/pivotTable/inteface.ts
@@ -3,6 +3,7 @@ import { IAggregator } from "../../interfaces";
 export interface INestNode {
     key: string | number;
     value: string | number;
+    sort: string | number;
     uniqueKey: string;
     fieldKey: string;
     children: INestNode[];

--- a/packages/graphic-walker/src/components/pivotTable/utils.ts
+++ b/packages/graphic-walker/src/components/pivotTable/utils.ts
@@ -1,12 +1,22 @@
-import { IRow } from "../../interfaces";
-import { INestNode } from "./inteface";
+import { IRow } from '../../interfaces';
+import { INestNode } from './inteface';
 
 const key_prefix = 'nk_';
 
-function insertNode (tree: INestNode, layerKeys: string[], nodeData: IRow, depth: number, collapsedKeyList: string[]) {
+function insertNode(
+    tree: INestNode,
+    layerKeys: string[],
+    nodeData: IRow,
+    depth: number,
+    collapsedKeyList: string[],
+    sort?: {
+        fid: string;
+        type: 'ascending' | 'descending';
+    }
+) {
     if (depth >= layerKeys.length) {
         // tree.key = nodeData[layerKeys[depth]];
-        return;   
+        return;
     }
     const key = nodeData[layerKeys[depth]];
     const uniqueKey = `${tree.uniqueKey}__${key}`;
@@ -16,35 +26,37 @@ function insertNode (tree: INestNode, layerKeys: string[], nodeData: IRow, depth
         child = {
             key,
             value: key,
-            uniqueKey: uniqueKey, 
+            sort: depth === layerKeys.length - 1 && sort ? nodeData[sort.fid] : key,
+            uniqueKey: uniqueKey,
             fieldKey: layerKeys[depth],
             children: [],
-            path: [...tree.path, {key: layerKeys[depth], value: key}],
+            path: [...tree.path, { key: layerKeys[depth], value: key }],
             height: layerKeys.length - depth - 1,
             isCollapsed: false,
-        }
+        };
         if (collapsedKeyList.includes(tree.uniqueKey)) {
             tree.isCollapsed = true;
         }
-        tree.children.splice(binarySearchIndex(tree.children, child.key), 0, child);
+        const reverse = depth === layerKeys.length - 1 && sort?.type === 'descending';
+        tree.children.splice(binarySearchIndex(tree.children, child.sort, reverse), 0, child);
     }
-    insertNode(child, layerKeys, nodeData, depth + 1, collapsedKeyList);
-
+    insertNode(child, layerKeys, nodeData, depth + 1, collapsedKeyList, sort);
 }
 
 // Custom binary search function to find appropriate index for insertion.
-function binarySearchIndex(arr: INestNode[], keyVal: string | number): number {
-    let start = 0, end = arr.length - 1;
+function binarySearchIndex(arr: INestNode[], keyVal: string | number, reverse = false): number {
+    let start = 0,
+        end = arr.length - 1;
 
     while (start <= end) {
         let middle = Math.floor((start + end) / 2);
-        let middleVal = arr[middle].key;
+        let middleVal = arr[middle].sort;
         if (typeof middleVal === 'number' && typeof keyVal === 'number') {
-            if (middleVal < keyVal) start = middle + 1;
+            if (reverse !== middleVal < keyVal) start = middle + 1;
             else end = middle - 1;
         } else {
             let cmp = String(middleVal).localeCompare(String(keyVal));
-            if (cmp < 0) start = middle + 1;
+            if (reverse !== cmp < 0) start = middle + 1;
             else end = middle - 1;
         }
     }
@@ -52,13 +64,14 @@ function binarySearchIndex(arr: INestNode[], keyVal: string | number): number {
 }
 
 const ROOT_KEY = '__root';
-const TOTAL_KEY = '__total'
+const TOTAL_KEY = '__total';
 
-function insertSummaryNode (node: INestNode): void {
+function insertSummaryNode(node: INestNode): void {
     if (node.children.length > 0) {
         node.children.push({
             key: TOTAL_KEY,
             value: 'total',
+            sort: '',
             fieldKey: node.children[0].fieldKey,
             uniqueKey: `${node.uniqueKey}${TOTAL_KEY}`,
             children: [],
@@ -66,17 +79,27 @@ function insertSummaryNode (node: INestNode): void {
             height: node.children[0].height,
             isCollapsed: true,
         });
-        for (let i = 0; i < node.children.length - 1; i ++) {
+        for (let i = 0; i < node.children.length - 1; i++) {
             insertSummaryNode(node.children[i]);
         }
     }
-};
+}
 
-export function buildNestTree (layerKeys: string[], data: IRow[], collapsedKeyList: string[], showSummary: boolean): INestNode {
+export function buildNestTree(
+    layerKeys: string[],
+    data: IRow[],
+    collapsedKeyList: string[],
+    showSummary: boolean,
+    sort?: {
+        fid: string;
+        type: 'ascending' | 'descending';
+    }
+): INestNode {
     const tree: INestNode = {
         key: ROOT_KEY,
         value: 'root',
         fieldKey: 'root',
+        sort: '',
         uniqueKey: ROOT_KEY,
         children: [],
         path: [],
@@ -84,7 +107,7 @@ export function buildNestTree (layerKeys: string[], data: IRow[], collapsedKeyLi
         isCollapsed: false,
     };
     for (let row of data) {
-        insertNode(tree, layerKeys, row, 0, collapsedKeyList);
+        insertNode(tree, layerKeys, row, 0, collapsedKeyList, sort);
     }
     if (showSummary) {
         insertSummaryNode(tree);
@@ -96,28 +119,28 @@ class NodeIterator {
     public tree: INestNode;
     public nodeStack: INestNode[] = [];
     public current: INestNode | null = null;
-    constructor (tree: INestNode) {
+    constructor(tree: INestNode) {
         this.tree = tree;
     }
-    public first () {
-        let node = this.tree
+    public first() {
+        let node = this.tree;
         this.nodeStack = [node];
         while (node.children.length > 0 && !node.isCollapsed) {
-            this.nodeStack.push(node.children[0])
-            node = node.children[0]
+            this.nodeStack.push(node.children[0]);
+            node = node.children[0];
         }
         this.current = node;
         return this.current;
     }
-    public next (): INestNode | null {
+    public next(): INestNode | null {
         let cursorMoved = false;
-        let counter = 0
+        let counter = 0;
         while (this.nodeStack.length > 1) {
-            counter++
+            counter++;
             if (counter > 100) break;
             let node = this.nodeStack[this.nodeStack.length - 1];
             let parent = this.nodeStack[this.nodeStack.length - 2];
-            let nodeIndex = parent.children.findIndex(n => n.key === node!.key);
+            let nodeIndex = parent.children.findIndex((n) => n.key === node!.key);
             if (nodeIndex === -1) break;
             if (cursorMoved) {
                 if (node.children.length > 0 && !node.isCollapsed) {
@@ -129,8 +152,8 @@ class NodeIterator {
             } else {
                 if (nodeIndex < parent.children.length - 1) {
                     this.nodeStack.pop();
-                    this.nodeStack.push(parent.children[nodeIndex + 1])
-                    cursorMoved = true
+                    this.nodeStack.push(parent.children[nodeIndex + 1]);
+                    cursorMoved = true;
                     continue;
                 }
                 if (nodeIndex >= parent.children.length - 1) {
@@ -146,15 +169,17 @@ class NodeIterator {
         }
         return this.current;
     }
-    public predicates (): { key: string; value: string | number }[] {
-        return this.nodeStack.filter(node => node.key !== ROOT_KEY).map(node => ({
-            key: node.fieldKey,
-            value: node.value
-        }))
+    public predicates(): { key: string; value: string | number }[] {
+        return this.nodeStack
+            .filter((node) => node.key !== ROOT_KEY)
+            .map((node) => ({
+                key: node.fieldKey,
+                value: node.value,
+            }));
     }
 }
 
-export function buildMetricTableFromNestTree (leftTree: INestNode, topTree: INestNode, data: IRow[]): (IRow | null)[][] {
+export function buildMetricTableFromNestTree(leftTree: INestNode, topTree: INestNode, data: IRow[]): (IRow | null)[][] {
     const mat: any[][] = [];
     const iteLeft = new NodeIterator(leftTree);
     const iteTop = new NodeIterator(topTree);
@@ -163,26 +188,28 @@ export function buildMetricTableFromNestTree (leftTree: INestNode, topTree: INes
         const vec: any[] = [];
         iteTop.first();
         while (iteTop.current !== null) {
-            const predicates = iteLeft.predicates().concat(iteTop.predicates()).filter((ele) => ele.value !== "total");
-            const matchedRows = data.filter(r => predicates.every(pre => r[pre.key] === pre.value));
+            const predicates = iteLeft
+                .predicates()
+                .concat(iteTop.predicates())
+                .filter((ele) => ele.value !== 'total');
+            const matchedRows = data.filter((r) => predicates.every((pre) => r[pre.key] === pre.value));
             if (matchedRows.length > 0) {
                 // If multiple rows are matched, then find the most matched one (the row with smallest number of keys)
-                vec.push(matchedRows.reduce((a, b) => Object.keys(a).length < Object.keys(b).length ? a : b));
+                vec.push(matchedRows.reduce((a, b) => (Object.keys(a).length < Object.keys(b).length ? a : b)));
             } else {
                 vec.push(undefined);
             }
             iteTop.next();
         }
-        mat.push(vec)
+        mat.push(vec);
         iteLeft.next();
     }
     return mat;
 }
 
-export function getAllChildrenSize (node: INestNode, depth: number): number {
+export function getAllChildrenSize(node: INestNode, depth: number): number {
     if (depth === 0) {
         return node.children.length;
     }
-    return node.children.reduce((acc, child) => acc + getAllChildrenSize(child, depth + 1), 0)
-
+    return node.children.reduce((acc, child) => acc + getAllChildrenSize(child, depth + 1), 0);
 }

--- a/packages/graphic-walker/src/components/pivotTable/utils.ts
+++ b/packages/graphic-walker/src/components/pivotTable/utils.ts
@@ -26,7 +26,7 @@ function insertNode(
         child = {
             key,
             value: key,
-            sort: depth === layerKeys.length - 1 && sort ? nodeData[sort.fid] : key,
+            sort: depth === layerKeys.length - 1 && sort ? nodeData[sort.fid] ?? `_${key}` : key,
             uniqueKey: uniqueKey,
             fieldKey: layerKeys[depth],
             children: [],
@@ -93,7 +93,8 @@ export function buildNestTree(
     sort?: {
         fid: string;
         type: 'ascending' | 'descending';
-    }
+    },
+    dataWithoutSort?: IRow[]
 ): INestNode {
     const tree: INestNode = {
         key: ROOT_KEY,
@@ -108,6 +109,11 @@ export function buildNestTree(
     };
     for (let row of data) {
         insertNode(tree, layerKeys, row, 0, collapsedKeyList, sort);
+    }
+    if (dataWithoutSort) {
+        for (let row of dataWithoutSort) {
+            insertNode(tree, layerKeys, row, 0, collapsedKeyList, { fid: '', type: sort?.type ?? 'ascending' });
+        }
     }
     if (showSummary) {
         insertSummaryNode(tree);

--- a/packages/graphic-walker/src/services.ts
+++ b/packages/graphic-walker/src/services.ts
@@ -151,7 +151,12 @@ export const buildPivotTableService = async (dimsInRow: IViewField[],
         allData: IRow[], 
         aggData: IRow[], 
         collapsedKeyList: string[], 
-        showTableSummary: boolean
+        showTableSummary: boolean,
+        sort?: {
+            fid: string,
+            type: 'ascending' | 'descending',
+            mode: 'row' | 'column',
+        }
     ): Promise<{lt: INestNode, tt: INestNode, metric: (IRow | null)[][]}> => {
     const worker = new BuildMetricTableWorker();
     try {
@@ -161,7 +166,8 @@ export const buildPivotTableService = async (dimsInRow: IViewField[],
             allData, 
             aggData, 
             collapsedKeyList, 
-            showTableSummary
+            showTableSummary,
+            sort,
         });
         return res;
     } catch (error) {

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -159,6 +159,17 @@ export class VizSpecStore {
         return 'none';
     }
 
+    get sortedEncoding() {
+        const { rows, columns } = this;
+        if (rows.length && !rows.find((x) => x.analyticType === 'measure')) {
+            return 'row';
+        }
+        if (columns.length && !columns.find((x) => x.analyticType === 'measure')) {
+            return 'column';
+        }
+        return 'none';
+    }
+
     get allFields() {
         return [...this.dimensions, ...this.measures];
     }

--- a/packages/graphic-walker/src/workers/buildMetricTable.worker.js
+++ b/packages/graphic-walker/src/workers/buildMetricTable.worker.js
@@ -15,9 +15,9 @@ import { buildPivotTable } from "./buildPivotTable"
  * @param {MessageEvent<{ dimsInRow: import('../interfaces').IViewField[]; dimsInColumn: import('../interfaces').IViewField[]; allData: import('../interfaces').IRow[]; aggData: import('../interfaces').IRow[]; collapsedKeyList: string[]; showTableSummary: boolean }>} e
  */
 const main = e => {
-    const { dimsInRow, dimsInColumn, allData, aggData, collapsedKeyList, showTableSummary } = e.data;
+    const { dimsInRow, dimsInColumn, allData, aggData, collapsedKeyList, showTableSummary, sort } = e.data;
     try {
-        const ans = buildPivotTable(dimsInRow, dimsInColumn, allData, aggData, collapsedKeyList, showTableSummary);
+        const ans = buildPivotTable(dimsInRow, dimsInColumn, allData, aggData, collapsedKeyList, showTableSummary, sort);
         self.postMessage(ans);
     } catch (error) {
         self.postMessage({ error: error.message });

--- a/packages/graphic-walker/src/workers/buildPivotTable.ts
+++ b/packages/graphic-walker/src/workers/buildPivotTable.ts
@@ -1,27 +1,71 @@
-import { INestNode } from "../components/pivotTable/inteface";
-import { buildMetricTableFromNestTree, buildNestTree } from "../components/pivotTable/utils"
-import { IViewField, IRow } from "../interfaces"
+import { INestNode } from '../components/pivotTable/inteface';
+import { buildMetricTableFromNestTree, buildNestTree } from '../components/pivotTable/utils';
+import { IViewField, IRow } from '../interfaces';
 
-export function buildPivotTable (
-    dimsInRow: IViewField[], 
-    dimsInColumn: IViewField[], 
-    allData: IRow[], 
-    aggData: IRow[], 
-    collapsedKeyList: string[], 
-    showTableSummary: boolean
-): {lt: INestNode, tt: INestNode, metric: (IRow | null)[][]} {
-    const lt = buildNestTree(
-        dimsInRow.map((d) => d.fid),
-        allData,
-        collapsedKeyList,
-        showTableSummary
-    );
-    const tt = buildNestTree(
-        dimsInColumn.map((d) => d.fid),
-        allData,
-        collapsedKeyList,
-        showTableSummary
-    );
-    const metric = buildMetricTableFromNestTree(lt, tt, [...allData, ...aggData])
-    return {lt, tt, metric}
+const getFirsts = (item: INestNode): INestNode[] => {
+    if (item.children.length > 0) {
+        return [item, ...getFirsts(item.children[0])];
+    }
+    return [item];
+}
+
+export function buildPivotTable(
+    dimsInRow: IViewField[],
+    dimsInColumn: IViewField[],
+    allData: IRow[],
+    aggData: IRow[],
+    collapsedKeyList: string[],
+    showTableSummary: boolean,
+    sort?: {
+        fid: string;
+        type: 'ascending' | 'descending';
+        mode: 'row' | 'column';
+    }
+): { lt: INestNode; tt: INestNode; metric: (IRow | null)[][] } {
+    let lt: INestNode;
+    let tt: INestNode;
+    if (sort?.mode === 'row') {
+        tt = buildNestTree(
+            dimsInColumn.map((d) => d.fid),
+            allData,
+            collapsedKeyList,
+            showTableSummary
+        );
+        let data = allData;
+        if (dimsInColumn.length > 0 ) {
+            const ks = dimsInColumn.map(x => x.fid);
+            const vs = getFirsts(tt.children[0]).map(x => x.value);
+            data = allData.filter(x => ks.every((k, i) => x[k] === vs[i]));
+        }
+        lt = buildNestTree(
+            dimsInRow.map((d) => d.fid),
+            data,
+            collapsedKeyList,
+            showTableSummary,
+            sort
+        );
+    } else {
+        lt = buildNestTree(
+            dimsInRow.map((d) => d.fid),
+            allData,
+            collapsedKeyList,
+            showTableSummary
+        );
+        let data = allData;
+        if (sort && dimsInRow.length > 0 ) {
+            const ks = dimsInRow.map(x => x.fid);
+            const vs = getFirsts(lt.children[0]).map(x => x.value);
+            data = allData.filter(x => ks.every((k, i) => x[k] === vs[i]));
+        }
+        tt = buildNestTree(
+            dimsInColumn.map((d) => d.fid),
+            data,
+            collapsedKeyList,
+            showTableSummary,
+            sort?.mode === 'column' ? sort : undefined
+        );
+    }
+
+    const metric = buildMetricTableFromNestTree(lt, tt, [...allData, ...aggData]);
+    return { lt, tt, metric };
 }

--- a/packages/graphic-walker/src/workers/buildPivotTable.ts
+++ b/packages/graphic-walker/src/workers/buildPivotTable.ts
@@ -7,7 +7,7 @@ const getFirsts = (item: INestNode): INestNode[] => {
         return [item, ...getFirsts(item.children[0])];
     }
     return [item];
-}
+};
 
 export function buildPivotTable(
     dimsInRow: IViewField[],
@@ -31,19 +31,30 @@ export function buildPivotTable(
             collapsedKeyList,
             showTableSummary
         );
-        let data = allData;
-        if (dimsInColumn.length > 0 ) {
-            const ks = dimsInColumn.map(x => x.fid);
-            const vs = getFirsts(tt.children[0]).map(x => x.value);
-            data = allData.filter(x => ks.every((k, i) => x[k] === vs[i]));
+        if (dimsInColumn.length > 0) {
+            const ks = dimsInColumn.map((x) => x.fid);
+            const vs = getFirsts(tt.children[0]).map((x) => x.value);
+            // move data of First column to first
+            const mentioned: IRow[] = [];
+            const rest: IRow[] = [];
+            allData.forEach((x) => (ks.every((k, i) => x[k] === vs[i]) ? mentioned.push(x) : rest.push(x)));
+            lt = buildNestTree(
+                dimsInRow.map((d) => d.fid),
+                mentioned,
+                collapsedKeyList,
+                showTableSummary,
+                sort,
+                rest
+            );
+        } else {
+            lt = buildNestTree(
+                dimsInRow.map((d) => d.fid),
+                allData,
+                collapsedKeyList,
+                showTableSummary,
+                sort
+            );
         }
-        lt = buildNestTree(
-            dimsInRow.map((d) => d.fid),
-            data,
-            collapsedKeyList,
-            showTableSummary,
-            sort
-        );
     } else {
         lt = buildNestTree(
             dimsInRow.map((d) => d.fid),
@@ -51,19 +62,30 @@ export function buildPivotTable(
             collapsedKeyList,
             showTableSummary
         );
-        let data = allData;
-        if (sort && dimsInRow.length > 0 ) {
-            const ks = dimsInRow.map(x => x.fid);
-            const vs = getFirsts(lt.children[0]).map(x => x.value);
-            data = allData.filter(x => ks.every((k, i) => x[k] === vs[i]));
+        if (sort && dimsInRow.length > 0) {
+            const ks = dimsInRow.map((x) => x.fid);
+            const vs = getFirsts(lt.children[0]).map((x) => x.value);
+            // move data of First row to first
+            const mentioned: IRow[] = [];
+            const rest: IRow[] = [];
+            allData.forEach((x) => (ks.every((k, i) => x[k] === vs[i]) ? mentioned.push(x) : rest.push(x)));
+            tt = buildNestTree(
+                dimsInColumn.map((d) => d.fid),
+                mentioned,
+                collapsedKeyList,
+                showTableSummary,
+                sort,
+                rest
+            );
+        } else {
+            tt = buildNestTree(
+                dimsInColumn.map((d) => d.fid),
+                allData,
+                collapsedKeyList,
+                showTableSummary,
+                sort
+            );
         }
-        tt = buildNestTree(
-            dimsInColumn.map((d) => d.fid),
-            data,
-            collapsedKeyList,
-            showTableSummary,
-            sort?.mode === 'column' ? sort : undefined
-        );
     }
 
     const metric = buildMetricTableFromNestTree(lt, tt, [...allData, ...aggData]);


### PR DESCRIPTION
Make data in pivot table is sortable.
sorting: sort the last field without measure field.
sort by nearest value in same group.
collpase won't affect sorting.
e.g.
original: 
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/e275aea7-466f-4799-98f1-4d77de579981)
sorted by asc:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/1344beac-5687-4959-be31-99e2270e0e76)
with empty field:
original: 
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/b613a171-f2b8-4b4a-8651-bd99a10ae729)
sorted by dsc:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/88397768-57cc-4f86-8ae1-a45af78d84f3)
