### PR TITLE
feat: add Sorting & Filter for DataTable

### DIFF
--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -137,7 +137,7 @@ function useFilters(metas: IMutField[]) {
                     name: meta.name ?? meta.fid,
                     semanticType: meta.semanticType,
                 };
-                if (editingFilterIdx === null) {
+                if (editingFilterIdx === null || !filters[editingFilterIdx]) {
                     setFilters(filters.concat(newFilter));
                     setEditingFilterIdx(filters.length);
                 } else {
@@ -430,7 +430,10 @@ const FilterPill = (props: { name: string; onRemove?: () => void; onClick?: () =
             className="inline-flex items-center gap-x-0.5 rounded-md bg-gray-50 dark:bg-gray-800 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-200 ring-1 ring-inset ring-gray-500/10"
         >
             {props.name}
-            <button onClick={props.onRemove} type="button" className="group relative -mr-1 h-3.5 w-3.5 rounded-sm hover:bg-gray-500/20">
+            <button onClick={e => {
+                e.stopPropagation();
+                props.onRemove?.();
+            }} type="button" className="group relative -mr-1 h-3.5 w-3.5 rounded-sm hover:bg-gray-500/20">
                 <span className="sr-only">Remove</span>
                 <svg
                     viewBox="0 0 14 14"

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 import { observer } from 'mobx-react-lite';
-import type { IMutField, IRow, IComputationFunction } from '../../interfaces';
+import type { IMutField, IRow, IComputationFunction, IVisFilter } from '../../interfaces';
 import { useTranslation } from 'react-i18next';
 import LoadingLayer from '../loadingLayer';
 import { dataReadRaw } from '../../computation';
@@ -135,10 +135,16 @@ const DataTable: React.FC<DataTableProps> = (props) => {
     const [dataLoading, setDataLoading] = useState(false);
     const taskIdRef = useRef(0);
 
+    const [sorting, setSorting] = useState<{ fid: string; sort: 'ascending' | 'descending' } | undefined>();
+    const [filters, setFilters] = useState<IVisFilter[]>([]);
+
     useEffect(() => {
         setDataLoading(true);
         const taskId = ++taskIdRef.current;
-        dataReadRaw(computationFunction, size, pageIndex)
+        dataReadRaw(computationFunction, size, pageIndex, {
+            sorting,
+            filters,
+        })
             .then((data) => {
                 if (taskId === taskIdRef.current) {
                     setDataLoading(false);
@@ -155,7 +161,7 @@ const DataTable: React.FC<DataTableProps> = (props) => {
         return () => {
             taskIdRef.current++;
         };
-    }, [computationFunction, pageIndex, size]);
+    }, [computationFunction, pageIndex, size, sorting, filters]);
 
     const loading = statLoading || dataLoading;
 
@@ -163,10 +169,8 @@ const DataTable: React.FC<DataTableProps> = (props) => {
 
     return (
         <Container className="relative">
-            <nav
-                className="flex items-center justify-between bg-white dark:bg-zinc-900 p-2"
-                aria-label="Pagination"
-            >
+            <div>{/** TODO: Filter puts in here */}</div>
+            <nav className="flex items-center justify-between bg-white dark:bg-zinc-900 p-2" aria-label="Pagination">
                 <div className="hidden sm:block">
                     <p className="text-sm text-gray-800 dark:text-gray-100">
                         Showing <span className="font-medium">{from + 1}</span> to <span className="font-medium">{to + 1}</span> of{' '}

--- a/packages/graphic-walker/src/components/modal.tsx
+++ b/packages/graphic-walker/src/components/modal.tsx
@@ -9,8 +9,8 @@ const Background = styled.div`
     position: fixed;
     left: 0;
     top: 0;
-    width: 100vw;
-    height: 100vh;
+    right: 0;
+    bottom: 0;
     backdrop-filter: blur(1px);
     z-index: 25535;
 `;

--- a/packages/graphic-walker/src/components/smallModal.tsx
+++ b/packages/graphic-walker/src/components/smallModal.tsx
@@ -9,8 +9,8 @@ const Background = styled.div`
     position: fixed;
     left: 0;
     top: 0;
-    width: 100vw;
-    height: 100vh;
+    right: 0;
+    bottom: 0;
     backdrop-filter: blur(1px);
     z-index: 25535;
 `;

--- a/packages/graphic-walker/src/computation/clientComputation.ts
+++ b/packages/graphic-walker/src/computation/clientComputation.ts
@@ -8,7 +8,7 @@ export const dataQueryClient = async (
     limit?: number,
 ): Promise<IRow[]> => {
     if (process.env.NODE_ENV !== "production") {
-        console.log('local query triggered');
+        console.log('local query triggered', workflow);
     }
     let res = rawData;
     for await (const step of workflow) {

--- a/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
+++ b/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
@@ -1,47 +1,17 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import DatasetTable from '../../components/dataTable';
 import { observer } from 'mobx-react-lite';
 import { useCompututaion, useVizStore } from '../../store';
-import { datasetStats } from '../../computation';
 
 const DatasetConfig: React.FC = () => {
     const vizStore = useVizStore();
     const computation = useCompututaion();
 
-    const [count, setCount] = useState(0);
-    const taskIdRef = useRef(0);
-    const [loading, setLoading] = useState(false);
-
-    useEffect(() => {
-        const taskId = ++taskIdRef.current;
-        setLoading(true);
-        datasetStats(computation)
-            .then((res) => {
-                if (taskId !== taskIdRef.current) {
-                    return;
-                }
-                setCount(res.rowCount);
-                setLoading(false);
-            })
-            .catch((err) => {
-                if (taskId !== taskIdRef.current) {
-                    return;
-                }
-                console.error(err);
-                setLoading(false);
-            });
-        return () => {
-            taskIdRef.current++;
-        };
-    }, [computation]);
-
     return (
         <div className="relative">
             <DatasetTable
                 size={100}
-                total={count}
                 metas={vizStore.meta}
-                loading={loading}
                 computation={computation}
                 onMetaChange={(fid, fIndex, diffMeta) => {
                     vizStore.updateCurrentDatasetMetas(fid, diffMeta);

--- a/packages/graphic-walker/src/dataSource/table.tsx
+++ b/packages/graphic-walker/src/dataSource/table.tsx
@@ -24,7 +24,6 @@ const Table: React.FC<TableProps> = (props) => {
                 size={size}
                 metas={metas}
                 computation={computation}
-                total={tmpDataSource.length}
                 onMetaChange={(fid, fIndex, diffMeta) => {
                     commonStore.updateTempDatasetMetas(fid, diffMeta);
                 }}

--- a/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { toJS } from 'mobx';
 import Modal from '../../components/modal';
-import type { IFilterField, IFilterRule } from '../../interfaces';
+import type { IFilterField, IFilterRule, IMutField, IViewField } from '../../interfaces';
 import { useVizStore } from '../../store';
 import Tabs, { RuleFormProps } from './tabs';
 import DefaultButton from '../../components/button/default';
@@ -29,12 +29,19 @@ const TemporalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange 
 
 const EmptyForm: React.FC<RuleFormProps> = () => <React.Fragment />;
 
-const FilterEditDialog: React.FC = observer(() => {
-    const vizStore = useVizStore();
-    const { editingFilterIdx, viewFilters, dimensions, measures, meta, allFields } = vizStore;
-
+export const PureFilterEditDialog = (props: {
+    viewFilters: IFilterField[];
+    dimensions: IViewField[];
+    measures: IViewField[];
+    allFields: IViewField[];
+    meta: IMutField[];
+    editingFilterIdx: number | null;
+    onSelectFilter: (field: string) => void;
+    onWriteFilter: (index: number, rule: IFilterRule | null) => void;
+    onClose: () => void;
+}) => {
+    const { editingFilterIdx, viewFilters, meta, allFields, onSelectFilter, onWriteFilter, onClose } = props;
     const { t } = useTranslation('translation', { keyPrefix: 'filters' });
-
     const field = React.useMemo(() => {
         return editingFilterIdx !== null ? viewFilters[editingFilterIdx] : null;
     }, [editingFilterIdx, viewFilters]);
@@ -66,34 +73,20 @@ const FilterEditDialog: React.FC = observer(() => {
 
     const handleSubmit = React.useCallback(() => {
         if (editingFilterIdx !== null) {
-            vizStore.writeFilter(editingFilterIdx, uncontrolledField?.rule ?? null);
+            onWriteFilter(editingFilterIdx, uncontrolledField?.rule ?? null);
         }
 
-        vizStore.closeFilterEditing();
-    }, [editingFilterIdx, uncontrolledField?.rule, vizStore]);
+        onClose();
+    }, [editingFilterIdx, uncontrolledField?.rule, onWriteFilter]);
 
     const allFieldOptions = React.useMemo(() => {
-        return allFields.filter(x => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID].includes(x.fid)).map((d) => ({
-            label: d.name,
-            value: d.fid,
-        }));
+        return allFields
+            .filter((x) => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID].includes(x.fid))
+            .map((d) => ({
+                label: d.name,
+                value: d.fid,
+            }));
     }, [allFields]);
-
-    const handleSelectFilterField = (fieldKey) => {
-        const existingFilterIdx = viewFilters.findIndex((field) => field.fid === fieldKey);
-        if (existingFilterIdx >= 0) {
-            vizStore.setFilterEditing(existingFilterIdx);
-        } else {
-            const sourceKey = dimensions.find((field) => field.fid === fieldKey) ? 'dimensions' : 'measures';
-            const sourceIndex =
-                sourceKey === 'dimensions'
-                    ? dimensions.findIndex((field) => field.fid === fieldKey)
-                    : measures.findIndex((field) => field.fid === fieldKey);
-            if (editingFilterIdx !== null) {
-                vizStore.modFilter(editingFilterIdx, sourceKey, sourceIndex);
-            }
-        }
-    };
 
     const Form = field
         ? ({
@@ -105,7 +98,7 @@ const FilterEditDialog: React.FC = observer(() => {
         : EmptyForm;
 
     return uncontrolledField ? (
-        <Modal show={Boolean(uncontrolledField)} title={t('editing')} onClose={() => vizStore.closeFilterEditing()}>
+        <Modal show={Boolean(uncontrolledField)} title={t('editing')} onClose={onClose}>
             <div className="px-4 py-1">
                 <div className="py-1">{t('form.name')}</div>
                 <DropdownSelect
@@ -113,16 +106,60 @@ const FilterEditDialog: React.FC = observer(() => {
                     className="mb-2"
                     options={allFieldOptions}
                     selectedKey={uncontrolledField.fid}
-                    onSelect={handleSelectFilterField}
+                    onSelect={onSelectFilter}
                 />
-                <Form rawFields={meta} field={uncontrolledField} onChange={handleChange} />
+                <Form rawFields={meta} key={uncontrolledField.fid} field={uncontrolledField} onChange={handleChange} />
                 <div className="mt-4">
                     <PrimaryButton onClick={handleSubmit} text={t('btn.confirm')} />
-                    <DefaultButton className="ml-2" onClick={() => vizStore.closeFilterEditing()} text={t('btn.cancel')} />
+                    <DefaultButton className="ml-2" onClick={onClose} text={t('btn.cancel')} />
                 </div>
             </div>
         </Modal>
     ) : null;
+};
+
+const FilterEditDialog: React.FC = observer(() => {
+    const vizStore = useVizStore();
+    const { editingFilterIdx, viewFilters, dimensions, measures, meta, allFields } = vizStore;
+
+    const handelClose = React.useCallback(() => vizStore.closeFilterEditing(), [vizStore]);
+
+    const handleWriteFilter = React.useCallback(
+        (index: number, rule: IFilterRule | null) => {
+            if (index !== null) {
+                vizStore.writeFilter(index, rule ?? null);
+            }
+        },
+        [vizStore]
+    );
+
+    const handleSelectFilterField = (fieldKey) => {
+        const existingFilterIdx = viewFilters.findIndex((field) => field.fid === fieldKey);
+        if (existingFilterIdx >= 0) {
+            vizStore.setFilterEditing(existingFilterIdx);
+        } else {
+            const sourceKey = dimensions.find((field) => field.fid === fieldKey) ? 'dimensions' : 'measures';
+            const sourceIndex =
+                sourceKey === 'dimensions' ? dimensions.findIndex((field) => field.fid === fieldKey) : measures.findIndex((field) => field.fid === fieldKey);
+            if (editingFilterIdx !== null) {
+                vizStore.modFilter(editingFilterIdx, sourceKey, sourceIndex);
+            }
+        }
+    };
+
+    return (
+        <PureFilterEditDialog
+            allFields={allFields}
+            dimensions={dimensions}
+            editingFilterIdx={editingFilterIdx}
+            measures={measures}
+            meta={meta}
+            onClose={handelClose}
+            onSelectFilter={handleSelectFilterField}
+            onWriteFilter={handleWriteFilter}
+            viewFilters={viewFilters}
+        />
+    );
 });
 
 export default FilterEditDialog;

--- a/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
@@ -31,16 +31,14 @@ const EmptyForm: React.FC<RuleFormProps> = () => <React.Fragment />;
 
 export const PureFilterEditDialog = (props: {
     viewFilters: IFilterField[];
-    dimensions: IViewField[];
-    measures: IViewField[];
-    allFields: IViewField[];
+    options: { label: string; value: string }[];
     meta: IMutField[];
     editingFilterIdx: number | null;
     onSelectFilter: (field: string) => void;
     onWriteFilter: (index: number, rule: IFilterRule | null) => void;
     onClose: () => void;
 }) => {
-    const { editingFilterIdx, viewFilters, meta, allFields, onSelectFilter, onWriteFilter, onClose } = props;
+    const { editingFilterIdx, viewFilters, meta, options, onSelectFilter, onWriteFilter, onClose } = props;
     const { t } = useTranslation('translation', { keyPrefix: 'filters' });
     const field = React.useMemo(() => {
         return editingFilterIdx !== null ? viewFilters[editingFilterIdx] : null;
@@ -79,15 +77,6 @@ export const PureFilterEditDialog = (props: {
         onClose();
     }, [editingFilterIdx, uncontrolledField?.rule, onWriteFilter]);
 
-    const allFieldOptions = React.useMemo(() => {
-        return allFields
-            .filter((x) => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID].includes(x.fid))
-            .map((d) => ({
-                label: d.name,
-                value: d.fid,
-            }));
-    }, [allFields]);
-
     const Form = field
         ? ({
               quantitative: QuantitativeRuleForm,
@@ -101,13 +90,7 @@ export const PureFilterEditDialog = (props: {
         <Modal show={Boolean(uncontrolledField)} title={t('editing')} onClose={onClose}>
             <div className="px-4 py-1">
                 <div className="py-1">{t('form.name')}</div>
-                <DropdownSelect
-                    buttonClassName="w-96"
-                    className="mb-2"
-                    options={allFieldOptions}
-                    selectedKey={uncontrolledField.fid}
-                    onSelect={onSelectFilter}
-                />
+                <DropdownSelect buttonClassName="w-96" className="mb-2" options={options} selectedKey={uncontrolledField.fid} onSelect={onSelectFilter} />
                 <Form rawFields={meta} key={uncontrolledField.fid} field={uncontrolledField} onChange={handleChange} />
                 <div className="mt-4">
                     <PrimaryButton onClick={handleSubmit} text={t('btn.confirm')} />
@@ -147,12 +130,19 @@ const FilterEditDialog: React.FC = observer(() => {
         }
     };
 
+    const allFieldOptions = React.useMemo(() => {
+        return allFields
+            .filter((x) => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID].includes(x.fid))
+            .map((d) => ({
+                label: d.name,
+                value: d.fid,
+            }));
+    }, [allFields]);
+
     return (
         <PureFilterEditDialog
-            allFields={allFields}
-            dimensions={dimensions}
+            options={allFieldOptions}
             editingFilterIdx={editingFilterIdx}
-            measures={measures}
             meta={meta}
             onClose={handelClose}
             onSelectFilter={handleSelectFilterField}

--- a/packages/graphic-walker/src/lib/sort.ts
+++ b/packages/graphic-walker/src/lib/sort.ts
@@ -1,10 +1,13 @@
 import { IRow } from '../interfaces';
+import { parseCmpFunction } from '../utils';
 
-function compareMulti(a: number[], b: number[]): number {
+const cmp = parseCmpFunction('');
+
+function compareMulti(a: (number | string)[], b: (number | string)[]): number {
     if (a.length < b.length) return -compareMulti(b, a);
     for (let i = 0; i < a.length; i++) {
         if (!b[i]) return 1;
-        const c = a[i] - b[i];
+        const c = cmp(a[i], b[i]);
         if (c !== 0) return c;
     }
     return 0;


### PR DESCRIPTION
Add Filter and sorting to DataTable.

Filter: 
Press Filter button on Table header to create a Filter.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/023f1780-d457-472c-804a-36b1f78ec06e)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/72e8215f-22e9-432d-a97c-2fd1f7c0b966)
When using Filter, the Filters of DataTable will show on the top of the table.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/3b46fae1-2279-4239-b053-0f2a6bf0892c)
Click Tag to Open EditDialog, and Click Remove Button to Remove the Filter.

If add a Filter is causing showing bounds out of the total data, the page will be reset to 1.

Sorting:
Press on Header text will add a descending sort on this header.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/f712732f-0fc5-49f9-a46f-340b379d94b6)
Press it again will make sort to be ascending.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/a6ce280b-a968-44d8-970e-c2ba975efc32)
