### PR TITLE
fix: dragging count field to left side is broken

### DIFF
--- a/packages/graphic-walker/src/components/visualConfig/index.tsx
+++ b/packages/graphic-walker/src/components/visualConfig/index.tsx
@@ -98,6 +98,7 @@ const VisualConfigPanel: React.FC = () => {
 
     useEffect(() => {
         setZeroScale(layout.zeroScale);
+        setSvg(layout.useSvg ?? false);
         setBackground(layout.background);
         setResolve(layout.resolve);
         setDefaultColor(extractRGBA(layout.primaryColor));

--- a/packages/graphic-walker/src/lib/gog.ts
+++ b/packages/graphic-walker/src/lib/gog.ts
@@ -1,17 +1,16 @@
 // File name: gog represents the Grammar of Graphics  (theory by Wilkinson)
-import { DraggableFieldState, IAnalyticType, ISemanticType } from "../interfaces";
+import { DraggableFieldState, IAnalyticType, ISemanticType } from '../interfaces';
 
-type SpitialEncodings = Pick<DraggableFieldState, 'columns' | 'rows'> | Pick<DraggableFieldState, 'latitude' | 'longitude'>
 type DraggableFieldValues = DraggableFieldState[Exclude<keyof DraggableFieldState, 'filters'>];
 // LR = Lint Rules
 const LR = {
     /**
      * measures should appear after dimensions, for we do not apply cross operator on measures.
-     * @param fields 
-     * @returns 
+     * @param fields
+     * @returns
      */
     measureAfterDimension(fields: DraggableFieldValues): DraggableFieldValues {
-        return fields.filter(f => f.analyticType === 'dimension').concat(fields.filter(f => f.analyticType === 'measure'));
+        return fields.filter((f) => f.analyticType === 'dimension').concat(fields.filter((f) => f.analyticType === 'measure'));
     },
     // due to renderer, we set a limit of var can be applied to cross operator in GoG.
     crossLimit(maxLimit: number) {
@@ -27,25 +26,25 @@ const LR = {
                 }
                 return acc;
             }, [] as DraggableFieldValues);
-        }
+        };
     },
-    forceAnalyticType (analyticType: IAnalyticType) {
+    forceAnalyticType(analyticType: IAnalyticType) {
         return function (fields: DraggableFieldValues): DraggableFieldValues {
-            return fields.map(f => ({
+            return fields.map((f) => ({
                 ...f,
-                analyticType
-            }))
-        }
+                analyticType,
+            }));
+        };
     },
-    forceSemanticType (semanticType: ISemanticType) {
+    forceSemanticType(semanticType: ISemanticType) {
         return function (fields: DraggableFieldValues): DraggableFieldValues {
-            return fields.map(f => ({
+            return fields.map((f) => ({
                 ...f,
-                semanticType
-            }))
-        }
+                semanticType,
+            }));
+        };
     },
-}
+};
 type Operator<T> = (value: T) => T;
 function applyOperations<T>(initialValue: T, operators: Operator<T>[]): T {
     return operators.reduce((currentValue, operator) => operator(currentValue), initialValue);
@@ -55,33 +54,22 @@ function applyOperations<T>(initialValue: T, operators: Operator<T>[]): T {
  * Algebra lint is the lint fix encoding settings in algebra stage in the grammar of graphics.
  * graphic-walker calculates the algebra on spitial channels (axises) (for now, rows, columns)
  * This steps mainly decide how the sql is generated.
- * @param encodings 
- * @returns 
+ * @param encodings
+ * @returns
  */
-export function algebraLint <T extends SpitialEncodings | DraggableFieldValues>(encodings: T): T {
-    if (Array.isArray(encodings)) {
-        return LR.measureAfterDimension(encodings) as T
+export function algebraLint<T extends Partial<DraggableFieldState>>(encodings: T): Partial<T> {
+    const result: Partial<T> = {};
+    if (encodings.rows && encodings.rows.length > 0) {
+        result.rows = applyOperations(encodings.rows, [LR.measureAfterDimension, LR.crossLimit(2)]);
     }
-    if ('rows' in encodings && 'columns' in encodings && (encodings.rows.length > 0 || encodings.columns.length > 0)) {
-        return {
-            ...encodings,
-            rows: applyOperations(encodings.rows, [LR.measureAfterDimension, LR.crossLimit(2)]),
-            columns: applyOperations(encodings.columns, [LR.measureAfterDimension, LR.crossLimit(2)])
-        };
-    }  else if ('latitude' in encodings && 'longitude' in encodings && (encodings.latitude.length > 0 || encodings.longitude.length > 0)) {
-        return {
-            ...encodings,
-            latitude: applyOperations(encodings.latitude, [
-                LR.forceAnalyticType('dimension'),
-                LR.forceSemanticType('quantitative'),
-                LR.crossLimit(1)
-            ]),
-            longitude: applyOperations(encodings.longitude, [
-                LR.forceAnalyticType('dimension'),
-                LR.forceSemanticType('quantitative'),
-                LR.crossLimit(1)
-            ])
-        };
+    if (encodings.columns && encodings.columns.length > 0) {
+        result.columns = applyOperations(encodings.columns, [LR.measureAfterDimension, LR.crossLimit(2)]);
     }
-    return encodings;
+    if (encodings.latitude && encodings.latitude.length > 0) {
+        result.latitude = applyOperations(encodings.latitude, [LR.forceAnalyticType('dimension'), LR.forceSemanticType('quantitative'), LR.crossLimit(1)]);
+    }
+    if (encodings.longitude && encodings.longitude.length > 0) {
+        result.longitude = applyOperations(encodings.longitude, [LR.forceAnalyticType('dimension'), LR.forceSemanticType('quantitative'), LR.crossLimit(1)]);
+    }
+    return result;
 }

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -334,7 +334,7 @@ export class VizSpecStore {
         const oriF = this.currentEncodings[sourceKey][sourceIndex];
         const sourceMeta = GLOBAL_CONFIG.META_FIELD_KEYS.includes(sourceKey);
         const destMeta = GLOBAL_CONFIG.META_FIELD_KEYS.includes(destinationKey);
-        if (destMeta && (oriF.fid === MEA_KEY_ID || oriF.fid === MEA_VAL_ID || oriF.fid === COUNT_FIELD_ID)) {
+        if (sourceMeta && destMeta && (oriF.fid === MEA_KEY_ID || oriF.fid === MEA_VAL_ID || oriF.fid === COUNT_FIELD_ID)) {
             return;
         }
         const limit = GLOBAL_CONFIG.CHANNEL_LIMIT[destinationKey] ?? Infinity;


### PR DESCRIPTION
issue: when draging MeasureValues, MeasureName, Row count from encodings to field list, will do nothing instead of removing fields.
fixed this
![20231113-135036](https://github.com/Kanaries/graphic-walker/assets/15280968/2c72bdc9-938b-4cf2-9e87-c4bef276c5ae)

update: add a lint make the MeasureValues MeasureName & RowCount field at fixed positon in meta.
![20231113-150157](https://github.com/Kanaries/graphic-walker/assets/15280968/777cdd5f-7d64-4219-84a1-b88e987f8a29)

