### PR TITLE
feat: add computation field

### DIFF
--- a/packages/duckdb-wasm-computation/package.json
+++ b/packages/duckdb-wasm-computation/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.28.0",
-    "@kanaries-temp/gw-dsl-parser": "^0.1.36-rc5",
+    "@kanaries-temp/gw-dsl-parser": "^0.1.39-rc9",
     "@kanaries/graphic-walker": "0.4.39",
     "apache-arrow": "^13.0.0",
     "nanoid": "^5.0.1"

--- a/packages/duckdb-wasm-computation/src/index.ts
+++ b/packages/duckdb-wasm-computation/src/index.ts
@@ -9,6 +9,7 @@ import initWasm, { parser_dsl_with_table } from '@kanaries-temp/gw-dsl-parser';
 import dslWasm from '@kanaries-temp/gw-dsl-parser/gw_dsl_parser_bg.wasm?url';
 import { nanoid } from 'nanoid';
 import { IDataSourceProvider, IMutField, IDataSourceListener, exportFullRaw, fromFields } from '@kanaries/graphic-walker';
+import { MapRow } from 'apache-arrow';
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     mvp: {
@@ -93,7 +94,11 @@ export async function getMemoryProvider(): Promise<IDataSourceProvider> {
             if (process.env.NODE_ENV !== 'production') {
                 console.log(query, sql);
             }
-            const res = await conn.query(sql).then((x) => x.toArray().map((r) => JSON.parse(r.toString())));
+            const res = await conn
+                .query(sql)
+                .then((x) =>
+                    x.toArray().map((r: MapRow) => Object.fromEntries(Object.entries(r.toJSON()).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])))
+                );
             return res;
         },
         registerCallback(cb) {
@@ -127,7 +132,11 @@ export async function getComutation(data: Record<string, number>[]) {
             if (process.env.NODE_ENV !== 'production') {
                 console.log(query, sql);
             }
-            const res = await conn.query(sql).then((x) => x.toArray().map((r) => JSON.parse(r.toString())));
+            const res = await conn
+                .query(sql)
+                .then((x) =>
+                    x.toArray().map((r) => Object.fromEntries(Object.entries(r.toJSON()).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])))
+                );
             return res;
         },
     };

--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -60,6 +60,7 @@
     "mobx": "^6.3.3",
     "mobx-react-lite": "^3.2.1",
     "nanoid": "^4.0.2",
+    "pgsql-ast-parser": "^11.1.0",
     "postcss": "^8.3.7",
     "postinstall-postinstall": "^2.1.0",
     "re-resizable": "^6.9.8",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -36,6 +36,7 @@ import DataBoard from './components/dataBoard';
 import SideReisze from './components/side-resize';
 import { VegaliteMapper } from './lib/vl2gw';
 import { newChart } from './models/visSpecHistory';
+import ComputedFieldDialog from './components/computedField';
 
 export type BaseVizProps = IAppI18nProps &
     IVizProps &
@@ -156,6 +157,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                         csvHandler={downloadCSVRef}
                                         rendererHandler={rendererRef}
                                         darkModePreference={darkMode}
+                                        experimentalFeatures={props.experimentalFeatures}
                                         exclude={toolbar?.exclude}
                                         extra={toolbar?.extra}
                                     />
@@ -165,6 +167,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                     <VisualConfig />
                                     <LogPanel />
                                     <BinPanel />
+                                    <ComputedFieldDialog />
                                     <Painter themeConfig={themeConfig} dark={darkMode} themeKey={themeKey} />
                                     {vizStore.showGeoJSONConfigPanel && <GeoConfigPanel geoList={props.geoList} />}
                                     <div className="sm:flex">
@@ -280,6 +283,7 @@ export function VizAppWithContext(props: IVizAppProps) {
                         spec={props.spec}
                         vlSpec={props.vlSpec}
                         themeConfig={props.themeConfig}
+                        experimentalFeatures={props.experimentalFeatures}
                     />
                 </FieldsContextWrapper>
             </VizStoreWrapper>

--- a/packages/graphic-walker/src/components/computedField/index.tsx
+++ b/packages/graphic-walker/src/components/computedField/index.tsx
@@ -1,0 +1,143 @@
+import { observer } from 'mobx-react-lite';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { useVizStore } from '../../store';
+import DefaultButton from '../button/default';
+import PrimaryButton from '../button/primary';
+import Modal from '../modal';
+import { parseErrorMessage } from '../../utils';
+import { highlightField } from '../highlightField';
+import { aggFuncs, reservedKeywords, sqlFunctions } from '../../lib/sql';
+import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID, PAINT_FIELD_ID } from '../../constants';
+import { unstable_batchedUpdates } from 'react-dom';
+
+const keywordRegex = new RegExp(`\\b(${Array.from(reservedKeywords).join('|')})\\b`, 'gi');
+const bulitInRegex = new RegExp(`\\b(${Array.from(sqlFunctions).join('|')})(\\s*)\\(`, 'gi');
+const aggBultinRegex = new RegExp(`\\b(${Array.from(aggFuncs).join('|')})(\\s*)\\(`, 'gi');
+
+const stringRegex = /('[^']*'?)/g;
+
+const ComputedFieldDialog: React.FC = observer(() => {
+    const vizStore = useVizStore();
+    const { editingComputedFieldFid } = vizStore;
+    const [name, setName] = useState<string>('');
+    const [sql, setSql] = useState<string>('');
+    const [error, setError] = useState<string>('');
+    const ref = useRef<{ clear(): void; setValue(v: string): void }>(null);
+
+    const SQLField = useMemo(() => {
+        const fieldRegex = new RegExp(
+            `\\b(${vizStore.allFields
+                .filter((x) => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID, PAINT_FIELD_ID].includes(x.fid))
+                .map((x) => x.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
+                .join('|')})\\b`,
+            'gi'
+        );
+        return highlightField((sql: string) => {
+            // highlight keyword
+            sql = sql.replace(keywordRegex, '<span class="text-fuchsia-700 dark:text-fuchsia-600">$1</span>');
+
+            // highlight function
+            sql = sql.replace(bulitInRegex, '<span class="text-yellow-700 dark:text-yellow-600">$1</span>$2(');
+
+            // highlight agg function
+            sql = sql.replace(aggBultinRegex, '<span class="text-amber-700 dark:text-amber-600">$1</span>$2(');
+
+            // highlight string
+            sql = sql.replace(stringRegex, '<span class="text-green-700 dark:text-green-600">$1</span>');
+
+            // highlight field
+            sql = sql.replace(fieldRegex, '<span class="text-blue-700 dark:text-blue-600">$1</span>');
+
+            return sql;
+        });
+    }, [vizStore.allFields]);
+
+    useEffect(() => {
+        if (editingComputedFieldFid !== undefined) {
+            if (editingComputedFieldFid === '') {
+                let idx = 1;
+                while (vizStore.allFields.find((x) => x.name === `Computed ${idx}`)) {
+                    idx++;
+                }
+                unstable_batchedUpdates(() => {
+                    setName(`Computed ${idx}`);
+                    setSql('');
+                    setError('');
+                });
+                ref.current?.clear();
+            } else {
+                const f = vizStore.allFields.find((x) => x.fid === editingComputedFieldFid);
+                if (!f || !f.computed || f.expression?.op !== 'expr') {
+                    vizStore.setComputedFieldFid('');
+                    return;
+                }
+                const sql = f.expression.params.find((x) => x.type === 'sql');
+                if (!sql) {
+                    vizStore.setComputedFieldFid('');
+                    return;
+                }
+                unstable_batchedUpdates(() => {
+                    setName(f.name);
+                    setSql(sql.value);
+                    setError('');
+                });
+                ref.current?.setValue(sql.value);
+            }
+        }
+    }, [editingComputedFieldFid, vizStore]);
+
+    return (
+        <Modal
+            show={editingComputedFieldFid !== undefined}
+            onClose={() => {
+                vizStore.setComputedFieldFid();
+            }}
+        >
+            <div className="flex flex-col space-y-2">
+                <div>
+                    <div className="text-xl font-bold">{editingComputedFieldFid === '' ? 'Add Computed Field' : 'Edit Computed Field'}</div>
+                    <span className="text-xs text-gray-500">
+                        Computed fields guide:{' '}
+                        <a
+                            target="_blank"
+                            className="underline text-indigo-500"
+                            href="https://github.com/Kanaries/graphic-walker/wiki/How-to-Create-Computed-field-in-Graphic-Walker"
+                        >
+                            read here
+                        </a>
+                    </span>
+                </div>
+                <div className="flex flex-col space-y-2">
+                    <label className="text-ml whitespace-nowrap">Name</label>
+                    <input
+                        type="text"
+                        className="block w-full text-gray-700 dark:text-gray-200 rounded-md border-0 py-1 px-2 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-1 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 dark:bg-zinc-900 "
+                        value={name}
+                        onChange={(e) => {
+                            setName(e.target.value);
+                        }}
+                    />
+                    <label className="text-ml whitespace-nowrap">SQL</label>
+                    <SQLField ref={ref} onChange={setSql} placeholder="Enter SQL..." />
+                </div>
+                {error && <div className="text-xs text-red-500">{error}</div>}
+                <div className="flex justify-end space-x-2">
+                    <PrimaryButton
+                        text={editingComputedFieldFid === '' ? 'Add' : 'Edit'}
+                        onClick={() => {
+                            try {
+                                vizStore.upsertComputedField(editingComputedFieldFid!, name, sql);
+                                vizStore.setComputedFieldFid();
+                            } catch (e) {
+                                setError(parseErrorMessage(e));
+                            }
+                        }}
+                    ></PrimaryButton>
+                    <DefaultButton text="Cancel" onClick={() => vizStore.setComputedFieldFid()}></DefaultButton>
+                </div>
+            </div>
+        </Modal>
+    );
+});
+
+export default ComputedFieldDialog;

--- a/packages/graphic-walker/src/components/dataBoard.tsx
+++ b/packages/graphic-walker/src/components/dataBoard.tsx
@@ -4,7 +4,7 @@ import { useCompututaion, useVizStore } from '../store';
 import DataTable from './dataTable';
 import React, { useMemo } from 'react';
 import { IComputationFunction, IVisFilter } from '../interfaces';
-import { addFilterForQuery, addTransformForQuery } from '../utils/workflow';
+import { addFilterForQuery, addTransformForQuery, processExpression } from '../utils/workflow';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../constants';
 
 const DataBoard = observer(function DataBoardModal() {
@@ -20,7 +20,7 @@ const DataBoard = observer(function DataBoardModal() {
         }
         return entries.map(([k, v]): IVisFilter => ({ fid: k, rule: { type: 'one of', value: [v] } }));
     }, [selectedMarkObject]);
-    const computedFileds = useMemo(() => allFields.filter((x) => x.fid !== COUNT_FIELD_ID && x.computed && x.expression), [allFields]);
+    const computedFileds = useMemo(() => allFields.filter((x) => x.fid !== COUNT_FIELD_ID && x.computed && x.expression && x.aggName !== 'expr'), [allFields]);
 
     const filteredComputation = useMemo((): IComputationFunction => {
         return (query) =>
@@ -28,15 +28,15 @@ const DataBoard = observer(function DataBoardModal() {
                 addTransformForQuery(
                     addFilterForQuery(query, filters),
                     computedFileds.map((x) => ({
-                        expression: x.expression!,
+                        expression: processExpression(x.expression!, allFields),
                         key: x.fid!,
                     }))
                 )
             );
-    }, [computation, filters, computedFileds]);
+    }, [computation, filters, computedFileds, allFields]);
 
     const metas = useMemo(() => {
-        return allFields.filter((x) => ![MEA_KEY_ID, MEA_VAL_ID, COUNT_FIELD_ID].includes(x.fid));
+        return allFields.filter(x => x.aggName !== 'expr').filter((x) => ![MEA_KEY_ID, MEA_VAL_ID, COUNT_FIELD_ID].includes(x.fid));
     }, [allFields]);
 
     return (

--- a/packages/graphic-walker/src/components/highlightField.tsx
+++ b/packages/graphic-walker/src/components/highlightField.tsx
@@ -1,0 +1,40 @@
+import React, { useState, useRef, useImperativeHandle } from 'react';
+
+export interface TextFieldProps {
+    placeholder?: string;
+    onChange?: (v: string) => void;
+}
+
+export function highlightField(highlighter: (value: string) => string) {
+    return React.forwardRef<{ clear(): void; setValue(value: string): void; }, TextFieldProps>(function TextField({ placeholder, onChange }, ref) {
+        const [value, setValue] = useState('');
+        const divRef = useRef<HTMLDivElement>(null);
+        const highlightValue = highlighter(value);
+        useImperativeHandle(ref, () => ({
+            clear() {
+                divRef.current && (divRef.current.innerHTML = '');
+                setValue('');
+            },
+            setValue(value) {
+                divRef.current && (divRef.current.innerHTML = value);
+                setValue(value);
+            },
+        }));
+        return (
+            <div className="relative w-full text-gray-700 dark:text-gray-200 rounded-md border-0 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400  sm:text-sm sm:leading-6 dark:bg-zinc-900">
+                <div className="absolute whitespace-pre inset-0 pointer-events-none py-1 px-2" dangerouslySetInnerHTML={{ __html: highlightValue }} />
+                {placeholder && value === '' && <div className="py-1 px-2 pointer-events-none text-gray-400 absolute inset-0 select-none">{placeholder}</div>}
+                <div
+                    ref={divRef}
+                    contentEditable="plaintext-only"
+                    onInput={(e) => {
+                        const text = e.currentTarget.textContent ?? '';
+                        setValue(text);
+                        onChange?.(text);
+                    }}
+                    className="py-1 px-2 focus-visible:ring-1 focus-visible:ring-inset rounded-md border-0 focus-visible:ring-indigo-600 text-transparent caret-gray-700 dark:caret-gray-200 focus-visible:outline-none"
+                ></div>
+            </div>
+        );
+    });
+}

--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -6,6 +6,7 @@ import type {
     IField,
     IFieldStats,
     IFilterWorkflowStep,
+    IMutField,
     IRow,
     ISortWorkflowStep,
     ITransformWorkflowStep,
@@ -114,7 +115,8 @@ export const fieldStat = async (
         valuesLimit?: number;
         valuesOffset?: number;
         sortBy?: 'value' | 'value_dsc' | 'count' | 'count_dsc' | 'none';
-    }
+    },
+    allFields: IMutField[]
 ): Promise<IFieldStats> => {
     const { values = true, range = true, valuesMeta = true, sortBy = 'none' } = options;
     const COUNT_ID = `count_${field.fid}`;
@@ -127,7 +129,7 @@ export const fieldStat = async (
                   type: 'transform',
                   transform: [
                       {
-                          expression: processExpression(field.expression!),
+                          expression: processExpression(field.expression!, allFields),
                           key: field.fid,
                       },
                   ],

--- a/packages/graphic-walker/src/fields/datasetFields/utils.ts
+++ b/packages/graphic-walker/src/fields/datasetFields/utils.ts
@@ -153,6 +153,22 @@ export const useMenuActions = (channel: 'dimensions' | 'measures'): IActionMenuI
                         },
                     })),
                 },
+                f.computed &&
+                    !isInnerField &&
+                    f.expression?.op === 'expr' && {
+                        label: 'Edit Computed Field',
+                        onPress() {
+                            vizStore.setComputedFieldFid(f.fid);
+                        },
+                    },
+                f.computed &&
+                    !isInnerField && {
+                        label: 'Remove Field',
+                        onPress() {
+                            const originChannel = f.analyticType === 'dimension' ? 'dimensions' : 'measures';
+                            vizStore.removeComputedField(originChannel, index);
+                        },
+                    },
             ]);
         });
     }, [channel, fields, vizStore, t, computation]);

--- a/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
@@ -65,7 +65,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
                                 ref={refMapper(provided.innerRef)}
                                 {...provided.draggableProps}
                                 {...provided.dragHandleProps}
-                                className={"flex items-stretch absolute top-0 left-0 right-0 bottom-0 m-1" + (provided.draggableProps.style?.transform ? ' z-10' : '')}
+                                className={"flex items-stretch absolute top-0 left-0 right-0 bottom-0 m-1" + (provided.draggableProps.style?.transform ? ' z-10' : '') + (channelItem.aggName === 'expr' && !config.defaultAggregated ? ' !opacity-50' : '')}
                             >
                                 <div
                                     onClick={() => {
@@ -89,7 +89,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
                                         </SelectContext>
                                     )}
                                     {channelItem.fid !== MEA_KEY_ID && <span className="flex-1 truncate">{channelItem.name}</span>}{' '}
-                                    {channelItem.analyticType === 'measure' && channelItem.fid !== COUNT_FIELD_ID && config.defaultAggregated && (
+                                    {channelItem.analyticType === 'measure' && channelItem.fid !== COUNT_FIELD_ID && config.defaultAggregated && channelItem.aggName !== 'expr' && (
                                         <DropdownContext
                                             options={aggregationOptions}
                                             onSelect={(value) => {

--- a/packages/graphic-walker/src/fields/obComponents/obPill.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obPill.tsx
@@ -45,6 +45,7 @@ const OBPill: React.FC<PillProps> = (props) => {
         <Pill
             ref={refMapper(provided.innerRef)}
             colType={field.analyticType === 'dimension' ? 'discrete' : 'continuous'}
+            className={`${field.aggName === 'expr' && !config.defaultAggregated ? '!opacity-50' : ''}`}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
         >
@@ -61,7 +62,7 @@ const OBPill: React.FC<PillProps> = (props) => {
             )}
             {!folds && <span className="flex-1 truncate">{field.name}</span>}
             &nbsp;
-            {field.analyticType === 'measure' && field.fid !== COUNT_FIELD_ID && config.defaultAggregated && (
+            {field.analyticType === 'measure' && field.fid !== COUNT_FIELD_ID && config.defaultAggregated && field.aggName !== 'expr' && (
                 <DropdownContext
                     options={aggregationOptions}
                     onSelect={(value) => {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -19,7 +19,7 @@ export interface IRow {
     [key: string]: any;
 }
 
-export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev' | 'distinctCount';
+export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev' | 'distinctCount' | 'expr';
 
 export type IEmbedMenuItem = 'data_interpretation' | 'data_view';
 export interface Specification {
@@ -122,10 +122,14 @@ export type IExpParameter =
     | {
           type: 'map';
           value: IPaintMap;
+      }
+    | {
+          type: 'sql';
+          value: string;
       };
 
 export interface IExpression {
-    op: 'bin' | 'log2' | 'log10' | 'one' | 'binCount' | 'dateTimeDrill' | 'dateTimeFeature' | 'log' | 'paint';
+    op: 'bin' | 'log2' | 'log10' | 'one' | 'binCount' | 'dateTimeDrill' | 'dateTimeFeature' | 'log' | 'paint' | 'expr';
     params: IExpParameter[];
     as: string;
     num?: number;
@@ -156,6 +160,7 @@ export interface IField {
     basename?: string;
     path?: string[];
     offset?: number;
+    aggergated?: boolean;
 }
 export type ISortMode = 'none' | 'ascending' | 'descending';
 export interface IViewField extends IField {
@@ -825,12 +830,20 @@ export interface IVizProps {
     enhanceAPI?: {
         header?: Record<string, string>;
         features?: {
-            askviz?: string | boolean | ((metas: IViewField[], query: string) => PromiseLike<IVisSpecForExport | IChartForExport> | IVisSpecForExport | IChartForExport);
+            askviz?:
+                | string
+                | boolean
+                | ((metas: IViewField[], query: string) => PromiseLike<IVisSpecForExport | IChartForExport> | IVisSpecForExport | IChartForExport);
             feedbackAskviz?: string | boolean | ((data: IAskVizFeedback) => void);
         };
     };
     geoList?: IGeoDataItem[];
     channelScales?: IChannelScales;
+    experimentalFeatures?: IExperimentalFeatures;
+}
+
+export interface IExperimentalFeatures {
+    computedField?: boolean;
 }
 
 export interface IVizStoreProps {
@@ -900,7 +913,7 @@ export type IDataSourceListener = (event: number, datasetId: string) => void;
 
 export interface IDataSourceProvider {
     addDataSource(data: IRow[], meta: IMutField[], name: string): Promise<string>;
-    getDataSourceList(): Promise<{ name: string; id: string; }[]>;
+    getDataSourceList(): Promise<{ name: string; id: string }[]>;
 
     getMeta(datasetId: string): Promise<IMutField[]>;
     setMeta(datasetId: string, meta: IMutField[]): Promise<void>;

--- a/packages/graphic-walker/src/lib/op/fold.ts
+++ b/packages/graphic-walker/src/lib/op/fold.ts
@@ -1,6 +1,6 @@
 import { MEA_VAL_ID, MEA_KEY_ID } from '../../constants';
 import { IRow, IViewField } from '../../interfaces';
-import { getMeaAggKey } from '../../utils';
+import { getMeaAggKey, getMeaAggName } from '../../utils';
 import { IFoldQuery } from '../../interfaces';
 
 export function fold(data: IRow[], query: IFoldQuery): IRow[] {
@@ -37,7 +37,7 @@ export function fold2(
             .map((x) => {
                 if (defaultAggregated) {
                     return {
-                        name: `${meaVal.aggName}(${x.name})`,
+                        name: getMeaAggName(x.name, meaVal.aggName),
                         fid: getMeaAggKey(x.fid, meaVal.aggName),
                     };
                 }

--- a/packages/graphic-walker/src/lib/op/stat.ts
+++ b/packages/graphic-walker/src/lib/op/stat.ts
@@ -45,6 +45,10 @@ export function count(nums: any[]): number {
     return nums.length;
 }
 
+export function countTruly(nums: any[]): number {
+    return nums.filter(x => x !== undefined && x !== null).length;
+}
+
 export function distinctCount(datas: any[]) {
     return new Set(datas).size;
 }

--- a/packages/graphic-walker/src/lib/sql.ts
+++ b/packages/graphic-walker/src/lib/sql.ts
@@ -1,0 +1,764 @@
+import parser from 'pgsql-ast-parser';
+import { IMutField, IRow, ISemanticType } from '../interfaces';
+import { sum, mean, median, stdev, variance, max, min, countTruly, distinctCount } from './op/stat';
+import { dataframe2Dataset } from './execExp';
+
+const aggregatorMap = {
+    sum,
+    mean,
+    median,
+    stdev,
+    variance,
+    max,
+    min,
+    count: countTruly,
+    distinctCount,
+};
+
+export function parseSQLExpr(sql: string): parser.Expr {
+    const ast = parser.parse(sql, 'expr');
+    return ast;
+}
+
+export const reservedKeywords = new Set([
+    'ALL',
+    'ANALYSE',
+    'ANALYZE',
+    'AND',
+    'ANY',
+    'ARRAY',
+    'AS',
+    'ASC',
+    'ASYMMETRIC',
+    'BINARY',
+    'BOTH',
+    'CASE',
+    'CAST',
+    'CHECK',
+    'COLLATE',
+    'COLUMN',
+    'CONCURRENTLY',
+    'CONSTRAINT',
+    'CREATE',
+    'CROSS',
+    'CURRENT_DATE',
+    'CURRENT_ROLE',
+    'CURRENT_TIME',
+    'CURRENT_TIMESTAMP',
+    'CURRENT_USER',
+    'DEFAULT',
+    'DEFERRABLE',
+    'DESC',
+    'DISTINCT',
+    'DO',
+    'ELSE',
+    'END',
+    'EXCEPT',
+    'FALSE',
+    'FETCH',
+    'FOR',
+    'FOREIGN',
+    'FREEZE',
+    'FROM',
+    'FULL',
+    'GRANT',
+    'GROUP',
+    'HAVING',
+    'ILIKE',
+    'IN',
+    'INITIALLY',
+    'INNER',
+    'INTERSECT',
+    'INTO',
+    'IS',
+    'ISNULL',
+    'JOIN',
+    'LATERAL',
+    'LEADING',
+    'LEFT',
+    'LIKE',
+    'LIMIT',
+    'LOCALTIME',
+    'LOCALTIMESTAMP',
+    'NATURAL',
+    'NOT',
+    'NOTNULL',
+    'NULL',
+    'OFFSET',
+    'ON',
+    'ONLY',
+    'OR',
+    'ORDER',
+    'OUTER',
+    'OVERLAPS',
+    'PLACING',
+    'PRIMARY',
+    'REFERENCES',
+    'RETURNING',
+    'RIGHT',
+    'SELECT',
+    'SESSION_USER',
+    'SIMILAR',
+    'SOME',
+    'SYMMETRIC',
+    'TABLE',
+    'THEN',
+    'TO',
+    'TRAILING',
+    'TRUE',
+    'UNION',
+    'UNIQUE',
+    'USER',
+    'USING',
+    'VARIADIC',
+    'VERBOSE',
+    'WHEN',
+    'WHERE',
+    'WINDOW',
+    'WITH',
+]);
+
+export const sqlFunctions = new Set([
+    'abs',
+    'atan2',
+    'add',
+    'currval',
+    'octet_length',
+    'array_length',
+    'md5_number_lower',
+    'upper',
+    'make_timestamp',
+    'array_resize',
+    'ascii',
+    'list_contains',
+    'day',
+    'get_bit',
+    'substring',
+    'subtract',
+    'array_cat',
+    'string_to_array',
+    'error',
+    'in_search_path',
+    'list_concat',
+    'lower',
+    'base64',
+    'editdist3',
+    'regexp_matches',
+    'nextval',
+    'date_part',
+    'typeof',
+    'regexp_extract_all',
+    'last_day',
+    'millisecond',
+    'month',
+    'to_base64',
+    'prefix',
+    'divide',
+    'ucase',
+    'from_hex',
+    'concat',
+    'not_ilike_escape',
+    'range',
+    'substr',
+    'unbin',
+    'len',
+    'split',
+    'list_value',
+    'list_position',
+    'list_indexof',
+    'enum_last',
+    'not_like_escape',
+    'even',
+    'set_bit',
+    'time_bucket',
+    'regexp_replace',
+    'struct_extract',
+    'gcd',
+    'constant_or_null',
+    'apply',
+    'vector_type',
+    'list_filter',
+    'chr',
+    'array_contains',
+    'ceiling',
+    'radians',
+    'nfc_normalize',
+    'log10',
+    'regexp_full_match',
+    'alias',
+    'length_grapheme',
+    'suffix',
+    'list_aggr',
+    'ilike_escape',
+    'multiply',
+    'array_concat',
+    'regexp_extract',
+    'like_escape',
+    'current_database',
+    'hex',
+    'isoyear',
+    'transaction_timestamp',
+    'array_indexof',
+    'list_element',
+    'jaccard',
+    'yearweek',
+    'to_months',
+    'year',
+    'xor',
+    'weekofyear',
+    'weekday',
+    'lpad',
+    'bit_length',
+    'dayofyear',
+    'union_tag',
+    'uuid',
+    'list_distance',
+    'dayname',
+    'unhex',
+    'txid_current',
+    'trunc',
+    'encode',
+    'to_minutes',
+    'to_milliseconds',
+    'to_binary',
+    'to_base',
+    'array_distinct',
+    'timezone_hour',
+    'tan',
+    'struct_pack',
+    'strptime',
+    'strpos',
+    'strlen',
+    'atan',
+    'str_split_regex',
+    'str_split',
+    'date_sub',
+    'map_values',
+    'least_common_multiple',
+    'stats',
+    'datediff',
+    'starts_with',
+    '!__postfix',
+    'factorial',
+    'sqrt',
+    'element_at',
+    'printf',
+    'signbit',
+    'sha256',
+    'list_extract',
+    'setseed',
+    'enum_range',
+    'second',
+    'reverse',
+    'replace',
+    'damerau_levenshtein',
+    'to_hours',
+    'substring_grapheme',
+    'repeat',
+    'length',
+    'to_microseconds',
+    'century',
+    'list_has',
+    'current_date',
+    'combine',
+    'epoch_ns',
+    'isinf',
+    'rpad',
+    'ceil',
+    'format',
+    'regexp_split_to_array',
+    'today',
+    'random',
+    'quarter',
+    'array_aggr',
+    'position',
+    'isnan',
+    'age',
+    'pi',
+    'aggregate',
+    'array_reverse_sort',
+    'nextafter',
+    'monthname',
+    'array_position',
+    'unicode',
+    'concat_ws',
+    'mismatches',
+    'epoch',
+    'minute',
+    'mod',
+    'millennium',
+    'string_split_regex',
+    'microsecond',
+    'bit_position',
+    'right_grapheme',
+    'list_reverse_sort',
+    'md5',
+    'rtrim',
+    'sign',
+    'string_split',
+    'list_resize',
+    'map_keys',
+    'map_entries',
+    'exp',
+    'map_concat',
+    'map',
+    'make_time',
+    'week',
+    'make_date',
+    'power',
+    '__internal_decompress_integral_usmallint',
+    'ltrim',
+    'log2',
+    'pow',
+    'log',
+    'greatest',
+    'list_cat',
+    'list_unique',
+    'contains',
+    'list_transform',
+    'timezone_minute',
+    'list_sort',
+    'list_pack',
+    'list_dot_product',
+    'list_apply',
+    'array_slice',
+    'lgamma',
+    'map_extract',
+    'left_grapheme',
+    'least',
+    'julian',
+    'jaro_winkler_similarity',
+    'isodow',
+    'union_extract',
+    'list_distinct',
+    'isfinite',
+    'to_years',
+    'instr',
+    'date_trunc',
+    'sin',
+    'translate',
+    'array_filter',
+    'strip_accents',
+    'to_timestamp',
+    'list_inner_product',
+    'array_apply',
+    'hash',
+    'to_seconds',
+    'decade',
+    'hamming',
+    'greatest_common_divisor',
+    'ends_with',
+    'get_current_timestamp',
+    'try_strptime',
+    'to_hex',
+    'get_current_time',
+    'timezone',
+    'md5_number_upper',
+    'generate_series',
+    'strftime',
+    'datepart',
+    'levenshtein',
+    '__internal_compress_integral_usmallint',
+    'union_value',
+    'gen_random_uuid',
+    'array_extract',
+    'from_binary',
+    'list_slice',
+    'from_base64',
+    'row',
+    'format_bytes',
+    'flatten',
+    'filter',
+    'datetrunc',
+    'cos',
+    'era',
+    'lcm',
+    'decode',
+    'hour',
+    'finalize',
+    'epoch_ms',
+    'right',
+    'enum_range_boundary',
+    'degrees',
+    'dayofweek',
+    'array_sort',
+    'datesub',
+    'formatReadableDecimalSize',
+    'date_diff',
+    'array_has',
+    'current_setting',
+    'current_schemas',
+    'map_from_entries',
+    'array_transform',
+    'current_query',
+    'md5_number',
+    'round',
+    'list_cosine_similarity',
+    'dayofmonth',
+    'asin',
+    'jaro_similarity',
+    'enum_code',
+    'cot',
+    'list_aggregate',
+    'ord',
+    'cbrt',
+    'array_unique',
+    'struct_insert',
+    'cardinality',
+    'to_days',
+    'acos',
+    'version',
+    'gamma',
+    'trim',
+    'floor',
+    'left',
+    'bit_count',
+    'current_schema',
+    'bin',
+    'now',
+    'bar',
+    'epoch_us',
+    'ln',
+    'array_aggregate',
+    'enum_first',
+    'bitstring',
+    'lcase',
+]);
+
+export const aggFuncs = new Set([
+    'any_value',
+    'arg_max',
+    'max_by',
+    'arg_min',
+    'argMin',
+    'min_by',
+    'avg',
+    'mean',
+    'bit_and',
+    'bit_or',
+    'bit_xor',
+    'bitstring_agg',
+    'bool_and',
+    'bool_or',
+    'count',
+    'favg',
+    'first',
+    'arbitrary',
+    'fsum',
+    'kahan_sum',
+    'geomean',
+    'geometric_mean',
+    'histogram',
+    'last',
+    'list',
+    'array_agg',
+    'max',
+    'min',
+    'product',
+    'string_agg',
+    'group_concat',
+    'listagg',
+    'sum',
+    'approx_count_distinct',
+    'approx_quantile',
+    'reservoir_quantile',
+    'corr',
+    'covar_pop',
+    'covar_samp',
+    'entropy',
+    'kurtosis',
+    'mad',
+    'median',
+    'mode',
+    'quantile_cont',
+    'quantile_disc',
+    'quantile',
+    'regr_avgx',
+    'regr_avgy',
+    'regr_count',
+    'regr_intercept',
+    'regr_r2',
+    'regr_slope',
+    'regr_sxx',
+    'regr_sxy',
+    'regr_syy',
+    'skewness',
+    'stddev_pop',
+    'stddev_samp',
+    'stddev',
+    'var_pop',
+    'var_samp',
+    'variance',
+]);
+
+export function getSQLItemAnalyticType(item: parser.Expr, fields: IMutField[]) {
+    const map = new Map<string, IMutField>();
+    fields.forEach((f) => {
+        map.set(f.name ?? f.fid, f);
+    });
+    const walk = (i: parser.Expr): [ISemanticType, boolean] => {
+        switch (i.type) {
+            case 'integer':
+            case 'numeric':
+                return ['quantitative', false];
+            case 'null':
+            case 'string':
+            case 'boolean':
+                return ['nominal', false];
+            case 'unary':
+                const [_, agg] = walk(i.operand);
+                switch (i.op) {
+                    case '+':
+                    case '-':
+                        return ['quantitative', agg];
+                    default:
+                        return ['nominal', agg];
+                }
+            case 'ref': {
+                const f = map.get(i.name);
+                if (f) {
+                    return [f.semanticType, false];
+                }
+                return ['nominal', false];
+            }
+            case 'case': {
+                if (i.else) {
+                    return walk(i.else);
+                } else {
+                    return walk(i.whens[0].value);
+                }
+            }
+            case 'array':
+            case 'list': {
+                if (i.expressions.length) {
+                    return walk(i.expressions[0]);
+                }
+                return ['nominal', false];
+            }
+            case 'binary': {
+                return walk(i.left);
+            }
+            case 'call': {
+                if (i.function.name === 'count') {
+                    return ['quantitative', true];
+                }
+                const [t] = walk(i.args[0]);
+                return [t, aggFuncs.has(i.function.name.toLowerCase())];
+            }
+            case 'cast': {
+                const [_, agg] = walk(i.operand);
+                if ('name' in i.to) {
+                    switch (i.to.name.toLowerCase()) {
+                        case 'date':
+                        case 'timestamp':
+                        case 'timestamp with time zone':
+                        case 'time':
+                        case 'time with time zone':
+                        case 'interval':
+                            return ['temporal', agg];
+                        case 'smallint':
+                        case 'integer':
+                        case 'bigint':
+                        case 'decimal':
+                        case 'numeric':
+                        case 'real':
+                        case 'double precision':
+                        case 'smallserial':
+                        case 'serial':
+                        case 'bigserial':
+                            return ['quantitative', agg];
+                    }
+                }
+                return ['nominal', agg];
+            }
+            default:
+                return ['nominal', false];
+        }
+    };
+    return walk(item);
+}
+
+export function walkFid(sql: string): string[] {
+    const set = new Set<string>();
+    const walk = (i: parser.Expr) => {
+        if (i.type === 'ref') {
+            set.add(i.name);
+        } else {
+            Object.values(i).forEach((x) => {
+                if (x !== null && typeof x === 'object' && 'type' in x) {
+                    walk(x);
+                }
+            });
+        }
+    };
+    walk(parseSQLExpr(sql));
+    return Array.from(set);
+}
+
+export function replaceFid(sql: string, fields: IMutField[]): string {
+    const dict = new Map<string, IMutField>();
+    fields.forEach((f) => {
+        dict.set((f.name ?? f.fid).toLowerCase(), f);
+    });
+    const item = parseSQLExpr(sql);
+    const mapper = parser.astMapper(() => ({
+        ref: (r) => {
+            return parser.assignChanged(r, { name: dict.get(r.name.toLowerCase())?.fid || r.name });
+        },
+    }));
+    return parser.toSql.expr(mapper.expr(item)!);
+}
+
+function fmap<T>(x: T | T[], mapper: (i: T) => T) {
+    if (x instanceof Array) {
+        return x.map(mapper);
+    }
+    return mapper(x);
+}
+
+function performOp<T>(op: (x: T, y: T) => T, a: T | T[], b: T | T[]) {
+    if (a instanceof Array) {
+        if (b instanceof Array) {
+            return a.map((x, i) => op(x, b[i]));
+        }
+        return a.map((x) => op(x, b));
+    }
+    if (b instanceof Array) {
+        return b.map((y) => op(a, y));
+    }
+    return op(a, b);
+}
+
+const isSingleTruly = (x: unknown | [unknown]) => {
+    if (x instanceof Array) {
+        return !!x[0];
+    }
+    return !!x;
+};
+
+function exprSQL(item: parser.Expr, datas: IRow[] | Record<string, any[]>): (string | number | boolean | null) | (string | number | boolean | null)[] {
+    const exec = (i: parser.Expr) => {
+        switch (i.type) {
+            case 'ref': {
+                if (datas instanceof Array) {
+                    if (datas[0][i.name] === undefined && i.name !== '*') {
+                        throw new Error(`there is no field named ${i.name}`);
+                    }
+                    if (i.name === '*') {
+                        return datas.map((r) => r[Object.keys(r)[0]]);
+                    }
+
+                    return datas.map((r) => r[i.name]);
+                } else {
+                    if (!datas[i.name] && i.name !== '*') {
+                        throw new Error(`there is no field named ${i.name}`);
+                    }
+                    if (i.name === '*') {
+                        return datas[Object.keys(datas)[0]];
+                    }
+                    return datas[i.name];
+                }
+            }
+            case 'integer':
+            case 'numeric':
+            case 'string':
+            case 'boolean': {
+                return i.value;
+            }
+            case 'binary': {
+                let op: (x: any, y: any) => any;
+                switch (i.op) {
+                    case '!=':
+                        op = (x, y) => x != y;
+                        break;
+                    case '%':
+                        op = (x, y) => x % y;
+                        break;
+                    case '*':
+                        op = (x, y) => x * y;
+                        break;
+                    case '/':
+                        op = (x, y) => x / y;
+                        break;
+                    case '+':
+                        op = (x, y) => x + y;
+                        break;
+                    case '-':
+                        op = (x, y) => x - y;
+                        break;
+                    case '=':
+                        op = (x, y) => x == y;
+                        break;
+                    case '>':
+                        op = (x, y) => x > y;
+                        break;
+                    case '<':
+                        op = (x, y) => x < y;
+                        break;
+                    case '>=':
+                        op = (x, y) => x >= y;
+                        break;
+                    case '<=':
+                        op = (x, y) => x <= y;
+                        break;
+                    case 'OR':
+                        op = (x, y) => x || y;
+                        break;
+                    case 'AND':
+                        op = (x, y) => x && y;
+                        break;
+                    default:
+                        throw new Error(`unsupport op ${i.op}, calculating ${parser.toSql.expr(i)}`);
+                }
+                return performOp(op, exec(i.left), exec(i.right));
+            }
+            case 'unary': {
+                switch (i.op) {
+                    case '+': {
+                        return fmap((a) => +a, exec(i.operand));
+                    }
+                    case '-': {
+                        return fmap((a) => -a, exec(i.operand));
+                    }
+                    case 'NOT': {
+                        return fmap((a) => !a, exec(i.operand));
+                    }
+                    default: {
+                        throw new Error(`unsupport unary ${i.op}, calculating ${parser.toSql.expr(i)}`);
+                    }
+                }
+            }
+            case 'call': {
+                if (i.function.name in aggregatorMap) {
+                    return aggregatorMap[i.function.name](exec(i.args[0]));
+                } else {
+                    throw new Error(`unsupport function ${i.function.name}, calculating ${parser.toSql.expr(i)}`);
+                }
+            }
+            case 'case': {
+                if (datas instanceof Array) {
+                    if (datas.length === 1) {
+                        const sat: parser.ExprWhen | undefined = i.whens.find((x) => isSingleTruly(exec(x.when)));
+                        if (sat) {
+                            return exec(sat.value);
+                        } else {
+                            return i.else ? exec(i.else) : null;
+                        }
+                    } else {
+                        return datas.flatMap((r) => exprSQL(i, [r]));
+                    }
+                } else {
+                    return exprSQL(i, dataframe2Dataset(datas));
+                }
+            }
+            default: {
+                throw new Error(`unsupport type ${i.type}, calculating ${parser.toSql.expr(i)}`);
+            }
+        }
+    };
+    return exec(item) as (string | number | boolean | null) | (string | number | boolean | null)[];
+}
+
+export function expr(sql: string, datas: IRow[] | Record<string, any[]>) {
+    return exprSQL(parseSQLExpr(sql), datas);
+}

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -12,7 +12,7 @@ import { download } from '../utils/save';
 import { useChartIndexControl } from '../utils/chartIndexControl';
 import { LEAFLET_DEFAULT_HEIGHT, LEAFLET_DEFAULT_WIDTH } from '../components/leafletRenderer';
 import { emptyEncodings, emptyVisualConfig } from '../utils/save';
-import { getMeaAggKey } from '../utils';
+import { getMeaAggKey, getMeaAggName } from '../utils';
 import { COUNT_FIELD_ID } from '../constants';
 import { GWGlobalConfig } from '../vis/theme';
 import { GLOBAL_CONFIG } from '../config';
@@ -82,7 +82,7 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
                         if (viewConfig.defaultAggregated && x.analyticType === 'measure') {
                             return {
                                 fid: getMeaAggKey(x.fid, x.aggName),
-                                name: `${x.aggName}(${x.name})`,
+                                name: getMeaAggName(x.name, x.aggName),
                             };
                         }
                         return { fid: x.fid, name: x.name };

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -47,6 +47,7 @@ import { KVTuple, uniqueId } from '../models/utils';
 import { encodeFilterRule } from '../utils/filter';
 import { INestNode } from '../components/pivotTable/inteface';
 import { getSort, getSortedEncoding } from '../utils';
+import { getSQLItemAnalyticType, parseSQLExpr } from '../lib/sql';
 
 const encodingKeys = (Object.keys(emptyEncodings) as (keyof DraggableFieldState)[]).filter((dkey) => !GLOBAL_CONFIG.META_FIELD_KEYS.includes(dkey));
 export const viewEncodingKeys = (geom: string) => {
@@ -98,7 +99,8 @@ export class VizSpecStore {
     showPainterPanel: boolean = false;
     lastErrorMessage: string = '';
     showAskvizFeedbackIndex: number | undefined = 0;
-    lastSpec: string = "";
+    lastSpec: string = '';
+    editingComputedFieldFid: string | undefined = undefined;
 
     private onMetaChange?: (fid: string, diffMeta: Partial<IMutField>) => void;
 
@@ -266,7 +268,7 @@ export class VizSpecStore {
 
     private appendFilter(index: number, sourceKey: keyof Omit<DraggableFieldState, 'filters'>, sourceIndex: number) {
         const oriF = this.currentEncodings[sourceKey][sourceIndex];
-        if (oriF.fid === MEA_KEY_ID || oriF.fid === MEA_VAL_ID || oriF.fid === COUNT_FIELD_ID) {
+        if (oriF.fid === MEA_KEY_ID || oriF.fid === MEA_VAL_ID || oriF.fid === COUNT_FIELD_ID || oriF.aggName === 'expr') {
             return;
         }
         this.visList[this.visIndex] = performers.appendFilter(this.visList[this.visIndex], index, sourceKey, sourceIndex, uniqueId());
@@ -388,7 +390,7 @@ export class VizSpecStore {
                     uniqueId(),
                     limit
                 );
-                return; 
+                return;
             }
             this.visList[this.visIndex] = performers.cloneField(
                 this.visList[this.visIndex],
@@ -676,9 +678,40 @@ export class VizSpecStore {
         this.showPainterPanel = show;
     }
 
-
     updateLastSpec(spec: string) {
         this.lastSpec = spec;
+    }
+
+    setComputedFieldFid(fid?: string) {
+        this.editingComputedFieldFid = fid;
+    }
+
+    upsertComputedField(fid: string, name: string, sql: string) {
+        if (fid === '') {
+            this.visList[this.visIndex] = performers.addSQLComputedField(this.visList[this.visIndex], uniqueId(), name, sql);
+        } else {
+            const originalField = this.allFields.find((x) => x.fid === fid);
+            if (!originalField) return;
+            const [semanticType, isAgg] = getSQLItemAnalyticType(parseSQLExpr(sql), this.allFields);
+            const analyticType = semanticType === 'quantitative' ? 'measure' : 'dimension';
+            const newAggName = isAgg ? 'expr' : analyticType === 'dimension' ? undefined : 'sum';
+            const preAggName = originalField.aggName === 'expr' ? 'expr' : originalField.aggName === undefined ? undefined : 'sum';
+
+            this.visList[this.visIndex] = performers.editAllField(this.visList[this.visIndex], fid, {
+                name,
+                analyticType,
+                semanticType,
+                ...(preAggName !== newAggName ? { aggName: newAggName } : {}),
+                expression: { as: fid, op: 'expr', params: [{ type: 'sql', value: sql }] },
+            });
+        }
+    }
+
+    removeComputedField(sourceKey: keyof DraggableFieldState, sourceIndex: number) {
+        const oriF = this.currentEncodings[sourceKey][sourceIndex];
+        if (oriF.computed) {
+            this.visList[this.visIndex] = performers.removeAllField(this.visList[this.visIndex], oriF.fid);
+        }
     }
 }
 

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -288,8 +288,15 @@ export function classNames(...classes: string[]) {
     return classes.filter(Boolean).join(' ');
 }
 
+export function getMeaAggName(meaName: string, agg?: string | undefined) {
+    if (!agg || agg === 'expr') {
+        return meaName;
+    }
+    return `${agg}(${meaName})`;
+}
+
 export function getMeaAggKey(meaKey: string, agg?: string | undefined) {
-    if (!agg) {
+    if (!agg || agg === 'expr') {
         return meaKey;
     }
     return `${meaKey}_${agg}`;

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -182,10 +182,12 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
             clickSub.unsubscribe();
         };
     }, [onGeomClick]);
-    const rowDims = useMemo(() => rows.filter((f) => f.analyticType === 'dimension'), [rows]);
-    const colDims = useMemo(() => columns.filter((f) => f.analyticType === 'dimension'), [columns]);
-    const rowMeas = useMemo(() => rows.filter((f) => f.analyticType === 'measure'), [rows]);
-    const colMeas = useMemo(() => columns.filter((f) => f.analyticType === 'measure'), [columns]);
+    const guardedRows = useMemo(() => rows.filter((x) => defaultAggregate || x.aggName !== 'expr'), [rows, defaultAggregate]);
+    const guardedCols = useMemo(() => columns.filter((x) => defaultAggregate || x.aggName !== 'expr'), [columns, defaultAggregate]);
+    const rowDims = useMemo(() => guardedRows.filter((f) => f.analyticType === 'dimension'), [guardedRows]);
+    const colDims = useMemo(() => guardedCols.filter((f) => f.analyticType === 'dimension'), [guardedCols]);
+    const rowMeas = useMemo(() => guardedRows.filter((f) => f.analyticType === 'measure'), [guardedRows]);
+    const colMeas = useMemo(() => guardedCols.filter((f) => f.analyticType === 'measure'), [guardedCols]);
     const rowRepeatFields = useMemo(() => (rowMeas.length === 0 ? rowDims.slice(-1) : rowMeas), [rowDims, rowMeas]); //rowMeas.slice(0, -1);
     const colRepeatFields = useMemo(() => (colMeas.length === 0 ? colDims.slice(-1) : colMeas), [colDims, colMeas]); //colMeas.slice(0, -1);
     const { reportError: reportGWError } = useReporter();
@@ -244,7 +246,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     const specs = useMemo(
         () =>
             toVegaSpec({
-                columns,
+                columns: guardedCols,
                 dataSource,
                 defaultAggregated: defaultAggregate,
                 geomType,
@@ -252,7 +254,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
                 interactiveScale,
                 layoutMode,
                 mediaTheme,
-                rows,
+                rows: guardedRows,
                 stack,
                 width: vegaWidth,
                 channelScales,
@@ -267,7 +269,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
                 vegaConfig,
             }),
         [
-            columns,
+            guardedCols,
             dataSource,
             defaultAggregate,
             geomType,
@@ -275,7 +277,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
             interactiveScale,
             layoutMode,
             mediaTheme,
-            rows,
+            guardedRows,
             stack,
             vegaWidth,
             channelScales,

--- a/packages/graphic-walker/src/vis/spec/aggregate.ts
+++ b/packages/graphic-walker/src/vis/spec/aggregate.ts
@@ -1,6 +1,6 @@
 import { COUNT_FIELD_ID } from '../../constants';
 import { IViewField } from '../../interfaces';
-import { getMeaAggKey } from '../../utils';
+import { getMeaAggKey, getMeaAggName } from '../../utils';
 import { encodeFid } from './encode';
 
 export function channelAggregate(encoding: { [key: string]: any }, fields: IViewField[]) {
@@ -11,7 +11,7 @@ export function channelAggregate(encoding: { [key: string]: any }, fields: IView
             c.title = 'Count';
             c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName))
         } else if (targetField) {
-            c.title = `${targetField.aggName}(${targetField.name})`;
+            c.title = getMeaAggName(targetField.name, targetField.aggName),
             c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName))
         }
     });

--- a/packages/graphic-walker/src/vis/spec/tooltip.ts
+++ b/packages/graphic-walker/src/vis/spec/tooltip.ts
@@ -1,5 +1,5 @@
 import { IViewField } from '../../interfaces';
-import { getMeaAggKey } from '../../utils';
+import { getMeaAggKey, getMeaAggName } from '../../utils';
 
 export function addTooltipEncode(encoding: { [key: string]: any }, details: Readonly<IViewField[]> = [], defaultAggregated = false) {
     const encs = Object.keys(encoding)
@@ -19,7 +19,7 @@ export function addTooltipEncode(encoding: { [key: string]: any }, details: Read
         .concat(
             details.map((f) => ({
                 field: defaultAggregated ? getMeaAggKey(f.fid, f.aggName) : f.fid,
-                title: defaultAggregated && f.aggName ? `${f.aggName}(${f.name})` : f.name,
+                title: defaultAggregated ? getMeaAggName(f.name, f.aggName) : f.name,
                 type: f.semanticType,
             }))
         );

--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -25,6 +25,7 @@ import {
     RectangleGroupIcon,
     GlobeAmericasIcon,
     HashtagIcon,
+    DocumentPlusIcon,
     PaintBrushIcon,
 } from '@heroicons/react/24/outline';
 import { observer } from 'mobx-react-lite';
@@ -34,7 +35,7 @@ import { useTranslation } from 'react-i18next';
 import { ResizeDialog } from '../components/sizeSetting';
 import { GLOBAL_CONFIG } from '../config';
 import { useVizStore } from '../store';
-import { IStackMode, IDarkMode } from '../interfaces';
+import { IStackMode, IDarkMode, IExperimentalFeatures } from '../interfaces';
 import { IReactVegaHandler } from '../vis/react-vega';
 import Toolbar, { ToolbarItemProps } from '../components/toolbar';
 import { ButtonWithShortcut } from './menubar';
@@ -74,9 +75,10 @@ interface IVisualSettings {
     csvHandler?: React.MutableRefObject<{ download: () => void }>;
     exclude?: string[];
     extra?: ToolbarItemProps[];
+    experimentalFeatures?: IExperimentalFeatures;
 }
 
-const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePreference, csvHandler, extra = [], exclude = [] }) => {
+const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePreference, csvHandler, extra = [], exclude = [], experimentalFeatures }) => {
     const vizStore = useVizStore();
     const { config, layout, canUndo, canRedo, limit, paintInfo } = vizStore;
     const { t: tGlobal } = useTranslation();
@@ -400,6 +402,9 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
                     vizStore.setVisualLayout('showTableSummary', checked);
                 },
             },
+            ...(experimentalFeatures?.computedField
+                ? [{ key: 'field:add', label: 'Add Computed Field', icon: DocumentPlusIcon, onClick: () => vizStore.setComputedFieldFid('') }]
+                : []),
             '-',
             {
                 key: 'axes_resize',
@@ -633,6 +638,7 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
         exclude,
         limit,
         showTableSummary,
+        experimentalFeatures,
         paintInfo
     ]);
 

--- a/packages/graphic-walker/src/workers/transform.worker.ts
+++ b/packages/graphic-walker/src/workers/transform.worker.ts
@@ -8,7 +8,8 @@ const main = (e: { data: { dataSource: IRow[]; trans: IFieldTransform[] } }) => 
             self.postMessage(ans);
         })
         .catch((error) => {
-            self.postMessage({ error: error.message });
+            console.error(error.stack);
+            self.postMessage(error.stack);
         });
 };
 

--- a/packages/playground/src/examples/pages/ds.stories.tsx
+++ b/packages/playground/src/examples/pages/ds.stories.tsx
@@ -12,7 +12,16 @@ export default function DataSourceSegment() {
     return (
         <DataSourceSegmentComponent provider={provider}>
             {(p) => {
-                return <GraphicWalker storeRef={p.storeRef} computation={p.computation} rawFields={p.meta} onMetaChange={p.onMetaChange} dark={theme} />;
+                return (
+                    <GraphicWalker
+                        storeRef={p.storeRef}
+                        computation={p.computation}
+                        rawFields={p.meta}
+                        onMetaChange={p.onMetaChange}
+                        dark={theme}
+                        experimentalFeatures={{ computedField: true }}
+                    />
+                );
             }}
         </DataSourceSegmentComponent>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,10 +977,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@kanaries-temp/gw-dsl-parser@^0.1.36-rc5":
-  version "0.1.36-rc5"
-  resolved "https://registry.npmmirror.com/@kanaries-temp/gw-dsl-parser/-/gw-dsl-parser-0.1.36-rc5.tgz#3918db0484b01354c34f0bbdf9a735ae7435bb22"
-  integrity sha512-MmHEHfkPH7jhNiLHxg8QUNI7G2NRicnabzNyC9SEp4yFRvKw0Axtk4dPocmTu6oyvoHWyRr4wyraKaFR07qy6w==
+"@kanaries-temp/gw-dsl-parser@^0.1.39-rc9":
+  version "0.1.39-rc9"
+  resolved "https://registry.npmmirror.com/@kanaries-temp/gw-dsl-parser/-/gw-dsl-parser-0.1.39-rc9.tgz#dbc5d6676be33943bca2c53b76a241b585d3a197"
+  integrity sha512-ZHwzHYkJpn1b+EjvCKN+8MBCvY9XJBEpV+pwYDQqYhqBvD1JYGOF5MHxVifs2e5KLqyDTT4cyxjtBJOzYd5khg==
 
 "@kanaries/react-beautiful-dnd@^0.1.1":
   version "0.1.1"
@@ -1354,9 +1354,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^18.2.37", "@types/react@^18.x":
-  version "18.2.46"
-  resolved "https://registry.npmmirror.com/@types/react/-/react-18.2.46.tgz#f04d6c528f8f136ea66333bc66abcae46e2680df"
-  integrity sha512-nNCvVBcZlvX4NU1nRRNV/mFl1nNRuTuslAJglQsq+8ldXe5Xv0Wd2f7WTE3jOxhLH2BFfiZGC6GCp+kHQbgG+w==
+  version "18.2.45"
+  resolved "https://registry.npmmirror.com/@types/react/-/react-18.2.45.tgz#253f4fac288e7e751ab3dc542000fb687422c15c"
+  integrity sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -1992,7 +1992,7 @@ command-line-usage@7.0.1, command-line-usage@^7.0.0:
     table-layout "^3.0.0"
     typical "^7.1.1"
 
-commander@2:
+commander@2, commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2242,6 +2242,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmmirror.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
 dlv@^1.1.3:
   version "1.1.3"
@@ -3617,6 +3622,11 @@ mobx@^6.3.3:
   resolved "https://registry.npmjs.org/mobx/-/mobx-6.11.0.tgz#8a748b18c140892d1d0f28b71315f1f639180006"
   integrity sha512-qngYCmr0WJiFRSAtYe82DB7SbzvbhehkJjONs8ydynUwoazzUQHZdAlaJqUfks5j4HarhWsZrMRhV7HtSO9HOQ==
 
+moo@^0.5.0, moo@^0.5.1:
+  version "0.5.2"
+  resolved "https://registry.npmmirror.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -3650,6 +3660,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nearley@^2.19.5:
+  version "2.20.1"
+  resolved "https://registry.npmmirror.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -3820,6 +3840,14 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pgsql-ast-parser@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.npmmirror.com/pgsql-ast-parser/-/pgsql-ast-parser-11.1.0.tgz#b3015171fd844e93f37368a50fdb3c06ab9e5b01"
+  integrity sha512-c0XnjHzUyg2Z/3iB2Akk6+jDtsza4Jqw4bC5SSt9pQ3b+K4aQC75gJQDvsNYvFqQNaPHLCUunDLPc5SZsQQLIA==
+  dependencies:
+    moo "^0.5.1"
+    nearley "^2.19.5"
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -3972,6 +4000,19 @@ raf-schd@^4.0.2:
   version "4.0.3"
   resolved "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmmirror.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.npmmirror.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 re-resizable@^6.9.8:
   version "6.9.11"
@@ -4186,6 +4227,11 @@ resolve@^1.1.7, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.2:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.npmmirror.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Make user able to add a computed field with sql.
need to use with a computation service that use sql.
usage: 
`<GraphicWalker {...props} enableComputedField />`

more info:
https://github.com/Kanaries/graphic-walker/wiki/How-to-Create-Computed-field-in-Graphic-Walker

more features:
![image](https://github.com/Kanaries/graphic-walker/assets/126073370/cc1304c5-8da9-4fc2-9ce6-568c4b2e3baa)
aggergated fields will show gray and be disabled when "Aggergation" is off.

![image](https://github.com/Kanaries/graphic-walker/assets/126073370/ffea0c91-8fbe-4aef-9c93-12c7b311ddf3)
you can filter at non-aggergation computed fields.

![image](https://github.com/Kanaries/graphic-walker/assets/126073370/fdbcc702-9d7b-418d-975b-c4d76e596e1a)
in the data board, you can check the value of any row with your non-aggergation computed fields.