### PR TITLE
feat: omit redundant separators

### DIFF
--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -42,6 +42,7 @@ import throttle from '../utils/throttle';
 import KanariesLogo from '../assets/kanaries.png';
 import { ImageWithFallback } from '../components/timeoutImg';
 import LimitSetting from '../components/limitSetting';
+import { omitRedundantSeparator } from './utils';
 
 const Invisible = styled.div`
     clip: rect(1px, 1px, 1px, 1px);
@@ -579,7 +580,7 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
             },
         ].filter(Boolean) as ToolbarItemProps[];
 
-        const items = builtInItems.filter((item) => typeof item === 'string' || !exclude.includes(item.key));
+        const items = omitRedundantSeparator(builtInItems.filter((item) => typeof item === 'string' || !exclude.includes(item.key)));
 
         switch (vizStore.config.geoms[0]) {
             case 'table':

--- a/packages/graphic-walker/src/visualSettings/utils.test.ts
+++ b/packages/graphic-walker/src/visualSettings/utils.test.ts
@@ -1,0 +1,18 @@
+import { ToolbarItemProps } from '../components/toolbar';
+import { omitRedundantSeparator } from './utils';
+
+describe('omitRedundantSeparator', () => {
+    const testItem = { key: 'test' } as ToolbarItemProps;
+    test('heading consecutive separator', () => {
+        const items: ToolbarItemProps[] = ['-', '-', testItem];
+        expect(omitRedundantSeparator(items)).toEqual([testItem]);
+    });
+    test('trailing consecutive separator', () => {
+        const items: ToolbarItemProps[] = [testItem, '-', '-'];
+        expect(omitRedundantSeparator(items)).toEqual([testItem]);
+    });
+    test('middle consecutive separators', () => {
+        const items: ToolbarItemProps[] = [testItem, '-', '-', testItem, '-', testItem];
+        expect(omitRedundantSeparator(items)).toEqual([testItem, '-', testItem, '-', testItem]);
+    });
+});

--- a/packages/graphic-walker/src/visualSettings/utils.ts
+++ b/packages/graphic-walker/src/visualSettings/utils.ts
@@ -1,0 +1,8 @@
+import { ToolbarItemProps } from '../components/toolbar';
+
+export function omitRedundantSeparator(items: ToolbarItemProps[]) {
+    const omitted = items.filter((item, index) =>
+        typeof item !== 'string' || item !== '-' || items[index + 1] !== '-'
+    );
+    return omitted.slice(omitted[0] === '-' ? 1 : 0, omitted[omitted.length - 1] === '-' ? -1 : undefined);
+}


### PR DESCRIPTION
At the current, using `toolbar.exclude` prop sometimes make some UI problems.
1. heading/trailing separator: ex. if `kanaries` is excluded, the separator appears at the end of toolbar.
2. consecutive separators: ex. if `coord_system` is excluded, consecutive separators appears at the middle of toolbar.

This pull request will cause leading and trailing separators and consecutive separators to be removed.

## Before
<img width="585" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/1424963/263d8932-85ee-4b6e-b83e-fb30b65dcfe4">

## After
<img width="545" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/1424963/4d16eade-4d3c-4f91-b7b9-bec39f5790b5">
