### PR TITLE
chore: control VizEmbedMenu in GLBOAL_CONFIG

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import { LightBulbIcon } from "@heroicons/react/24/outline";
 import { IGeographicData, IComputationFunction, ISegmentKey, IThemeKey, IMutField, IGeoDataItem, VegaGlobalConfig, IChannelScales, Specification, IDarkMode } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
@@ -20,7 +19,6 @@ import VisualConfig from './components/visualConfig';
 import ExplainData from './components/explainData';
 import GeoConfigPanel from './components/leafletRenderer/geoConfigPanel';
 import type { ToolbarItemProps } from './components/toolbar';
-import ClickMenu from './components/clickMenu';
 import AskViz from './components/askViz';
 import { VizSpecStore, renderSpec } from './store/visualSpecStore';
 import FieldsContextWrapper from './fields/fieldsContext';
@@ -34,6 +32,7 @@ import Errorpanel from './components/errorpanel';
 import { GWGlobalConfig } from './vis/theme';
 import { useCurrentMediaTheme } from './utils/media';
 import { parseErrorMessage } from './utils';
+import { VizEmbedMenu } from './components/embedMenu';
 
 export interface BaseVizProps {
     i18nLang?: string;
@@ -197,20 +196,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                                         channelScales={props.channelScales}
                                                     />
                                                 )}
-                                                {vizEmbededMenu.show && (
-                                                    <ClickMenu x={vizEmbededMenu.position[0]} y={vizEmbededMenu.position[1]}>
-                                                        <div
-                                                            className="flex items-center whitespace-nowrap py-1 px-4 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer"
-                                                            onClick={() => {
-                                                                vizStore.closeEmbededMenu();
-                                                                vizStore.setShowInsightBoard(true);
-                                                            }}
-                                                        >
-                                                            <span className="flex-1 pr-2">{t('App.labels.data_interpretation')}</span>
-                                                            <LightBulbIcon className="ml-1 w-3 flex-grow-0 flex-shrink-0" />
-                                                        </div>
-                                                    </ClickMenu>
-                                                )}
+                                                <VizEmbedMenu />
                                             </div>
                                         </div>
                                     </div>

--- a/packages/graphic-walker/src/components/clickMenu.tsx
+++ b/packages/graphic-walker/src/components/clickMenu.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import styled from "styled-components";
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
 
 const MenuContainer = styled.div`
     min-width: 100px;
@@ -15,10 +15,20 @@ interface ClickMenuProps {
 
 const ClickMenu: React.FC<ClickMenuProps> = (props) => {
     const { x, y, children } = props;
+    const [rect, setRect] = useState<DOMRect>();
+    const containerCb = useCallback((el: HTMLDivElement) => {
+        if (el) {
+            setRect(el.getBoundingClientRect());
+        }
+    }, []);
+    const left = x - (rect?.left ?? 0);
+    const top = y - (rect?.top ?? 0);
     return (
-        <MenuContainer className="shadow-lg text-sm bg-white border border-gray-100 dark:bg-black dark:border-gray-700" style={{ left: x + "px", top: y + "px" }}>
-            {children}
-        </MenuContainer>
+        <div className="absolute inset-0" ref={containerCb}>
+            <MenuContainer className="shadow-lg text-sm bg-white border border-gray-100 dark:bg-black dark:border-gray-700" style={{ left, top }}>
+                {children}
+            </MenuContainer>
+        </div>
     );
 };
 

--- a/packages/graphic-walker/src/components/embedMenu.tsx
+++ b/packages/graphic-walker/src/components/embedMenu.tsx
@@ -1,0 +1,42 @@
+import { observer } from 'mobx-react-lite';
+import { useVizStore } from '../store';
+import ClickMenu from './clickMenu';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import React from 'react';
+import { GLOBAL_CONFIG } from '../config';
+
+export const VizEmbedMenu = observer(function VizEmbedMenu() {
+    const vizStore = useVizStore();
+    const { t } = useTranslation();
+    const { vizEmbededMenu } = vizStore;
+    if (!vizEmbededMenu.show) {
+        return null;
+    }
+    return (
+        <ClickMenu x={vizEmbededMenu.position[0]} y={vizEmbededMenu.position[1]}>
+            {GLOBAL_CONFIG.EMBEDED_MENU_LIST.map((key) => {
+                switch (key) {
+                    case 'data_interpretation':
+                        return (
+                            <div
+                                key={key}
+                                className="flex items-center whitespace-nowrap py-1 px-4 hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer"
+                                onClick={() => {
+                                    vizStore.closeEmbededMenu();
+                                    vizStore.setShowInsightBoard(true);
+                                }}
+                            >
+                                <span className="flex-1 pr-2">{t('App.labels.data_interpretation')}</span>
+                                <LightBulbIcon className="ml-1 w-3 flex-grow-0 flex-shrink-0" />
+                            </div>
+                        );
+                    default:
+                        const unexceptedKey: never = key;
+                        console.error('Unknown item', unexceptedKey);
+                        return null;
+                }
+            })}
+        </ClickMenu>
+    );
+});

--- a/packages/graphic-walker/src/config.ts
+++ b/packages/graphic-walker/src/config.ts
@@ -1,4 +1,4 @@
-import { DraggableFieldState, IAggregator, ICoordMode, IStackMode, IVisualConfig } from './interfaces';
+import { DraggableFieldState, IAggregator, ICoordMode, IEmbedMenuItem, IStackMode, IVisualConfig } from './interfaces';
 
 const GEOM_TYPES: Record<ICoordMode, string[]> = {
     generic: ['auto', 'bar', 'line', 'area', 'trail', 'point', 'circle', 'tick', 'rect', 'arc', 'text', 'boxplot', 'table'],
@@ -44,6 +44,8 @@ const NON_POSITION_CHANNEL_CONFIG_LIST: Array<keyof IVisualConfig['resolve']> = 
 
 const AGGREGATOR_LIST: IAggregator[] = ['sum', 'mean', 'median', 'count', 'min', 'max', 'variance', 'stdev'];
 
+const EMBEDED_MENU_LIST: IEmbedMenuItem[] = ['data_interpretation'];
+
 export const GLOBAL_CONFIG = {
     AGGREGATOR_LIST,
     CHART_LAYOUT_TYPE,
@@ -56,6 +58,7 @@ export const GLOBAL_CONFIG = {
     CHANNEL_LIMIT,
     POSITION_CHANNEL_CONFIG_LIST,
     NON_POSITION_CHANNEL_CONFIG_LIST,
+    EMBEDED_MENU_LIST,
 };
 
 export function getGlobalConfig() {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -16,6 +16,8 @@ export interface IRow {
 }
 
 export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev';
+
+export type IEmbedMenuItem = 'data_interpretation';
 export interface Specification {
     position?: string[];
     color?: string[];

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -15,6 +15,7 @@ import { emptyEncodings, emptyVisualConfig } from '../utils/save';
 import { getMeaAggKey } from '../utils';
 import { COUNT_FIELD_ID } from '../constants';
 import { GWGlobalConfig } from '../vis/theme';
+import { GLOBAL_CONFIG } from '../config';
 
 interface RendererProps {
     themeKey?: IThemeKey;
@@ -122,12 +123,14 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
     const handleGeomClick = useCallback(
         (values: any, e: any) => {
             e.stopPropagation();
-            runInAction(() => {
-                vizStore.showEmbededMenu([e.pageX, e.pageY]);
-                vizStore.setFilters(values);
-            });
-            const selectedMarkObject = values.vlPoint.or[0];
-            vizStore.updateSelectedMarkObject(selectedMarkObject);
+            if (GLOBAL_CONFIG.EMBEDED_MENU_LIST.length > 0) {
+                runInAction(() => {
+                    vizStore.showEmbededMenu([e.pageX, e.pageY]);
+                    vizStore.setFilters(values);
+                });
+                const selectedMarkObject = values.vlPoint.or[0];
+                vizStore.updateSelectedMarkObject(selectedMarkObject);    
+            }
         },
         [vizStore]
     );


### PR DESCRIPTION
add control of VizEmbedMenu in GLBOAL_CONFIG for user to disable it.
usage:
```
import { getGlobalConfig } from "@kanaries/graphic-walker";
getGlobalConfig().EMBEDED_MENU_LIST = [];
```