### PR TITLE
chore: change default fold value

### DIFF
--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -310,7 +310,7 @@ const actions: {
             data = actions[Methods.setConfig](
                 data,
                 'folds',
-                validFoldBy.map((x) => x.fid)
+                validFoldBy.filter((_, i) => i === 0).map((x) => x.fid)
             );
         }
         if (originalField.fid === MEA_VAL_ID) {


### PR DESCRIPTION
change default fold value to first measure, to make it easier to use when there is lots of measure fields.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/a8e905d5-7eca-47c3-804e-dcaa72ce7587)
