### PR TITLE
feat: use Filter with aggregation

### DIFF
--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -64,9 +64,11 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
 
     const { t } = useTranslation('translation', { keyPrefix: 'filters' });
 
+    const fieldName = field.enableAgg ? `${field.aggName}(${field.name})` : field.name;
+
     return (
         <Pill className="text-gray-900" ref={refMapper(provided.innerRef)} {...provided.draggableProps} {...provided.dragHandleProps}>
-            <header className="bg-indigo-50">{field.name}</header>
+            <header className="bg-indigo-50">{fieldName}</header>
             <div
                 className="bg-white dark:bg-zinc-900  text-gray-500 hover:bg-gray-100 flex flex-row output"
                 onClick={() => vizStore.setFilterEditing(fIndex)}

--- a/packages/graphic-walker/src/hooks/index.ts
+++ b/packages/graphic-walker/src/hooks/index.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState, useEffect, useRef } from 'react';
 
 export function useDebounceValue<T>(value: T, timeout = 200): T {
@@ -22,4 +23,28 @@ export function useDebounceValueBind<T>(value: T, setter: (v: T) => void, timeou
         }
     }, [valueToSet]);
     return [innerValue, setInnerValue];
+}
+/**
+ * hook of state that change of value will change innerValue inplace, make reduced re-render.
+ * @param value the Value to control
+ */
+export function useRefControledState<T>(value: T) {
+    const [innerValue, setInnerValue] = React.useState<T>(value);
+    const innerValueRef = React.useRef(innerValue);
+    innerValueRef.current = innerValue;
+    const valueRef = React.useRef(value);
+    const useInner = React.useRef(false);
+    if (valueRef.current !== value) {
+        valueRef.current = value;
+        useInner.current = false;
+    }
+    const setValue = React.useCallback((value: React.SetStateAction<T>) => {
+        if (useInner.current) {
+            setInnerValue(value);
+        } else {
+            useInner.current = true;
+            setInnerValue(typeof value === 'function' ? (value as (item: T) => T)(valueRef.current) : value);
+        }
+    }, []);
+    return [useInner.current ? innerValue : value, setValue] as const;
 }

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -192,6 +192,7 @@ export interface IDataSource {
 
 export interface IFilterField extends IViewField {
     rule: IFilterRule | null;
+    enableAgg?: boolean;
 }
 
 export interface IFilterFiledSimple {

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -227,6 +227,7 @@
         "editing": "Filter Rule Settings",
         "form": {
             "name": "Field",
+            "aggregation": "Aggregation",
             "rule": "Rule"
         },
         "header": {

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -221,6 +221,7 @@
         "editing": "フィルターの設定",
         "form": {
             "name": "フィールド",
+            "aggregation": "集計",
             "rule": "ルール"
         },
         "header": {

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -227,6 +227,7 @@
         "editing": "筛选器规则设定",
         "form": {
             "name": "字段",
+            "aggregation": "聚合",
             "rule": "规则"
         },
         "header": {

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -418,6 +418,10 @@ export class VizSpecStore {
         this.visList[this.visIndex] = performers.setFieldAggregator(this.visList[this.visIndex], stateKey, index, aggName);
     }
 
+    setFilterAggregator(index: number, aggName: IAggregator | '') {
+        this.visList[this.visIndex] = performers.setFilterAggregator(this.visList[this.visIndex], index, aggName);
+    }
+
     applyDefaultSort(sortType: ISortMode = 'ascending') {
         this.visList[this.visIndex] = performers.applySort(this.visList[this.visIndex], sortType);
     }

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../constants';
-import { IRow, Filters, IViewField } from '../interfaces';
+import { IRow, Filters, IViewField, IFilterField } from '../interfaces';
 interface NRReturns {
     normalizedData: IRow[];
     maxMeasures: IRow;
@@ -293,6 +293,9 @@ export function getMeaAggKey(meaKey: string, agg?: string | undefined) {
         return meaKey;
     }
     return `${meaKey}_${agg}`;
+}
+export function getFilterMeaAggKey(field: IFilterField) {
+    return field.enableAgg && field.aggName ? getMeaAggKey(field.fid, field.aggName) : field.fid;
 }
 export function getSort({ rows, columns }: { rows: readonly IViewField[]; columns: readonly IViewField[] }) {
     if (rows.length && !rows.find((x) => x.analyticType === 'measure')) {

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -11,7 +11,7 @@ import type {
     IFilterField,
 } from '../interfaces';
 import type { VizSpecStore } from '../store/visualSpecStore';
-import { getMeaAggKey } from '.';
+import { getFilterMeaAggKey, getMeaAggKey } from '.';
 import { MEA_KEY_ID, MEA_VAL_ID } from '../constants';
 
 const walkExpression = (expression: IExpression, each: (field: string) => void): void => {
@@ -73,15 +73,17 @@ export const toWorkflow = (
     let computedWorkflow: IFilterWorkflowStep | null = null;
     let viewQueryWorkflow: IViewWorkflowStep | null = null;
     let sortWorkflow: ISortWorkflowStep | null = null;
+    let aggFilterWorkflow: IFilterWorkflowStep | null = null;
 
     // TODO: apply **fold** before filter
 
     const createFilter = (f: IFilterField): IVisFilter => {
-        viewKeys.add(f.fid);
+        const fid = getFilterMeaAggKey(f);
+        viewKeys.add(fid);
         const rule = f.rule!;
         if (rule.type === 'one of') {
             return {
-                fid: f.fid,
+                fid,
                 rule: {
                     type: 'one of',
                     value: [...rule.value],
@@ -90,7 +92,7 @@ export const toWorkflow = (
         } else if (rule.type === 'temporal range') {
             const range = [new Date(rule.value[0]).getTime(), new Date(rule.value[1]).getTime()] as const;
             return {
-                fid: f.fid,
+                fid,
                 rule: {
                     type: 'temporal range',
                     value: range,
@@ -107,7 +109,7 @@ export const toWorkflow = (
         } else if (rule.type === 'range') {
             const range = [Number(rule.value[0]), Number(rule.value[1])] as const;
             return {
-                fid: f.fid,
+                fid,
                 rule: {
                     type: 'range',
                     value: range,
@@ -124,7 +126,7 @@ export const toWorkflow = (
     };
 
     // First, to apply filters on the detailed data
-    const filters = viewFilters.filter((f) => !f.computed && f.rule).map<IVisFilter>(createFilter);
+    const filters = viewFilters.filter((f) => !f.computed && f.rule && !f.enableAgg).map<IVisFilter>(createFilter);
     if (filters.length) {
         filterWorkflow = {
             type: 'filter',
@@ -150,7 +152,7 @@ export const toWorkflow = (
     }
 
     // Third, apply filter on the transformed data
-    const computedFilters = viewFilters.filter((f) => f.computed && f.rule).map<IVisFilter>(createFilter);
+    const computedFilters = viewFilters.filter((f) => f.computed && f.rule && !f.enableAgg).map<IVisFilter>(createFilter);
     if (computedFilters.length) {
         computedWorkflow = {
             type: 'filter',
@@ -162,7 +164,8 @@ export const toWorkflow = (
     // When aggregation is enabled, there're 2 cases:
     // 1. If any of the measures is aggregated, then we apply the aggregation
     // 2. If there's no measure in the view, then we apply the aggregation
-    const aggregateOn = viewMeasures.filter((f) => f.aggName).map((f) => [f.fid, f.aggName as string]);
+    const aggergatedFilter = viewFilters.filter((f) => f.enableAgg && f.aggName && f.rule);
+    const aggregateOn = viewMeasures.filter((f) => f.aggName).map((f) => [f.fid, f.aggName as string]).concat(aggergatedFilter.map(f => [f.fid, f.aggName as string]));
     const aggergated = defaultAggregated && (aggregateOn.length || (viewMeasures.length === 0 && viewDimensions.length > 0));
 
     if (aggergated) {
@@ -172,7 +175,7 @@ export const toWorkflow = (
                 {
                     op: 'aggregate',
                     groupBy: viewDimensions.map((f) => f.fid),
-                    measures: viewMeasures.map((f) => ({
+                    measures: viewMeasures.concat(aggergatedFilter).map((f) => ({
                         field: f.fid,
                         agg: f.aggName as any,
                         asFieldKey: getMeaAggKey(f.fid, f.aggName!),
@@ -192,6 +195,14 @@ export const toWorkflow = (
         };
     }
 
+    // Apply aggregation Filter after aggregation.
+    if (aggergated && viewDimensions.length > 0 && aggergatedFilter.length > 0) {
+        aggFilterWorkflow = {
+            type: 'filter',
+            filters: aggergatedFilter.map(createFilter),
+        };
+    }
+
     if (sort !== 'none' && limit) {
         sortWorkflow = {
             type: 'sort',
@@ -200,7 +211,7 @@ export const toWorkflow = (
         };
     }
 
-    const steps: IDataQueryWorkflowStep[] = [filterWorkflow!, transformWorkflow!, computedWorkflow!, viewQueryWorkflow!, sortWorkflow!].filter(Boolean);
+    const steps: IDataQueryWorkflowStep[] = [filterWorkflow!, transformWorkflow!, computedWorkflow!, viewQueryWorkflow!, aggFilterWorkflow!, sortWorkflow!].filter(Boolean);
     return steps;
 };
 


### PR DESCRIPTION
### **Warning: This feature requires Computation support multi view.** 

This PR relies on DSL parser to support get info of a aggregated view.

Add a aggregation dropdown in FilterDialog when the field is measure.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/5f23cf79-91b2-47b4-be25-0c17a518d65d)

the range that can be set will relies on the Group in current Vis.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/3ee3fc38-5597-43c6-ae4f-846b97dae4ee)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/8f276939-3620-4372-8f64-5cf707904f06)

When there is no group set, the range in dialog will be stat of the original field even the aggregation is 'count'.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/34e1f466-338d-4829-a654-077226a484c0)

and the aggregation filter will be ignored when there is no group set, or it's not aggregated chart.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/8175de5f-4144-4fa5-9827-ad9ff799fac7)
