### PR TITLE
fix: pure-renderer size

### DIFF
--- a/packages/graphic-walker/src/renderer/pureRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/pureRenderer.tsx
@@ -14,6 +14,7 @@ import { GWGlobalConfig } from '../vis/theme';
 
 type IPureRendererProps =
     | {
+          className?: string;
           name?: string;
           themeKey?: IThemeKey;
           themeConfig?: GWGlobalConfig;
@@ -39,7 +40,7 @@ type IPureRendererProps =
  * This is a pure component, which means it will not depend on any global state.
  */
 const PureRenderer = forwardRef<IReactVegaHandler, IPureRendererProps>(function PureRenderer(props, ref) {
-    const { name, themeKey, dark, visualState, visualConfig, visualLayout: layout, locale, type, themeConfig, channelScales } = props;
+    const { name, className, themeKey, dark, visualState, visualConfig, visualLayout: layout, locale, type, themeConfig, channelScales } = props;
     const computation = useMemo(() => {
         if (props.type === 'remote') {
             return props.computation;
@@ -102,8 +103,8 @@ const PureRenderer = forwardRef<IReactVegaHandler, IPureRendererProps>(function 
     const isSpatial = coordSystem === 'geographic';
 
     return (
-        <ShadowDom className="flex w-full" style={{ height: '100%' }}>
-            <div className="relative flex flex-col w-full flex-1">
+        <ShadowDom className={className}>
+            <div className="relative">
                 {isSpatial && (
                     <div className="max-w-full" style={{ height: LEAFLET_DEFAULT_HEIGHT, flexGrow: 1 }}>
                         <LeafletRenderer data={data} draggableFieldState={visualState} visualConfig={visualConfig} visualLayout={visualLayout} />

--- a/packages/graphic-walker/src/renderer/specRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/specRenderer.tsx
@@ -3,19 +3,9 @@ import { Resizable } from 're-resizable';
 import React, { forwardRef, useMemo } from 'react';
 
 import PivotTable from '../components/pivotTable';
-import LeafletRenderer from '../components/leafletRenderer';
+import LeafletRenderer, { LEAFLET_DEFAULT_HEIGHT, LEAFLET_DEFAULT_WIDTH } from '../components/leafletRenderer';
 import ReactVega, { IReactVegaHandler } from '../vis/react-vega';
-import {
-   
-    DraggableFieldState,
-    IDarkMode,
-    IRow,
-    IThemeKey,
-    IVisualConfigNew, IVisualLayout,
-    VegaGlobalConfig,
-   
-    IChannelScales,
-} from '../interfaces';
+import { DraggableFieldState, IDarkMode, IRow, IThemeKey, IVisualConfigNew, IVisualLayout, VegaGlobalConfig, IChannelScales } from '../interfaces';
 import LoadingLayer from '../components/loadingLayer';
 import { useCurrentMediaTheme } from '../utils/media';
 import { getTheme } from '../utils/useTheme';
@@ -42,7 +32,8 @@ interface SpecRendererProps {
  */
 const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
     {
-        name,layout,
+        name,
+        layout,
         themeKey,
         dark,
         data,
@@ -52,19 +43,17 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
         onGeomClick,
         onChartResize,
         locale,
-       
+
         themeConfig: customizedThemeConfig,
         channelScales,
-     },
+    },
     ref
 ) {
     // const { draggableFieldState, visualConfig } = vizStore;
-    const {
-        geoms, defaultAggregated,
-        coordSystem } = visualConfig;
+    const { geoms, defaultAggregated, coordSystem } = visualConfig;
     const {
         interactiveScale,
-       
+
         stack,
         showActions,
         size,
@@ -75,7 +64,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
         useSvg,
         primaryColor,
         colorPalette,
-        scale  
+        scale,
     } = layout;
 
     const rows = draggableFieldState.rows;
@@ -158,7 +147,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
 
     return (
         <Resizable
-            className={enableResize ? 'border-blue-400 border-2 overflow-hidden' : ''}
+            className={enableResize ? 'border-blue-400 border-2 overflow-hidden inline-block' : 'inline-block'}
             style={{ padding: '12px' }}
             onResizeStop={(e, direction, ref, d) => {
                 onChartResize?.(size.width + d.width, size.height + d.height);
@@ -177,10 +166,20 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                           topLeft: false,
                       }
             }
-            size={{
+            size={
+                // ensure PureRenderer with Auto size is correct
+                size.mode === 'fixed'
+                    ? {
                           width: size.width + 'px',
                           height: size.height + 'px',
-            }}
+                      }
+                    : isSpatial
+                    ? {
+                          width: LEAFLET_DEFAULT_WIDTH + 'px',
+                          height: LEAFLET_DEFAULT_HEIGHT + 'px',
+                      }
+                    : undefined
+            }
         >
             {loading && <LoadingLayer />}
             {isSpatial && (


### PR DESCRIPTION
fix an issue when rendering Chart with size=auto in Purerenderer, the actual element size will equal the hidden property "width" and "height" and the chart's can overflow the container element.