### PR TITLE
chore: change distinct count logic

### DIFF
--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -139,16 +139,32 @@ export const fieldStat = async (
                 query: [
                     {
                         op: 'aggregate',
-                        groupBy: [],
+                        groupBy: [field.fid],
                         measures: [
-                            {
-                                field: field.fid,
-                                agg: 'distinctCount',
-                                asFieldKey: TOTAL_DISTINCT_ID,
-                            },
                             {
                                 field: '*',
                                 agg: 'count',
+                                asFieldKey: COUNT_ID,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                type: 'view',
+                query: [
+                    {
+                        op: 'aggregate',
+                        groupBy: [],
+                        measures: [
+                            {
+                                field: '*',
+                                agg: 'count',
+                                asFieldKey: TOTAL_DISTINCT_ID,
+                            },
+                            {
+                                field: COUNT_ID,
+                                agg: 'sum',
                                 asFieldKey: 'count',
                             },
                         ],

--- a/packages/graphic-walker/src/fields/filterField/tabs.tsx
+++ b/packages/graphic-walker/src/fields/filterField/tabs.tsx
@@ -295,7 +295,7 @@ const useVisualCount = (
         if (!field.rule || (field.rule.type !== 'one of' && field.rule.type !== 'not in') || !metaData) return;
         setSelectedValueSum(0);
         onChange({
-            type: currentSum === metaData.valuesMeta.total ? 'one of' : 'not in',
+            type: currentCount === metaData.valuesMeta.distinctTotal ? 'one of' : 'not in',
             value: new Set(),
         });
     }, [field.rule, onChange, metaData]);


### PR DESCRIPTION
change the distinctCount logic to use double views, to contains when field containing NULL fields in SQL backend.
fixed select all not reponsive at some situation.
bug screenshot: 
![20231114160029_rec_](https://github.com/Kanaries/graphic-walker/assets/15280968/22b75a25-36f7-4e25-93f3-ea66922a91a6)
fixed: 
![20231114160226_rec_](https://github.com/Kanaries/graphic-walker/assets/15280968/495460d5-25e6-4b3d-9538-49db7e2deece)
