### PR TITLE
fix: block empty view workflow

### DIFF
--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -9,6 +9,7 @@ import type {
     IRow,
     ISortWorkflowStep,
     ITransformWorkflowStep,
+    IViewWorkflowStep,
     IVisFilter,
 } from '../interfaces';
 import { getTimeFormat } from '../lib/inferMeta';
@@ -85,12 +86,12 @@ export const dataReadRaw = async (
 };
 
 export const dataQuery = async (service: IComputationFunction, workflow: IDataQueryWorkflowStep[], limit?: number): Promise<IRow[]> => {
+    const viewWorkflow = workflow.find(x => x.type === 'view') as IViewWorkflowStep | undefined;
     if (
-        workflow.length === 1 &&
-        workflow[0].type === 'view' &&
-        workflow[0].query.length === 1 &&
-        workflow[0].query[0].op === 'raw' &&
-        workflow[0].query[0].fields.length === 0
+        viewWorkflow &&
+        viewWorkflow.query.length === 1 &&
+        viewWorkflow.query[0].op === 'raw' &&
+        viewWorkflow.query[0].fields.length === 0
     ) {
         return [];
     }

--- a/packages/graphic-walker/src/fields/filterField/slider.tsx
+++ b/packages/graphic-walker/src/fields/filterField/slider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { filter, fromEvent, map, throttleTime } from 'rxjs';
 import { useTranslation } from 'react-i18next';
@@ -71,10 +71,11 @@ const SliderSlice = styled.div`
     height: 100%;
 `;
 
-
 const nicer = (range: readonly [number, number], value: number): string => {
+    if (typeof value !== 'number') {
+        return '';
+    }
     const precision = /(\.\d*)$/.exec(((range[1] - range[0]) / 1000).toString())?.[0].length;
-    
     return precision === undefined ? `${value}` : value.toFixed(precision).replace(/\.?0+$/, '');
 };
 
@@ -86,26 +87,36 @@ interface ValueInputProps {
     onChange: (value: number) => void;
 }
 
-const ValueInput: React.FC<ValueInputProps> = props => {
+const ValueInput: React.FC<ValueInputProps> = (props) => {
     const { min, max, value, resetValue, onChange } = props;
-    const handleSubmitValue = (value) => {
-        if (!isNaN(value) && value <= max && value >= min) {
-            onChange(value);
+    const [innerValue, setInnerValue] = useState(`${value}`);
+
+    const handleSubmitValue = () => {
+        const v = Number(innerValue);
+        if (!isNaN(v) && v <= max && v >= min) {
+            onChange(v);
         } else {
             onChange(resetValue);
+            setInnerValue(`${resetValue}`);
         }
-    }
+    };
+
+    useEffect(() => {
+        setInnerValue(`${value}`);
+    }, [value]);
+
     return (
         <input
             type="number"
             min={min}
             max={max}
             className="block w-full rounded-md border-0 py-1 px-2 text-gray-900 dark:text-white shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 dark:bg-zinc-900 dark:border-gray-700 focus:ring-1 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-            value={value}
-            onChange={(e) => handleSubmitValue(Number(e.target.value))}
+            value={innerValue}
+            onChange={(e) => setInnerValue(e.target.value)}
+            onBlur={handleSubmitValue}
         />
-    )
-}
+    );
+};
 
 interface SliderProps {
     min: number;

--- a/packages/graphic-walker/src/fields/filterField/slider.tsx
+++ b/packages/graphic-walker/src/fields/filterField/slider.tsx
@@ -73,6 +73,7 @@ const SliderSlice = styled.div`
 
 const nicer = (range: readonly [number, number], value: number): string => {
     if (typeof value !== 'number') {
+        console.warn('Expected a number but received', typeof value);
         return '';
     }
     const precision = /(\.\d*)$/.exec(((range[1] - range[0]) / 1000).toString())?.[0].length;
@@ -114,6 +115,11 @@ const ValueInput: React.FC<ValueInputProps> = (props) => {
             value={innerValue}
             onChange={(e) => setInnerValue(e.target.value)}
             onBlur={handleSubmitValue}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                    handleSubmitValue();
+                }
+            }}            
         />
     );
 };


### PR DESCRIPTION
when setting only a filter, the graphic walker will query a empty view query, which would cause error when using computation function.
this PR fixed this and blocked the query in this situation.