### PR TITLE
fix: graphic walker chart scroll

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,15 +1,7 @@
 import React, { useEffect, useMemo, useRef, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import {
-    ISegmentKey,
-    IAppI18nProps,
-    IVizProps,
-    IErrorHandlerProps,
-    IVizAppProps,
-    ISpecProps,
-    IComputationContextProps,
-} from './interfaces';
+import { ISegmentKey, IAppI18nProps, IVizProps, IErrorHandlerProps, IVizAppProps, ISpecProps, IComputationContextProps } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
 import PosFields from './fields/posFields';
@@ -176,7 +168,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                             <FilterField />
                                             <AestheticFields />
                                         </SideReisze>
-                                        <div className="flex-1">
+                                        <div className="flex-1 min-w-[0px]">
                                             <div>
                                                 <PosFields />
                                             </div>

--- a/packages/graphic-walker/src/renderer/specRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/specRenderer.tsx
@@ -178,7 +178,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                           width: LEAFLET_DEFAULT_WIDTH + 'px',
                           height: LEAFLET_DEFAULT_HEIGHT + 'px',
                       }
-                    : undefined
+                    : { width: 'auto', height: 'auto' }
             }
         >
             {loading && <LoadingLayer />}


### PR DESCRIPTION
Fixed the issue when chart size is "auto" and it exceed the graphic-walker container width, the chart will overflow the container instead of show a scrollbar.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/5b71072e-697a-4627-b7d7-9174e654aaed)
