### PR TITLE
feat: enhance font style for `Tooltip` and `Callout`

### DIFF
--- a/packages/graphic-walker/src/components/callout.tsx
+++ b/packages/graphic-walker/src/components/callout.tsx
@@ -54,7 +54,7 @@ const Callout = memo<CalloutProps>(function Callout({ target, children, darkMode
         root &&
         pos &&
         createPortal(
-            <Bubble role="dialog" dark={darkMode === 'dark'} className="fixed bg-white dark:bg-zinc-900  z-50" style={{ left: pos[0], top: pos[1] + 4 }}>
+            <Bubble role="dialog" dark={darkMode === 'dark'} className="fixed font-sans text-xs bg-white dark:bg-zinc-900 z-50" style={{ left: pos[0], top: pos[1] + 4 }}>
                 {children}
             </Bubble>,
             root

--- a/packages/graphic-walker/src/components/limitSetting.tsx
+++ b/packages/graphic-walker/src/components/limitSetting.tsx
@@ -24,7 +24,7 @@ export default function LimitSetting(props: { value: number; setValue: (v: numbe
                     }
                 }}
             />
-            <output className="text-sm ml-1" htmlFor="height">
+            <output className="ml-1" htmlFor="height">
                 <input
                     type="checkbox"
                     className="h-4 w-4 mr-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"

--- a/packages/graphic-walker/src/components/sizeSetting.tsx
+++ b/packages/graphic-walker/src/components/sizeSetting.tsx
@@ -32,11 +32,11 @@ export const ResizeDialog: React.FC<SizeSettingProps> = (props) => {
                         setInnerWidth(Math.round(Number(e.target.value) ** 2 * 1000));
                     }}
                 />
-                <output className="text-sm ml-1" htmlFor="width">
+                <output className="ml-1" htmlFor="width">
                     {`${t("width")}: ${innerWidth}`}
                 </output>
             </div>
-            <div className=" mt-2">
+            <div className="mt-2">
                 <input
                     className="w-full h-2 bg-blue-100 appearance-none"
                     style={{ cursor: "ew-resize" }}
@@ -50,7 +50,7 @@ export const ResizeDialog: React.FC<SizeSettingProps> = (props) => {
                         setInnerHeight(Math.round(Number(e.target.value) ** 2 * 1000));
                     }}
                 />
-                <output className="text-sm ml-1" htmlFor="height">
+                <output className="ml-1" htmlFor="height">
                     {`${t("height")}: ${innerHeight}`}
                 </output>
             </div>

--- a/packages/graphic-walker/src/components/tooltip.tsx
+++ b/packages/graphic-walker/src/components/tooltip.tsx
@@ -131,7 +131,7 @@ const Tooltip = memo<TooltipProps>(function Tooltip({
                 root &&
                 createPortal(
                     <Bubble
-                        className={`${darkMode === 'dark' ? 'dark bg-zinc-900' : 'bg-white'} fixed text-xs p-1 px-3 text-gray-500 z-50`}
+                        className={`${darkMode === 'dark' ? 'dark bg-zinc-900' : 'bg-white'} font-sans fixed text-xs p-1 px-3 text-gray-500 z-50`}
                         dark={darkMode === 'dark'}
                         onMouseOver={() => setHover(true)}
                         onMouseOut={() => setHover(false)}


### PR DESCRIPTION
Kanaries is an awesome tool for data visual analysis, though I've encountered some UI details concerning the 'Tooltip' and 'Callout' that could be improved.

## Screenshots
### `Tooltip`
| Before | After |
| -------- | -------- | 
| <img width="782" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/f06781f7-4b1b-41c5-9133-4575c2112fab"> | <img width="833" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/96958441-390c-46fb-bc96-afd474e6ec9d"> |

### `Callout`
| Before | After |
| -------- | -------- | 
| <img width="842" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/103e77ca-e2e0-4876-90a0-ad895aa53553"> | <img width="855" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/54cad0b1-0e5c-4f01-bd09-e0d3b59d9dee"> |
| <img width="835" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/8488a10d-c3aa-4730-936f-2413c914b6b1"> | <img width="944" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/125171539/965bbedc-9403-430d-927a-529b5b3965bc"> |
