### PR TITLE
Feat: export table as Component

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -2,16 +2,13 @@ import React, { useEffect, useMemo, useRef, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
 import {
-    IGeographicData,
-    IComputationFunction,
     ISegmentKey,
-    IThemeKey,
-    IMutField,
-    IGeoDataItem,
-    VegaGlobalConfig,
-    IChannelScales,
-    Specification,
-    IDarkMode,
+    IAppI18nProps,
+    IVizProps,
+    IErrorHandlerProps,
+    IVizAppProps,
+    ISpecProps,
+    IComputationContextProps,
 } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
@@ -40,38 +37,18 @@ import BinPanel from './fields/datasetFields/binPanel';
 import { ErrorContext } from './utils/reportError';
 import { ErrorBoundary } from 'react-error-boundary';
 import Errorpanel from './components/errorpanel';
-import { GWGlobalConfig } from './vis/theme';
 import { useCurrentMediaTheme } from './utils/media';
 import { parseErrorMessage } from './utils';
 import { VizEmbedMenu } from './components/embedMenu';
 
-export interface BaseVizProps {
-    i18nLang?: string;
-    i18nResources?: { [lang: string]: Record<string, string | any> };
-    themeKey?: IThemeKey;
-    darkMode?: 'light' | 'dark';
-    themeConfig?: GWGlobalConfig;
-    toolbar?: {
-        extra?: ToolbarItemProps[];
-        exclude?: string[];
+export type BaseVizProps = IAppI18nProps &
+    IVizProps &
+    IErrorHandlerProps &
+    ISpecProps &
+    IComputationContextProps & {
+        darkMode?: 'light' | 'dark';
+        dataSelection?: React.ReactChild;
     };
-    geographicData?: IGeographicData & {
-        key: string;
-    };
-    enhanceAPI?: {
-        header?: Record<string, string>;
-        features?: {
-            askviz?: string | boolean;
-        };
-    };
-    dataSelection?: React.ReactChild;
-    computation?: IComputationFunction;
-    computationTimeout?: number;
-    onError?: (err: Error) => void;
-    geoList?: IGeoDataItem[];
-    channelScales?: IChannelScales;
-    spec?: Specification;
-}
 
 export const VizApp = observer(function VizApp(props: BaseVizProps) {
     const {
@@ -230,51 +207,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
     );
 });
 
-export type VizProps = {
-    i18nLang?: string;
-    i18nResources?: { [lang: string]: Record<string, string | any> };
-    themeConfig?: GWGlobalConfig;
-    themeKey?: IThemeKey;
-    dark?: IDarkMode;
-    toolbar?: {
-        extra?: ToolbarItemProps[];
-        exclude?: string[];
-    };
-    geographicData?: IGeographicData & {
-        key: string;
-    };
-    enhanceAPI?: {
-        header?: Record<string, string>;
-        features?: {
-            askviz?: string | boolean;
-        };
-    };
-    keepAlive?: boolean | string;
-    storeRef?: React.MutableRefObject<VizSpecStore | null>;
-    rawFields: IMutField[];
-    onMetaChange?: (fid: string, meta: Partial<IMutField>) => void;
-    computationTimeout?: number;
-    dataSelection?: React.ReactChild;
-    onError?: (err: Error) => void;
-    geoList?: IGeoDataItem[];
-    channelScales?: IChannelScales;
-    spec?: Specification;
-} & (
-    | {
-          /**
-           * auto parse field key into a safe string. default is true
-           */
-          fieldKeyGuard?: boolean;
-          dataSource: any[];
-      }
-    | {
-          fieldKeyGuard?: undefined;
-          dataSource?: undefined;
-          computation: IComputationFunction;
-      }
-);
-
-export function VizAppWithContext(props: VizProps) {
+export function VizAppWithContext(props: IVizAppProps) {
     const { computation, safeMetas } = useMemo(() => {
         if (props.dataSource) {
             if (props.fieldKeyGuard) {
@@ -311,7 +244,6 @@ export function VizAppWithContext(props: VizProps) {
                         computation={computation}
                         computationTimeout={props.computationTimeout}
                         channelScales={props.channelScales}
-                        dataSelection={props.dataSelection}
                         geoList={props.geoList}
                         geographicData={props.geographicData}
                         onError={props.onError}

--- a/packages/graphic-walker/src/FullApp.tsx
+++ b/packages/graphic-walker/src/FullApp.tsx
@@ -1,41 +1,11 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
-import { IChannelScales, IDarkMode, IGeoDataItem, IGeographicData, IThemeKey } from './interfaces';
+import { IGWProps } from './interfaces';
 import DataSourceSegment from './dataSource/index';
 import { StoreWrapper, VisContext, useGlobalStore } from './store';
 import { useCurrentMediaTheme } from './utils/media';
-import type { ToolbarItemProps } from './components/toolbar';
 import { VizApp } from './App';
-import { CommonStore } from './store/commonStore';
 import FieldsContextWrapper from './fields/fieldsContext';
-import { GWGlobalConfig } from './vis/theme';
-
-export interface IGWProps {
-    i18nLang?: string;
-    i18nResources?: { [lang: string]: Record<string, string | any> };
-    keepAlive?: boolean | string;
-    /** @default "vega" */
-    themeKey?: IThemeKey;
-    themeConfig?: GWGlobalConfig;
-    dark?: IDarkMode;
-    toolbar?: {
-        extra?: ToolbarItemProps[];
-        exclude?: string[];
-    };
-    enhanceAPI?: {
-        header?: Record<string, string>;
-        features?: {
-            askviz?: string | boolean;
-        };
-    };
-    storeRef?: React.MutableRefObject<CommonStore | null>;
-    geographicData?: IGeographicData & {
-        key: string;
-    };
-    onError?: (err: Error) => void;
-    geoList?: IGeoDataItem[];
-    channelScales?: IChannelScales;
-}
 
 export const AppContent = observer<Omit<IGWProps, 'storeRef' | 'keepAlive'>>(function App(props) {
     const { i18nLang = 'en-US', i18nResources, themeKey = 'vega', dark = 'media', themeConfig, toolbar, enhanceAPI, geographicData, onError, geoList, channelScales } = props;

--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -61,11 +61,7 @@ export const TableApp = observer(function VizApp(props: BaseTableProps) {
                 <ComputationContext.Provider value={wrappedComputation}>
                     <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
                         <div className="bg-white dark:bg-zinc-900 dark:text-white">
-                            <div className="m-4 p-4 border border-gray-200 dark:border-gray-700" style={{ marginTop: '0em', borderTop: 'none' }}>
-                                <div className="relative">
-                                    <DatasetTable size={pageSize} metas={vizStore.meta} computation={wrappedComputation} />
-                                </div>
-                            </div>
+                            <DatasetTable size={pageSize} metas={vizStore.meta} computation={wrappedComputation} />
                         </div>
                     </div>
                 </ComputationContext.Provider>

--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -1,0 +1,114 @@
+import { observer } from 'mobx-react-lite';
+import React, { useEffect, useCallback, useMemo } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { useTranslation } from 'react-i18next';
+import { IAppI18nProps, IErrorHandlerProps, IComputationContextProps, ITableProps, ITableSpecProps } from './interfaces';
+import { mergeLocaleRes, setLocaleLanguage } from './locales/i18n';
+import { useVizStore, withErrorReport, withTimeout, ComputationContext, VizStoreWrapper } from './store';
+import { parseErrorMessage } from './utils';
+import { ErrorContext } from './utils/reportError';
+import { guardDataKeys } from './utils/dataPrep';
+import { getComputation } from './computation/clientComputation';
+import DatasetTable from './components/dataTable';
+import { useCurrentMediaTheme } from './utils/media';
+
+export type BaseTableProps = IAppI18nProps &
+    IErrorHandlerProps &
+    IComputationContextProps &
+    ITableSpecProps & {
+        darkMode?: 'light' | 'dark';
+    };
+
+export const TableApp = observer(function VizApp(props: BaseTableProps) {
+    const { computation, darkMode = 'light', i18nLang = 'en-US', i18nResources, computationTimeout = 60000, onError, pageSize = 20 } = props;
+
+    const { i18n } = useTranslation();
+    const curLang = i18n.language;
+
+    useEffect(() => {
+        if (i18nResources) {
+            mergeLocaleRes(i18nResources);
+        }
+    }, [i18nResources]);
+
+    useEffect(() => {
+        if (i18nLang !== curLang) {
+            setLocaleLanguage(i18nLang);
+        }
+    }, [i18nLang, curLang]);
+
+    const vizStore = useVizStore();
+
+    const reportError = useCallback(
+        (msg: string, code?: number) => {
+            const err = new Error(`Error${code ? `(${code})` : ''}: ${msg}`);
+            console.error(err);
+            onError?.(err);
+            if (code) {
+                vizStore.updateShowErrorResolutionPanel(code, msg);
+            }
+        },
+        [vizStore, onError]
+    );
+
+    const wrappedComputation = useMemo(
+        () => (computation ? withErrorReport(withTimeout(computation, computationTimeout), (err) => reportError(parseErrorMessage(err), 501)) : async () => []),
+        [reportError, computation, computationTimeout]
+    );
+    return (
+        <ErrorContext value={{ reportError }}>
+            <ErrorBoundary fallback={<div>Something went wrong</div>} onError={props.onError}>
+                <ComputationContext.Provider value={wrappedComputation}>
+                    <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
+                        <div className="bg-white dark:bg-zinc-900 dark:text-white">
+                            <div className="m-4 p-4 border border-gray-200 dark:border-gray-700" style={{ marginTop: '0em', borderTop: 'none' }}>
+                                <div className="relative">
+                                    <DatasetTable size={pageSize} metas={vizStore.meta} computation={wrappedComputation} />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ComputationContext.Provider>
+            </ErrorBoundary>
+        </ErrorContext>
+    );
+});
+
+export function TableAppWithContext(props: ITableProps) {
+    const { computation, safeMetas } = useMemo(() => {
+        if (props.dataSource) {
+            if (props.fieldKeyGuard) {
+                const { safeData, safeMetas } = guardDataKeys(props.dataSource, props.rawFields);
+                return {
+                    safeMetas,
+                    computation: getComputation(safeData),
+                };
+            }
+            return {
+                safeMetas: props.rawFields,
+                computation: getComputation(props.dataSource),
+            };
+        }
+        return {
+            safeMetas: props.rawFields,
+            computation: props.computation,
+        };
+    }, [props.rawFields, props.dataSource ? props.dataSource : props.computation, props.fieldKeyGuard]);
+
+    const darkMode = useCurrentMediaTheme(props.dark);
+
+    return (
+        <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
+            <VizStoreWrapper onMetaChange={props.onMetaChange} meta={safeMetas} keepAlive={props.keepAlive} storeRef={props.storeRef}>
+                <TableApp
+                    darkMode={darkMode}
+                    i18nLang={props.i18nLang}
+                    i18nResources={props.i18nResources}
+                    computation={computation}
+                    computationTimeout={props.computationTimeout}
+                    onError={props.onError}
+                />
+            </VizStoreWrapper>
+        </div>
+    );
+}

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -21,7 +21,6 @@ interface DataTableProps {
 }
 const Container = styled.div`
     overflow-x: auto;
-    max-height: 660px;
     table {
         box-sizing: content-box;
         border-collapse: collapse;

--- a/packages/graphic-walker/src/index.tsx
+++ b/packages/graphic-walker/src/index.tsx
@@ -1,14 +1,15 @@
 import React, { type ForwardedRef, forwardRef, useState } from 'react';
 import { DOMProvider } from '@kanaries/react-beautiful-dnd';
 import { observer } from 'mobx-react-lite';
-import { VizAppWithContext, VizProps } from './App';
-import { App, IGWProps } from './FullApp';
+import { VizAppWithContext } from './App';
+import { App } from './FullApp';
 
 import { ShadowDom } from './shadow-dom';
 import AppRoot from './components/appRoot';
-import type { IGWHandler, IGWHandlerInsider } from './interfaces';
+import type { IGWHandler, IGWHandlerInsider, IGWProps, ITableProps, IVizAppProps } from './interfaces';
 
 import './empty_sheet.css';
+import { TableAppWithContext } from './Table';
 
 export const FullGraphicWalker = observer(
     forwardRef<IGWHandler, IGWProps>((props, ref) => {
@@ -34,7 +35,7 @@ export const FullGraphicWalker = observer(
 );
 
 export const GraphicWalker = observer(
-    forwardRef<IGWHandler, VizProps>((props, ref) => {
+    forwardRef<IGWHandler, IVizAppProps>((props, ref) => {
         const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
 
         const handleMount = (shadowRoot: ShadowRoot) => {
@@ -56,9 +57,32 @@ export const GraphicWalker = observer(
     })
 );
 
+export const TableWalker = observer(
+    forwardRef<IGWHandler, ITableProps>((props, ref) => {
+        const [shadowRoot, setShadowRoot] = useState<ShadowRoot | null>(null);
+
+        const handleMount = (shadowRoot: ShadowRoot) => {
+            setShadowRoot(shadowRoot);
+        };
+        const handleUnmount = () => {
+            setShadowRoot(null);
+        };
+
+        return (
+            <AppRoot ref={ref as ForwardedRef<IGWHandlerInsider>}>
+                <ShadowDom onMount={handleMount} onUnmount={handleUnmount}>
+                    <DOMProvider value={{ head: shadowRoot ?? document.head, body: shadowRoot ?? document.body }}>
+                        <TableAppWithContext {...props} />
+                    </DOMProvider>
+                </ShadowDom>
+            </AppRoot>
+        );
+    })
+);
+
 export { default as PureRenderer } from './renderer/pureRenderer';
 export { embedGraphicWalker } from './vanilla';
-export type { IGWProps };
+export type { IGWProps, ITableProps, IVizAppProps };
 export { ISegmentKey, ColorSchemes } from './interfaces';
 export { resolveChart, convertChart } from './models/visSpecHistory';
 export { getGlobalConfig } from './config';

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -3,6 +3,10 @@ import { Config as VlConfig } from 'vega-lite';
 import type { FeatureCollection } from 'geojson';
 import type { feature } from 'topojson-client';
 import { DATE_TIME_DRILL_LEVELS } from './constants';
+import { ToolbarItemProps } from './components/toolbar';
+import { GWGlobalConfig } from './vis/theme';
+import { VizSpecStore } from './store/visualSpecStore';
+import { CommonStore } from './store/commonStore';
 
 export type DeepReadonly<T extends Record<keyof any, any>> = {
     readonly [K in keyof T]: T[K] extends Record<keyof any, any> ? DeepReadonly<T[K]> : T[K];
@@ -757,3 +761,86 @@ export interface IChannelScales {
     radius?: IScale | ((info: IFieldInfos) => IScale);
     theta?: IScale | ((info: IFieldInfos) => IScale);
 }
+
+export interface IAppI18nProps {
+    i18nLang?: string;
+    i18nResources?: { [lang: string]: Record<string, string | any> };
+}
+
+export interface IThemeProps {
+    dark?: IDarkMode;
+}
+
+export interface IErrorHandlerProps {
+    onError?: (err: Error) => void;
+}
+
+export interface IVizProps {
+    themeConfig?: GWGlobalConfig;
+    /** @default "vega" */
+    themeKey?: IThemeKey;
+    toolbar?: {
+        extra?: ToolbarItemProps[];
+        exclude?: string[];
+    };
+    geographicData?: IGeographicData & {
+        key: string;
+    };
+    enhanceAPI?: {
+        header?: Record<string, string>;
+        features?: {
+            askviz?: string | boolean;
+        };
+    };
+    geoList?: IGeoDataItem[];
+    channelScales?: IChannelScales;
+}
+
+export interface IVizStoreProps {
+    storeRef?: React.MutableRefObject<VizSpecStore | null>;
+    keepAlive?: boolean | string;
+    rawFields: IMutField[];
+    onMetaChange?: (fid: string, meta: Partial<IMutField>) => void;
+}
+
+export type IComputationProps = {
+    computationTimeout?: number;
+} & (
+    | {
+          /**
+           * auto parse field key into a safe string. default is true
+           */
+          fieldKeyGuard?: boolean;
+          dataSource: any[];
+      }
+    | {
+          fieldKeyGuard?: undefined;
+          dataSource?: undefined;
+          computation: IComputationFunction;
+      }
+);
+
+export interface IComputationContextProps {
+    computation?: IComputationFunction;
+    computationTimeout?: number;
+}
+
+export type IGWProps = IAppI18nProps &
+    IVizProps &
+    IThemeProps &
+    IErrorHandlerProps & {
+        storeRef?: React.MutableRefObject<CommonStore | null>;
+        keepAlive?: boolean | string;
+    };
+
+export interface ISpecProps {
+    spec?: Specification;
+}
+
+export interface ITableSpecProps {
+    pageSize?: number;
+}
+
+export type IVizAppProps = IAppI18nProps & IVizProps & IThemeProps & IErrorHandlerProps & IVizStoreProps & IComputationProps & ISpecProps;
+
+export type ITableProps = IAppI18nProps & IThemeProps & IErrorHandlerProps & IVizStoreProps & IComputationProps & ITableSpecProps;

--- a/packages/graphic-walker/src/vanilla.tsx
+++ b/packages/graphic-walker/src/vanilla.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { FullGraphicWalker, GraphicWalker } from './index';
+import { FullGraphicWalker, IGWProps } from './index';
 
-import { IGWProps } from './FullApp';
 
 export function embedGraphicWalker(dom: HTMLElement | null, props: IGWProps | undefined = {}) {
     if (!dom) {


### PR DESCRIPTION
Add a new Component TableWalker to use Table as a Component.
usage: 
```
import { TableWalker } from "@kanaries/graphic-walker";
// use static data
<TableWalker dataSource={data} rawFields={meta} />
// use a custom computation
<TableWalker computation={computation} rawFields={meta} />
```