### PR TITLE
fix: dnd issue in containing block

### DIFF
--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -38,7 +38,7 @@
     "@headlessui-float/react": "^0.11.4",
     "@headlessui/react": "^1.7.12",
     "@heroicons/react": "^2.0.8",
-    "@kanaries/react-beautiful-dnd": "^0.0.3",
+    "@kanaries/react-beautiful-dnd": "^0.1.0",
     "@kanaries/web-data-loader": "^0.1.7",
     "@tailwindcss/forms": "^0.5.4",
     "@types/jest": "^29.5.3",

--- a/packages/graphic-walker/src/components/modal.tsx
+++ b/packages/graphic-walker/src/components/modal.tsx
@@ -1,9 +1,6 @@
 import React, { useRef } from "react";
 import styled from "styled-components";
-import { XCircleIcon } from "@heroicons/react/24/outline";
-import { Fragment, useState } from "react";
-import { Dialog, Transition } from "@headlessui/react";
-import { ExclamationTriangleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const Background = styled.div`
     position: fixed;

--- a/packages/graphic-walker/src/components/smallModal.tsx
+++ b/packages/graphic-walker/src/components/smallModal.tsx
@@ -1,9 +1,6 @@
 import React, { useRef } from "react";
 import styled from "styled-components";
-import { XCircleIcon } from "@heroicons/react/24/outline";
-import { Fragment, useState } from "react";
-import { Dialog, Transition } from "@headlessui/react";
-import { ExclamationTriangleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const Background = styled.div`
     position: fixed;

--- a/packages/graphic-walker/src/fields/datasetFields/dimFields.tsx
+++ b/packages/graphic-walker/src/fields/datasetFields/dimFields.tsx
@@ -7,6 +7,7 @@ import DataTypeIcon from '../../components/dataTypeIcon';
 import ActionMenu from "../../components/actionMenu";
 import { FieldPill } from './fieldPill';
 import { useMenuActions } from "./utils";
+import { refMapper } from '../fieldsContext';
 
 interface Props {
     provided: DroppableProvided;
@@ -17,7 +18,7 @@ const DimFields: React.FC<Props> = (props) => {
     const { dimensions } = vizStore;
     const menuActions = useMenuActions('dimensions');
     return (
-        <div {...provided.droppableProps} ref={provided.innerRef}>
+        <div {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {dimensions.map((f, index) => (
                 <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
                     {(provided, snapshot) => {
@@ -32,7 +33,7 @@ const DimFields: React.FC<Props> = (props) => {
                                     className={`flex dark:text-white pt-0.5 pb-0.5 pl-2 pr-2 mx-0 m-1 text-xs hover:bg-blue-100 dark:hover:bg-blue-800 rounded-full truncate border border-transparent ${
                                         snapshot.isDragging ? 'bg-blue-100 dark:bg-blue-800' : ''
                                     }`}
-                                    ref={provided.innerRef}
+                                    ref={refMapper(provided.innerRef)}
                                     isDragging={snapshot.isDragging}
                                     {...provided.draggableProps}
                                     {...provided.dragHandleProps}

--- a/packages/graphic-walker/src/fields/datasetFields/meaFields.tsx
+++ b/packages/graphic-walker/src/fields/datasetFields/meaFields.tsx
@@ -8,6 +8,7 @@ import ActionMenu from '../../components/actionMenu';
 import { useMenuActions } from './utils';
 import { FieldPill } from './fieldPill';
 import { MEA_KEY_ID } from '../../constants';
+import { refMapper } from '../fieldsContext';
 
 interface Props {
     provided: DroppableProvided;
@@ -20,7 +21,7 @@ const MeaFields: React.FC<Props> = (props) => {
     const menuActions = useMenuActions('measures');
 
     return (
-        <div {...provided.droppableProps} ref={provided.innerRef}>
+        <div {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {measures.map((f, index) => (
                 <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
                     {(provided, snapshot) => {
@@ -32,7 +33,7 @@ const MeaFields: React.FC<Props> = (props) => {
                                             snapshot.isDragging ? 'bg-purple-100 dark:bg-purple-800' : ''
                                         }`}
                                         isDragging={snapshot.isDragging}
-                                        ref={provided.innerRef}
+                                        ref={refMapper(provided.innerRef)}
                                         {...provided.draggableProps}
                                         {...provided.dragHandleProps}
                                     >

--- a/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
@@ -11,6 +11,7 @@ import { GLOBAL_CONFIG } from '../../config';
 import { Draggable, DroppableStateSnapshot } from '@kanaries/react-beautiful-dnd';
 import styled from 'styled-components';
 import SelectContext, { type ISelectContextOption } from '../../components/selectContext';
+import { refMapper } from '../fieldsContext';
 
 const PillActions = styled.div`
     overflow: visible !important;
@@ -48,7 +49,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
     }, [allFields]);
 
     return (
-        <div className="p-1 select-none relative" {...provided.droppableProps} ref={provided.innerRef}>
+        <div className="p-1 select-none relative" {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             <div
                 className={`p-1.5 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 flex item-center justify-center grow text-gray-500 dark:text-gray-400 ${
                     snapshot.draggingFromThisWith || snapshot.isDraggingOver || !channelItem ? 'opacity-100' : 'opacity-0'
@@ -61,7 +62,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
                     {(provided, snapshot) => {
                         return (
                             <div
-                                ref={provided.innerRef}
+                                ref={refMapper(provided.innerRef)}
                                 {...provided.draggableProps}
                                 {...provided.dragHandleProps}
                                 className={"flex items-stretch absolute top-0 left-0 right-0 bottom-0 m-1" + (provided.draggableProps.style?.transform ? ' z-10' : '')}

--- a/packages/graphic-walker/src/fields/fieldsContext.tsx
+++ b/packages/graphic-walker/src/fields/fieldsContext.tsx
@@ -1,41 +1,114 @@
-import React, { useCallback } from 'react';
+import React, { createContext, useCallback, useContext, useRef } from 'react';
 import { DraggableFieldState, IDraggableStateKey } from '../interfaces';
 import {
     DragDropContext,
     DropResult,
     ResponderProvided,
     DraggableLocation,
-} from "@kanaries/react-beautiful-dnd";
+    Sensor,
+    useKeyboardSensor,
+    useMouseSensor,
+    useTouchSensor,
+} from '@kanaries/react-beautiful-dnd';
 import { useVizStore } from '../store';
+import { proxied } from '../utils/proxy';
 window['__react-beautiful-dnd-disable-dev-warnings'] = true;
+window['__react-beautiful-dnd-disable-scroll-hack'] = true;
 
+const blockContext = createContext<React.RefObject<HTMLDivElement>>({ current: null });
 
-export const FieldsContextWrapper: React.FC = props => {
-    const vizStore = useVizStore();
-    const onDragEnd = useCallback((result: DropResult, provided: ResponderProvided) => {
-        if (!result.destination) {
-            vizStore.removeField(result.source.droppableId as keyof DraggableFieldState, result.source.index)
-            return;
-        }
-        const destination = result.destination as DraggableLocation;
-        if (destination.droppableId === result.source.droppableId) {
-            if (destination.index === result.source.index) return;
-            vizStore.reorderField(destination.droppableId as keyof DraggableFieldState, result.source.index, destination.index);
-        } else {
-            let sourceKey = result.source
-                    .droppableId as keyof DraggableFieldState;
-            let targetKey = destination
-                .droppableId as keyof DraggableFieldState;
-            vizStore.moveField(sourceKey, result.source.index, targetKey, destination.index)
-        }
-    }, [vizStore])
-    return <DragDropContext onDragEnd={onDragEnd}
-        onDragStart={() => {}}
-        onDragUpdate={() => {}}
-    >
-        { props.children }
-    </DragDropContext>
+export function refMapper<T extends HTMLElement>(refCallback: (node: T | null) => void) {
+    const block = useContext(blockContext);
+    return useCallback(
+        (node: T | null) => {
+            if (node === null) return refCallback(null);
+            const n = Object.defineProperty(node, 'getBoundingClientRect', {
+                get() {
+                    return () => {
+                        const blockRect = block.current?.getBoundingClientRect();
+                        const rect = HTMLElement.prototype.getBoundingClientRect.call(node);
+                        if (!blockRect) return rect;
+                        return new DOMRect(rect.x - blockRect.x, rect.y - blockRect.y, rect.width, rect.height);
+                    };
+                },
+            });
+            refCallback(n);
+        },
+        [refCallback]
+    );
 }
+
+function sensorMapper(sensor: Sensor): Sensor {
+    return (api) => {
+        const block = useContext(blockContext);
+        const proxiedAPI = proxied(api, {
+            tryGetLock: (req, next) => {
+                const i = next(...req);
+                if (i === null) return null;
+                return proxied(i, {
+                    fluidLift: ([pos], next) => {
+                        const rect = block.current?.getBoundingClientRect();
+                        const target = rect
+                            ? next({
+                                  x: pos.x - rect.x,
+                                  y: pos.y - rect.y,
+                              })
+                            : next(pos);
+                        return proxied(target, {
+                            move: ([pos], next) => {
+                                const rect = block.current?.getBoundingClientRect();
+                                if (rect) {
+                                    next({
+                                        x: pos.x - rect.x,
+                                        y: pos.y - rect.y,
+                                    });
+                                } else {
+                                    next(pos);
+                                }
+                                return target;
+                            },
+                        });
+                    },
+                });
+            },
+        });
+        return sensor(proxiedAPI);
+    };
+}
+
+const sensors = [useMouseSensor, useTouchSensor, useKeyboardSensor].map(sensorMapper);
+
+export const FieldsContextWrapper: React.FC = (props) => {
+    const vizStore = useVizStore();
+    const blockRef = useRef<HTMLDivElement>(null);
+    const onDragEnd = useCallback(
+        (result: DropResult, provided: ResponderProvided) => {
+            if (!result.destination) {
+                vizStore.removeField(result.source.droppableId as keyof DraggableFieldState, result.source.index);
+                return;
+            }
+            const destination = result.destination as DraggableLocation;
+            if (destination.droppableId === result.source.droppableId) {
+                if (destination.index === result.source.index) return;
+                vizStore.reorderField(destination.droppableId as keyof DraggableFieldState, result.source.index, destination.index);
+            } else {
+                let sourceKey = result.source.droppableId as keyof DraggableFieldState;
+                let targetKey = destination.droppableId as keyof DraggableFieldState;
+                vizStore.moveField(sourceKey, result.source.index, targetKey, destination.index);
+            }
+        },
+        [vizStore]
+    );
+    return (
+        <blockContext.Provider value={blockRef}>
+            <div className="scale-100" ref={blockRef}>
+                <DragDropContext enableDefaultSensors={false} sensors={sensors} onDragEnd={onDragEnd} onDragStart={() => {}} onDragUpdate={() => {}}>
+                    {props.children}
+                </DragDropContext>
+            </div>
+        </blockContext.Provider>
+    );
+};
 
 export default FieldsContextWrapper;
 
@@ -45,7 +118,7 @@ export const DRAGGABLE_STATE_KEYS: Readonly<IDraggableStateKey[]> = [
     { id: 'color', mode: 1 },
     { id: 'opacity', mode: 1 },
     { id: 'size', mode: 1 },
-    { id: 'shape', mode: 1},
+    { id: 'shape', mode: 1 },
     { id: 'theta', mode: 1 },
     { id: 'radius', mode: 1 },
     { id: 'longitude', mode: 1 },

--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { PencilSquareIcon } from '@heroicons/react/24/solid';
 import { useVizStore } from '../../store';
+import { refMapper } from '../fieldsContext';
 
 interface FilterPillProps {
     provided: DraggableProvided;
@@ -64,7 +65,7 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
     const { t } = useTranslation('translation', { keyPrefix: 'filters' });
 
     return (
-        <Pill className="text-gray-900" ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+        <Pill className="text-gray-900" ref={refMapper(provided.innerRef)} {...provided.draggableProps} {...provided.dragHandleProps}>
             <header className="bg-indigo-50">{field.name}</header>
             <div
                 className="bg-white dark:bg-zinc-900  text-gray-500 hover:bg-gray-100 flex flex-row output"

--- a/packages/graphic-walker/src/fields/filterField/index.tsx
+++ b/packages/graphic-walker/src/fields/filterField/index.tsx
@@ -9,6 +9,7 @@ import { useVizStore } from '../../store';
 import { FilterFieldContainer, FilterFieldsContainer } from '../components';
 import FilterPill from './filterPill';
 import FilterEditDialog from './filterEditDialog';
+import { refMapper } from '../fieldsContext';
 
 
 interface FieldContainerProps {
@@ -22,7 +23,7 @@ const FilterItemContainer: React.FC<FieldContainerProps> = observer(({ provided 
     return (
         <FilterFieldsContainer
             {...provided.droppableProps}
-            ref={provided.innerRef}
+            ref={refMapper(provided.innerRef)}
         >
             {filters.map((f, index) => (
                 <Draggable key={f.dragId} draggableId={f.dragId} index={index}>

--- a/packages/graphic-walker/src/fields/obComponents/obFContainer.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obFContainer.tsx
@@ -5,6 +5,7 @@ import { useVizStore } from '../../store';
 import { Draggable, DroppableProvided } from '@kanaries/react-beautiful-dnd';
 import { IDraggableViewStateKey } from '../../interfaces';
 import OBPill from './obPill';
+import { refMapper } from '../fieldsContext';
 
 interface FieldContainerProps {
     provided: DroppableProvided;
@@ -18,7 +19,7 @@ const OBFieldContainer: React.FC<FieldContainerProps> = (props) => {
     const vizStore = useVizStore();
     const { allEncodings } = vizStore;
     return (
-        <FieldsContainer {...provided.droppableProps} ref={provided.innerRef}>
+        <FieldsContainer {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {/* {provided.placeholder} */}
             {allEncodings[dkey.id].map((f, index) => (
                 <Draggable key={f.dragId} draggableId={f.dragId} index={index}>

--- a/packages/graphic-walker/src/fields/obComponents/obPill.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obPill.tsx
@@ -10,6 +10,7 @@ import { Pill } from '../components';
 import { GLOBAL_CONFIG } from '../../config';
 import DropdownContext from '../../components/dropdownContext';
 import SelectContext, { type ISelectContextOption } from '../../components/selectContext';
+import { refMapper } from '../fieldsContext';
 
 interface PillProps {
     provided: DraggableProvided;
@@ -42,7 +43,7 @@ const OBPill: React.FC<PillProps> = (props) => {
 
     return (
         <Pill
-            ref={provided.innerRef}
+            ref={refMapper(provided.innerRef)}
             colType={field.analyticType === 'dimension' ? 'discrete' : 'continuous'}
             {...provided.draggableProps}
             {...provided.dragHandleProps}

--- a/packages/graphic-walker/src/utils/proxy.ts
+++ b/packages/graphic-walker/src/utils/proxy.ts
@@ -1,0 +1,17 @@
+export type ParaOrNoting<T> = T extends (...args: any) => any ? Parameters<T> : [];
+export type ReturnOrID<T> = T extends (...args: any) => any ? ReturnType<T> : T;
+
+export function proxied<T extends Object>(x: T, ex: { [k in keyof T]?: (req: ParaOrNoting<T[k]>, next: T[k]) => ReturnOrID<T[k]> }) {
+    return new Proxy(x, {
+        get(target, p) {
+            if (ex[p]) {
+                if (typeof target[p] === 'function') {
+                    return (...args) => ex[p](args, (...x) => target[p].call(target, ...x));
+                } else {
+                    return ex[p]([], target[p]);
+                }
+            }
+            return target[p];
+        },
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,6 +1175,19 @@
     redux "^4.0.4"
     use-memo-one "^1.1.1"
 
+"@kanaries/react-beautiful-dnd@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.npmmirror.com/@kanaries/react-beautiful-dnd/-/react-beautiful-dnd-0.1.0.tgz#6ee065918b9e93fa7d1dd6e5f73f51ae0c5b5ea0"
+  integrity sha512-L7O8SpztNDeD3ZL7BUjjwBBz45uhVoY9gFbp8a3UOsN1djbhnmynny/6M1LwhtNEQhaOTcIBIaLFOYKCUzgVlA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    css-box-model "^1.2.0"
+    memoize-one "^5.1.1"
+    raf-schd "^4.0.2"
+    react-redux "^7.2.0"
+    redux "^4.0.4"
+    use-memo-one "^1.1.1"
+
 "@kanaries/web-data-loader@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@kanaries/web-data-loader/-/web-data-loader-0.1.7.tgz#ce322bc4028f00a433a655fe631a148c51c875bc"


### PR DESCRIPTION
Make graphic-walker's drag'n'drop usable in some containing block context
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/fed09ffe-4f19-4479-beeb-939f4742cbd7)

Test: 
add code above to graphic-waklker container
```
<div id="root" style="
    height: 200vh;
"><div style="
    position: fixed;
    top: 80px;
    bottom: 80px;
    left: 80px;
    right: 80px;
    padding: 20px;
    border: 1px solid black;
    overflow: auto;
">
(GraphicWalker)
</div></div>
```