### PR TITLE
fix: fix date picker with timezone

### DIFF
--- a/packages/graphic-walker/src/fields/filterField/tabs.tsx
+++ b/packages/graphic-walker/src/fields/filterField/tabs.tsx
@@ -2,17 +2,14 @@ import { observer } from 'mobx-react-lite';
 import React, { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import {
-    ChevronDownIcon,
-    ChevronUpIcon,
-} from '@heroicons/react/24/outline';
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 
 import type { IFilterField, IFilterRule, IFieldStats, IField, IViewField, IMutField, IComputationFunction } from '../../interfaces';
 import { useCompututaion, useVizStore } from '../../store';
 import LoadingLayer from '../../components/loadingLayer';
 import { fieldStat, getTemporalRange } from '../../computation';
 import Slider from './slider';
-import { parseCmpFunction } from '../../utils';
+import { formatDate, parseCmpFunction } from '../../utils';
 
 export type RuleFormProps = {
     rawFields: IMutField[];
@@ -351,8 +348,8 @@ export const CalendarInput: React.FC<CalendarInputProps> = (props) => {
     const dateStringFormatter = (timestamp: number) => {
         const date = new Date(timestamp);
         if (Number.isNaN(date.getTime())) return '';
-        return date.toISOString().slice(0, 19);
-    };
+        return formatDate(date);
+    };  
     const handleSubmitDate = (value: string) => {
         if (new Date(value).getTime() <= max && new Date(value).getTime() >= min) {
             onChange(new Date(value).getTime());
@@ -371,7 +368,6 @@ export const CalendarInput: React.FC<CalendarInputProps> = (props) => {
 };
 
 export const FilterTemporalRangeRule: React.FC<RuleFormProps & { active: boolean }> = observer(({ active, field, onChange }) => {
-
     const { t } = useTranslation('translation');
 
     const computationFunction = useCompututaion();
@@ -435,8 +431,6 @@ export const FilterTemporalRangeRule: React.FC<RuleFormProps & { active: boolean
         </Container>
     ) : null;
 });
-
-
 
 export const FilterRangeRule: React.FC<RuleFormProps & { active: boolean }> = observer(({ active, field, onChange }) => {
     const { t } = useTranslation('translation', { keyPrefix: 'constant.filter_type' });

--- a/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
+++ b/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
@@ -1,17 +1,7 @@
 import { DATE_TIME_DRILL_LEVELS } from '../../constants';
 import type { IExpParameter } from '../../interfaces';
+import { formatDate } from '../../utils';
 import type { IDataFrame } from '../execExp';
-
-const formatDate = (date: Date) => {
-    const Y = date.getFullYear();
-    const M = date.getMonth() + 1;
-    const D = date.getDate();
-    const H = date.getHours();
-    const m = date.getMinutes();
-    const s = date.getSeconds();
-    const pad = (x: number) => `${x}`.padStart(2, '0');
-    return `${Y}-${pad(M)}-${D} ${pad(H)}:${pad(m)}:${pad(s)}`;
-};
 
 function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame): IDataFrame {
     const fieldKey = params.find((p) => p.type === 'field')?.value;

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -335,3 +335,14 @@ export function parseErrorMessage(errorLike: any): string {
     }
     return String(errorLike);
 }
+
+export const formatDate = (date: Date) => {
+    const Y = date.getFullYear();
+    const M = date.getMonth() + 1;
+    const D = date.getDate();
+    const H = date.getHours();
+    const m = date.getMinutes();
+    const s = date.getSeconds();
+    const pad = (x: number) => `${x}`.padStart(2, '0');
+    return `${Y}-${pad(M)}-${pad(D)} ${pad(H)}:${pad(m)}:${pad(s)}`;
+};


### PR DESCRIPTION
Fixed issue when saved a Temporal Filter, and open it again, the value will shift some hours that effected by locale timezone.
error screenshot:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/fc2485f6-da71-493e-a8ca-07baf462f335)
except behaivor:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/720fbc7b-3c32-4d22-a588-41ae607d4eb8)
