### PR TITLE
fix: timeout img not working

### DIFF
--- a/packages/graphic-walker/src/components/timeoutImg.tsx
+++ b/packages/graphic-walker/src/components/timeoutImg.tsx
@@ -17,7 +17,7 @@ export const ImageWithFallback = (
     return (
         <img
             {...rest}
-            src={failed ? src : fallbackSrc}
+            src={failed ? fallbackSrc : src}
             onError={() => {
                 setFailed(true);
             }}


### PR DESCRIPTION
fix the problem that TimeoutImg always use fallback image.