### PR TITLE
fix: add error panel for table

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -136,6 +136,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                             <div className="px-2 mx-2">
                                 <SegmentNav />
                             </div>
+                            <Errorpanel />
                             {segmentKey === ISegmentKey.vis && (
                                 <div className="px-2 mx-2 mt-2">
                                     <VisNav />
@@ -162,7 +163,6 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                     <ExplainData themeKey={themeKey} dark={darkMode} />
                                     {vizStore.showDataBoard && <DataBoard />}
                                     <VisualConfig />
-                                    <Errorpanel />
                                     <LogPanel />
                                     <BinPanel />
                                     <Painter themeConfig={themeConfig} dark={darkMode} themeKey={themeKey} />

--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -12,6 +12,7 @@ import { getComputation } from './computation/clientComputation';
 import DatasetTable from './components/dataTable';
 import { useCurrentMediaTheme } from './utils/media';
 import { toJS } from 'mobx';
+import Errorpanel from './components/errorpanel';
 
 export type BaseTableProps = IAppI18nProps &
     IErrorHandlerProps &
@@ -68,6 +69,7 @@ export const TableApp = observer(function VizApp(props: BaseTableProps) {
                             <DatasetTable size={pageSize} metas={metas} computation={wrappedComputation} />
                         </div>
                     </div>
+                    <Errorpanel />
                 </ComputationContext.Provider>
             </ErrorBoundary>
         </ErrorContext>


### PR DESCRIPTION
Currently, the Error Panel only shows in Vis Segment, and will show nothing when user is in Data Segment even there is error when Table component fetching data.
This PR let it shows when DataTable meets Errors too.