### PR TITLE
feat: filter Edit dialog optimize

### DIFF
--- a/computation.md
+++ b/computation.md
@@ -24,6 +24,10 @@ type IFilterRule = (
         type: 'one of';
         value: Array<string | number>;
     }
+    | {
+        type: 'not in';
+        value: Array<string | number>;
+    }
 );
 
 interface IFilterField {
@@ -89,7 +93,8 @@ The schema of the filter query is
                                     "type": {
                                         "type": "string",
                                         "enum": [
-                                            "one of"
+                                            "one of",
+                                            "not in"
                                         ]
                                     },
                                     "value": {

--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -41,6 +41,7 @@
     "@kanaries/react-beautiful-dnd": "^0.0.3",
     "@kanaries/web-data-loader": "^0.1.7",
     "@tailwindcss/forms": "^0.5.4",
+    "@tanstack/react-virtual": "^3.0.0-beta.68",
     "@types/jest": "^29.5.3",
     "autoprefixer": "^10.3.5",
     "canvas-size": "^1.2.6",

--- a/packages/graphic-walker/src/computation/clientComputation.ts
+++ b/packages/graphic-walker/src/computation/clientComputation.ts
@@ -19,9 +19,9 @@ export const dataQueryClient = async (
                         fid: filter.fid,
                         rule: null,
                     };
-                    if (filter.rule.type === 'one of') {
+                    if (filter.rule.type === 'one of' || filter.rule.type === 'not in') {
                         res.rule = {
-                            type: 'one of',
+                            type: filter.rule.type,
                             value: new Set(filter.rule.value),
                         };
                     } else {

--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -100,9 +100,22 @@ export const dataQuery = async (service: IComputationFunction, workflow: IDataQu
     return res;
 };
 
-export const fieldStat = async (service: IComputationFunction, field: IField, options: { values?: boolean; range?: boolean }): Promise<IFieldStats> => {
-    const { values = true, range = true } = options;
+export const fieldStat = async (
+    service: IComputationFunction,
+    field: IField,
+    options: {
+        values?: boolean;
+        range?: boolean;
+        valuesMeta?: boolean;
+        selectedCount?: Set<string | number>;
+        valuesLimit?: number;
+        valuesOffset?: number;
+        sortBy?: 'value' | 'value_dsc' | 'count' | 'count_dsc' | 'none';
+    }
+): Promise<IFieldStats> => {
+    const { values = true, range = true, valuesMeta = true, sortBy = 'none' } = options;
     const COUNT_ID = `count_${field.fid}`;
+    const TOTAL_DISTINCT_ID = `total_distinct_${field.fid}`;
     const MIN_ID = `min_${field.fid}`;
     const MAX_ID = `max_${field.fid}`;
     const transformWork: ITransformWorkflowStep[] = field.computed
@@ -118,6 +131,32 @@ export const fieldStat = async (service: IComputationFunction, field: IField, op
               },
           ]
         : [];
+    const valuesMetaQueryPayload: IDataQueryPayload = {
+        workflow: [
+            ...transformWork,
+            {
+                type: 'view',
+                query: [
+                    {
+                        op: 'aggregate',
+                        groupBy: [],
+                        measures: [
+                            {
+                                field: field.fid,
+                                agg: 'distinctCount',
+                                asFieldKey: TOTAL_DISTINCT_ID,
+                            },
+                            {
+                                field: '*',
+                                agg: 'count',
+                                asFieldKey: 'count',
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
     const valuesQueryPayload: IDataQueryPayload = {
         workflow: [
             ...transformWork,
@@ -137,8 +176,20 @@ export const fieldStat = async (service: IComputationFunction, field: IField, op
                     },
                 ],
             },
+            ...(sortBy === 'none'
+                ? []
+                : ([
+                      {
+                          type: 'sort',
+                          by: [sortBy.startsWith('value') ? field.fid : COUNT_ID],
+                          sort: sortBy.endsWith('dsc') ? 'descending' : 'ascending',
+                      },
+                  ] as ISortWorkflowStep[])),
         ],
+        limit: options.valuesLimit,
+        offset: options.valuesOffset,
     };
+    const [valuesMetaRes = { [TOTAL_DISTINCT_ID]: 0, count: 0 }] = valuesMeta ? await service(valuesMetaQueryPayload) : [{ [TOTAL_DISTINCT_ID]: 0, count: 0 }];
     const valuesRes = values ? await service(valuesQueryPayload) : [];
     const rangeQueryPayload: IDataQueryPayload = {
         workflow: [
@@ -180,14 +231,54 @@ export const fieldStat = async (service: IComputationFunction, field: IField, op
               },
           ];
 
+    const selectedCountWork: IDataQueryPayload | null = options.selectedCount?.size
+        ? {
+              workflow: [
+                  ...transformWork,
+                  {
+                      type: 'filter',
+                      filters: [
+                          {
+                              fid: field.fid,
+                              rule: {
+                                  type: 'one of',
+                                  value: [...options.selectedCount],
+                              },
+                          },
+                      ],
+                  },
+                  {
+                      type: 'view',
+                      query: [
+                          {
+                              op: 'aggregate',
+                              groupBy: [],
+                              measures: [
+                                  {
+                                      field: '*',
+                                      agg: 'count',
+                                      asFieldKey: 'count',
+                                  },
+                              ],
+                          },
+                      ],
+                  },
+              ],
+          }
+        : null;
+    const [selectedCountRes = { count: 0 }] = selectedCountWork ? await service(selectedCountWork) : [];
+
     return {
-        values: valuesRes
-            .sort((a, b) => b[COUNT_ID] - a[COUNT_ID])
-            .map((row) => ({
-                value: row[field.fid],
-                count: row[COUNT_ID],
-            })),
+        values: valuesRes.map((row) => ({
+            value: row[field.fid],
+            count: row[COUNT_ID],
+        })),
+        valuesMeta: {
+            total: valuesMetaRes.count,
+            distinctTotal: valuesMetaRes[TOTAL_DISTINCT_ID],
+        },
         range: [rangeRes[MIN_ID], rangeRes[MAX_ID]],
+        selectedCount: selectedCountRes.count,
     };
 };
 

--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -12,46 +12,46 @@ interface FilterPillProps {
 }
 
 const Pill = styled.div`
-  user-select: none;
-  align-items: stretch;
-  border-style: solid;
-  border-width: 1px;
-  box-sizing: border-box;
-  cursor: default;
-  display: flex;
-  flex-direction: column;
-  font-size: 12px;
-  min-width: 150px;
-  overflow-y: hidden;
-  padding: 0;
+    user-select: none;
+    align-items: stretch;
+    border-style: solid;
+    border-width: 1px;
+    box-sizing: border-box;
+    cursor: default;
+    display: flex;
+    flex-direction: column;
+    font-size: 12px;
+    min-width: 150px;
+    overflow-y: hidden;
+    padding: 0;
 
-  > * {
-    flex-grow: 1;
-    padding-block: 0.2em;
-    padding-inline: 0.5em;
-  }
-
-  > header {
-    height: 20px;
-    border-bottom-width: 1px;
-  }
-
-  > div.output {
-    min-height: 20px;
-
-    > span {
-      overflow-y: hidden;
-      max-height: 4em;
+    > * {
+        flex-grow: 1;
+        padding-block: 0.2em;
+        padding-inline: 0.5em;
     }
 
-    .icon {
-      display: none;
-
-      &:hover {
-        display: unset;
-      }
+    > header {
+        height: 20px;
+        border-bottom-width: 1px;
     }
-  }
+
+    > div.output {
+        min-height: 20px;
+
+        > span {
+            overflow-y: hidden;
+            max-height: 4em;
+        }
+
+        .icon {
+            display: none;
+
+            &:hover {
+                display: unset;
+            }
+        }
+    }
 `;
 
 const FilterPill: React.FC<FilterPillProps> = observer((props) => {
@@ -80,6 +80,8 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
                             ? `range: [${field.rule.value[0]}, ${field.rule.value[1]}]`
                             : field.rule.type === 'temporal range'
                             ? `range: [${new Date(field.rule.value[0])}, ${new Date(field.rule.value[1])}]`
+                            : field.rule.type === 'not in'
+                            ? `notIn: [${[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]`
                             : null}
                     </span>
                 ) : (

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -19,7 +19,7 @@ export interface IRow {
     [key: string]: any;
 }
 
-export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev';
+export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev' | 'distinctCount';
 
 export type IEmbedMenuItem = 'data_interpretation' | 'data_view';
 export interface Specification {
@@ -72,6 +72,8 @@ export interface IDatasetStats {
 
 export interface IFieldStats {
     values: { value: number | string; count: number }[];
+    valuesMeta: { total: number; distinctTotal: number };
+    selectedCount: number;
     range: [number, number];
 }
 
@@ -237,6 +239,10 @@ export type IFilterRule =
       }
     | {
           type: 'one of';
+          value: Set<string | number>;
+      }
+    | {
+          type: 'not in';
           value: Set<string | number>;
       };
 

--- a/packages/graphic-walker/src/lib/filter.ts
+++ b/packages/graphic-walker/src/lib/filter.ts
@@ -14,6 +14,12 @@ export const filter = (dataSource: IRow[], filters: IFilterFiledSimple[]) => {
                         return false;
                     }
                 }
+                case 'not in': {
+                    if (rule.value.has(which[fid])) {
+                    } else {
+                        break;
+                    }
+                }
                 case 'range': {
                     if (rule.value[0] <= which[fid] && which[fid] <= rule.value[1]) {
                         break;

--- a/packages/graphic-walker/src/lib/op/aggregate.ts
+++ b/packages/graphic-walker/src/lib/op/aggregate.ts
@@ -1,7 +1,7 @@
 import { IRow } from "../../interfaces";
 import { getMeaAggKey } from "../../utils";
 import { IAggQuery } from "../../interfaces";
-import { sum, mean, median, stdev, variance, max, min, count } from "./stat";
+import { sum, mean, median, stdev, variance, max, min, count, distinctCount } from "./stat";
 
 const aggregatorMap = {
     sum,
@@ -12,6 +12,7 @@ const aggregatorMap = {
     max,
     min,
     count,
+    distinctCount,
 };
 
 const KEY_JOINER = '___';

--- a/packages/graphic-walker/src/lib/op/stat.ts
+++ b/packages/graphic-walker/src/lib/op/stat.ts
@@ -41,6 +41,10 @@ export function min(nums: number[]): number {
     return ans;
 }
 
-export function count(nums: number[]): number {
+export function count(nums: any[]): number {
     return nums.length;
+}
+
+export function distinctCount(datas: any[]) {
+    return new Set(datas).size;
 }

--- a/packages/graphic-walker/src/utils/filter.ts
+++ b/packages/graphic-walker/src/utils/filter.ts
@@ -2,7 +2,7 @@ import { IFilterRule, SetToArray } from '../interfaces';
 
 export function encodeFilterRule(rule: IFilterRule | null): SetToArray<IFilterRule> | null {
     if (!rule) return null;
-    if (rule.type === 'one of') {
+    if (rule.type === 'one of' || rule.type === 'not in') {
         return {
             ...rule,
             value: [...rule.value],
@@ -12,7 +12,7 @@ export function encodeFilterRule(rule: IFilterRule | null): SetToArray<IFilterRu
 }
 export function decodeFilterRule(rule: SetToArray<IFilterRule> | null): IFilterRule | null {
     if (!rule) return null;
-    if (rule.type === 'one of') {
+    if (rule.type === 'one of' || rule.type === 'not in') {
         return {
             ...rule,
             value: new Set(rule.value),

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -96,7 +96,15 @@ export const toWorkflow = (
                     value: range,
                 },
             };
-        } else {
+        } else if (rule.type === 'not in') {
+            return {
+                fid: f.fid,
+                rule: {
+                    type: 'not in',
+                    value: [...rule.value],
+                },
+            };
+        } else if (rule.type === 'range') {
             const range = [Number(rule.value[0]), Number(rule.value[1])] as const;
             return {
                 fid: f.fid,
@@ -104,6 +112,13 @@ export const toWorkflow = (
                     type: 'range',
                     value: range,
                 },
+            };
+        } else {
+            const neverRule: never = rule;
+            console.error('unknown rule', neverRule);
+            return {
+                fid: f.fid,
+                rule,
             };
         }
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,6 +1252,18 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tanstack/react-virtual@^3.0.0-beta.68":
+  version "3.0.0-beta.68"
+  resolved "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.68.tgz#225532329d74d7c0f82564d36ad8bf461e320ab5"
+  integrity sha512-YEFNCf+N3ZlNou2r4qnh+GscMe24foYEjTL05RS0ZHvah2RoUDPGuhnuedTv0z66dO2vIq6+Bl4TXatht5T7GQ==
+  dependencies:
+    "@tanstack/virtual-core" "3.0.0-beta.68"
+
+"@tanstack/virtual-core@3.0.0-beta.68":
+  version "3.0.0-beta.68"
+  resolved "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.68.tgz#e6c478b393df57861e0a98fd0fea9982b79b6e7d"
+  integrity sha512-CnvsEJWK7cugigckt13AeY80FMzH+OMdEP0j0bS3/zjs44NiRe49x8FZC6R9suRXGMVMXtUHet0zbTp/Ec9Wfg==
+
 "@tauri-apps/api@^1.1.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@tauri-apps/api/-/api-1.2.0.tgz#1f196b3e012971227f41b98214c846430a4eb477"


### PR DESCRIPTION
make the list in FilterEditDialog become a VirtualList
and it will fetch only data in view, reduce the cost of running on large dataset.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/4964cce2-6edc-4948-8931-f1542a70a648)

also introduced a new type of filter, 'not in', to make it possible save a filter without fetching all data.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/30e67f72-5594-4674-8486-e35ffbcfa2c4)
