### PR TITLE
fix: add report compuation error

### DIFF
--- a/packages/graphic-walker/src/components/errorpanel/index.tsx
+++ b/packages/graphic-walker/src/components/errorpanel/index.tsx
@@ -8,6 +8,10 @@ import DefaultButton from '../button/default';
 export default observer(function ErrorPanel() {
     const vizStore = useVizStore();
     const { t } = useTranslation();
+    const closeModal = () => {
+        vizStore.updateShowErrorResolutionPanel(0);
+        return;
+    };
     switch (vizStore.showErrorResolutionPanel) {
         case 0:
             return null;
@@ -23,7 +27,7 @@ export default observer(function ErrorPanel() {
                                 className="mx-2 cursor-pointer font-semibold text-indigo-600 hover:text-indigo-500"
                                 onClick={() => {
                                     vizStore.setVisualLayout('size', { mode: 'fixed', width: 800, height: 600 });
-                                    vizStore.updateShowErrorResolutionPanel(0);
+                                    closeModal();
                                 }}
                             >
                                 Set Now
@@ -35,7 +39,7 @@ export default observer(function ErrorPanel() {
                                 className="mx-2 cursor-pointer font-semibold text-indigo-600 hover:text-indigo-500"
                                 onClick={() => {
                                     vizStore.setVisualLayout('useSvg', true);
-                                    vizStore.updateShowErrorResolutionPanel(0);
+                                    closeModal();
                                 }}
                             >
                                 Set Now
@@ -47,10 +51,27 @@ export default observer(function ErrorPanel() {
                                 <DefaultButton
                                     text={`Close`}
                                     className="mr-2 px-2"
-                                    onClick={() => {
-                                        vizStore.updateShowErrorResolutionPanel(0);
-                                        return;
-                                    }}
+                                    onClick={closeModal}
+                                />
+                            </div>
+                        </fieldset>
+                    </div>
+                </Modal>
+            );
+        case 501:
+            return (
+                <Modal show={true}>
+                    <div className="flex flex-col justify-center items-start">
+                        <h2 className="font-medium text-xl my-2">Oops!</h2>
+                        <p className="font-normal my-2">There is some error with Computation service. Here is the Error message:</p>
+                        <p className="font-normal my-2">{vizStore.lastErrorMessage}</p>
+
+                        <fieldset className="mt-2 gap-1 flex flex-col justify-center items-end w-full">
+                            <div className="mt-2">
+                                <DefaultButton
+                                    text={`Close`}
+                                    className="mr-2 px-2"
+                                    onClick={closeModal}
                                 />
                             </div>
                         </fieldset>

--- a/packages/graphic-walker/src/store/index.tsx
+++ b/packages/graphic-walker/src/store/index.tsx
@@ -105,3 +105,11 @@ export function withTimeout<T extends any[], U>(f: (...args: T) => Promise<U>, t
             }),
         ]);
 }
+
+export function withErrorReport<T extends any[], U>(f: (...args: T) => Promise<U>, onError: (err: string | Error) => void) {
+    return (...args: T) =>
+        f(...args).catch((err) => {
+            onError(err);
+            throw err;
+        });
+}

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -92,6 +92,7 @@ export class VizSpecStore {
     createField: ICreateField | undefined = undefined;
     localGeoJSON: FeatureCollection | undefined = undefined;
     showErrorResolutionPanel: number = 0;
+    lastErrorMessage: string = "";
 
     private onMetaChange?: (fid: string, diffMeta: Partial<IMutField>) => void;
 
@@ -596,8 +597,9 @@ export class VizSpecStore {
         this.selectedMarkObject = newMarkObj;
     }
 
-    updateShowErrorResolutionPanel(errCode: number) {
+    updateShowErrorResolutionPanel(errCode: number, msg = "") {
         this.showErrorResolutionPanel = errCode;
+        this.lastErrorMessage = msg;
     }
 }
 

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -315,3 +315,13 @@ const defaultValueComparator = (a: any, b: any) => {
 export function parseCmpFunction(str?: string): (a: any, b: any) => number {
     return defaultValueComparator;
 }
+
+export function parseErrorMessage(errorLike: any): string {
+    if (errorLike instanceof Error) {
+        return errorLike.message;
+    }
+    if (typeof errorLike === 'string') {
+        return errorLike;
+    }
+    return String(errorLike);
+}

--- a/packages/graphic-walker/src/utils/reportError.ts
+++ b/packages/graphic-walker/src/utils/reportError.ts
@@ -2,6 +2,7 @@ import React from 'react';
 
 export const Errors = {
     canvasExceedSize: 500,
+    computationError: 501,
 } as const;
 
 export const errorContext = React.createContext({


### PR DESCRIPTION
When computation function has error, graphic walker will show a modal instead of just show a message in the log.

![image](https://github.com/Kanaries/graphic-walker/assets/15280968/07d0a4c1-98ef-4cca-8f74-7d6829253d9f)
