### PR TITLE
feat: add nominal support for data painter

### DIFF
--- a/packages/graphic-walker/src/components/painter/components.tsx
+++ b/packages/graphic-walker/src/components/painter/components.tsx
@@ -42,53 +42,6 @@ export const PixelCursor = (props: { color: string; dia: number; factor: number;
     );
 };
 
-// export const Container = (props: { color: string; cursor: CursorDef; children?: React.ReactNode | Iterable<React.ReactNode>; showPreview?: boolean }) => {
-//     const { color, cursor, children, showPreview } = props;
-//     const [cursorPos, setCursorPos] = React.useState<[number, number] | null>(null);
-//     return (
-//         <div
-//             className="relative cursor-none"
-//             onMouseOut={() => setCursorPos(null)}
-//             onMouseMoveCapture={(e) => setCursorPos([e.nativeEvent.offsetX, e.nativeEvent.offsetY])}
-//             onTouchMoveCapture={(e) => {
-//                 const rect = e.currentTarget.getBoundingClientRect();
-//                 setCursorPos([e.changedTouches[0].pageX - rect.left, e.changedTouches[0].pageY - rect.top]);
-//             }}
-//             onTouchEnd={() => setCursorPos(null)}
-//         >
-//             {children}
-//             {cursorPos !== null && cursor.type === 'circle' && (
-//                 <div
-//                     className="absolute pointer-events-none"
-//                     style={{
-//                         background: color,
-//                         width: cursor.dia * cursor.factor,
-//                         height: cursor.dia * cursor.factor,
-//                         borderRadius: cursor.dia * cursor.factor,
-//                         opacity: 0.6,
-//                         left: cursorPos[0] - (cursor.dia * cursor.factor) / 2,
-//                         top: cursorPos[1] - (cursor.dia * cursor.factor) / 2,
-//                     }}
-//                 />
-//             )}
-//             {showPreview && !cursorPos && cursor.type === 'circle' && (
-//                 <div
-//                     className="absolute pointer-events-none"
-//                     style={{
-//                         background: color,
-//                         width: cursor.dia * cursor.factor,
-//                         height: cursor.dia * cursor.factor,
-//                         borderRadius: cursor.dia * cursor.factor,
-//                         opacity: 0.6,
-//                         left: `calc(50% - ${(cursor.dia * cursor.factor) / 2}px)`,
-//                         top: `calc(50% - ${(cursor.dia * cursor.factor) / 2}px)`,
-//                     }}
-//                 />
-//             )}
-//         </div>
-//     );
-// };
-
 export type CursorDef =
     | {
           type: 'circle';

--- a/packages/graphic-walker/src/components/painter/components.tsx
+++ b/packages/graphic-walker/src/components/painter/components.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { getCircle } from '../../lib/paint';
 import { SketchPicker } from 'react-color';
-import Default from '../tabs/defaultTab';
 import DefaultButton from '../button/default';
 import { ShadowDomContext } from '../../shadow-dom';
 
@@ -43,72 +42,77 @@ export const PixelCursor = (props: { color: string; dia: number; factor: number;
     );
 };
 
-export const Container = (props: {
-    color: string;
-    dia: number;
-    factor: number;
-    children?: React.ReactNode | Iterable<React.ReactNode>;
-    showPreview?: boolean;
-}) => {
-    const { color, factor, dia, children, showPreview } = props;
-    const [cursorPos, setCursorPos] = React.useState<[number, number] | null>(null);
-    const size = dia * factor;
-    return (
-        <div
-            className="relative cursor-none"
-            onMouseOut={() => setCursorPos(null)}
-            onMouseMoveCapture={(e) => setCursorPos([e.nativeEvent.offsetX, e.nativeEvent.offsetY])}
-            onTouchMoveCapture={(e) => {
-                const rect = e.currentTarget.getBoundingClientRect();
-                setCursorPos([e.changedTouches[0].pageX - rect.left, e.changedTouches[0].pageY - rect.top]);
-            }}
-            onTouchEnd={() => setCursorPos(null)}
-        >
-            {children}
-            {cursorPos !== null && (
-                <div
-                    className="absolute pointer-events-none"
-                    style={{
-                        background: color,
-                        width: size,
-                        height: size,
-                        borderRadius: size,
-                        opacity: 0.6,
-                        left: cursorPos[0] - size / 2,
-                        top: cursorPos[1] - size / 2,
-                    }}
-                />
-            )}
-            {showPreview && !cursorPos && (
-                <div
-                    className="absolute pointer-events-none"
-                    style={{
-                        background: color,
-                        width: size,
-                        height: size,
-                        borderRadius: size,
-                        opacity: 0.6,
-                        left: `calc(50% - ${size / 2}px)`,
-                        top: `calc(50% - ${size / 2}px)`,
-                    }}
-                />
-            )}
-        </div>
-    );
-};
+// export const Container = (props: { color: string; cursor: CursorDef; children?: React.ReactNode | Iterable<React.ReactNode>; showPreview?: boolean }) => {
+//     const { color, cursor, children, showPreview } = props;
+//     const [cursorPos, setCursorPos] = React.useState<[number, number] | null>(null);
+//     return (
+//         <div
+//             className="relative cursor-none"
+//             onMouseOut={() => setCursorPos(null)}
+//             onMouseMoveCapture={(e) => setCursorPos([e.nativeEvent.offsetX, e.nativeEvent.offsetY])}
+//             onTouchMoveCapture={(e) => {
+//                 const rect = e.currentTarget.getBoundingClientRect();
+//                 setCursorPos([e.changedTouches[0].pageX - rect.left, e.changedTouches[0].pageY - rect.top]);
+//             }}
+//             onTouchEnd={() => setCursorPos(null)}
+//         >
+//             {children}
+//             {cursorPos !== null && cursor.type === 'circle' && (
+//                 <div
+//                     className="absolute pointer-events-none"
+//                     style={{
+//                         background: color,
+//                         width: cursor.dia * cursor.factor,
+//                         height: cursor.dia * cursor.factor,
+//                         borderRadius: cursor.dia * cursor.factor,
+//                         opacity: 0.6,
+//                         left: cursorPos[0] - (cursor.dia * cursor.factor) / 2,
+//                         top: cursorPos[1] - (cursor.dia * cursor.factor) / 2,
+//                     }}
+//                 />
+//             )}
+//             {showPreview && !cursorPos && cursor.type === 'circle' && (
+//                 <div
+//                     className="absolute pointer-events-none"
+//                     style={{
+//                         background: color,
+//                         width: cursor.dia * cursor.factor,
+//                         height: cursor.dia * cursor.factor,
+//                         borderRadius: cursor.dia * cursor.factor,
+//                         opacity: 0.6,
+//                         left: `calc(50% - ${(cursor.dia * cursor.factor) / 2}px)`,
+//                         top: `calc(50% - ${(cursor.dia * cursor.factor) / 2}px)`,
+//                     }}
+//                 />
+//             )}
+//         </div>
+//     );
+// };
+
+export type CursorDef =
+    | {
+          type: 'circle';
+          dia: number;
+          factor: number;
+      }
+    | {
+          type: 'rect';
+          x: number;
+          xFactor: number;
+          y: number;
+          yFactor: number;
+      };
 
 export const PixelContainer = (props: {
     color: string;
-    dia: number;
-    factor: number;
+    cursor: CursorDef;
     offsetX: number;
     offsetY: number;
     children?: React.ReactNode | Iterable<React.ReactNode>;
     showPreview?: boolean;
 }) => {
-    const { color, dia, factor, offsetX, offsetY, children, showPreview } = props;
+    const { color, cursor, offsetX, offsetY, children, showPreview } = props;
     const [cursorPos, setCursorPos] = React.useState<[number, number] | null>(null);
-    const center = (dia - (dia % 2)) / 2;
     return (
         <div
             className="relative cursor-none"
@@ -121,27 +125,78 @@ export const PixelContainer = (props: {
             onTouchEnd={() => setCursorPos(null)}
         >
             {children}
-            {cursorPos !== null && (
-                <PixelCursor
+            {cursorPos !== null && cursor.type === 'rect' && (
+                <>
+                    <div
+                        className="absolute pointer-events-none"
+                        style={{
+                            backgroundColor: color,
+                            left:
+                                Math.floor((cursorPos[0] - offsetX) / cursor.xFactor) * cursor.xFactor +
+                                offsetX -
+                                ((cursor.x - (cursor.x % 2)) / 2) * cursor.xFactor,
+                            top:
+                                Math.floor((cursorPos[1] - offsetY) / cursor.yFactor) * cursor.yFactor +
+                                offsetY -
+                                ((cursor.y - (cursor.y % 2)) / 2 - 1 + (cursor.y % 2)) * cursor.yFactor,
+                            width: cursor.x * cursor.xFactor,
+                            height: cursor.y * cursor.yFactor,
+                            opacity: 0.6,
+                        }}
+                    />
+                    <div
+                        className="absolute pointer-events-none bg-black dark:bg-white"
+                        style={{
+                            width: 16,
+                            height: 16,
+                            borderRadius: 16,
+                            opacity: 0.4,
+                            left: cursorPos[0] - 8,
+                            top: cursorPos[1] - 8,
+                        }}
+                    />
+                </>
+            )}
+            {showPreview && !cursorPos && cursor.type === 'rect' && (
+                <div
                     className="absolute pointer-events-none"
-                    color={color}
-                    factor={factor}
-                    dia={dia}
                     style={{
-                        left: Math.floor((cursorPos[0] - offsetX) / factor) * factor + offsetX - center * factor,
-                        top: Math.floor((cursorPos[1] - offsetY) / factor) * factor + offsetY - (center - 1 + (dia % 2)) * factor,
+                        backgroundColor: color,
+                        width: cursor.x * cursor.xFactor,
+                        height: cursor.y * cursor.yFactor,
+                        opacity: 0.6,
+                        left: `calc(50% - ${((cursor.x - (cursor.x % 2)) / 2) * cursor.xFactor}px)`,
+                        top: `calc(50% - ${((cursor.y - (cursor.y % 2)) / 2) * cursor.yFactor}px)`,
                     }}
                 />
             )}
-            {showPreview && !cursorPos && (
+            {cursorPos !== null && cursor.type === 'circle' && (
                 <PixelCursor
                     className="absolute pointer-events-none"
                     color={color}
-                    factor={factor}
-                    dia={dia}
+                    factor={cursor.factor}
+                    dia={cursor.dia}
                     style={{
-                        left: `calc(50% - ${center * factor}px)`,
-                        top: `calc(50% - ${center * factor}px)`,
+                        left:
+                            Math.floor((cursorPos[0] - offsetX) / cursor.factor) * cursor.factor +
+                            offsetX -
+                            ((cursor.dia - (cursor.dia % 2)) / 2) * cursor.factor,
+                        top:
+                            Math.floor((cursorPos[1] - offsetY) / cursor.factor) * cursor.factor +
+                            offsetY -
+                            ((cursor.dia - (cursor.dia % 2)) / 2 - 1 + (cursor.dia % 2)) * cursor.factor,
+                    }}
+                />
+            )}
+            {showPreview && !cursorPos && cursor.type === 'circle' && (
+                <PixelCursor
+                    className="absolute pointer-events-none"
+                    color={color}
+                    factor={cursor.factor}
+                    dia={cursor.dia}
+                    style={{
+                        left: `calc(50% - ${((cursor.dia - (cursor.dia % 2)) / 2) * cursor.factor}px)`,
+                        top: `calc(50% - ${((cursor.dia - (cursor.dia % 2)) / 2) * cursor.factor}px)`,
                     }}
                 />
             )}

--- a/packages/graphic-walker/src/components/painter/index.tsx
+++ b/packages/graphic-walker/src/components/painter/index.tsx
@@ -187,7 +187,7 @@ const PainterContent = (props: {
                 const rerender = throttle(() => res.view._renderer._render(scene.root), 100, { trailing: true });
                 resetRef.current = () => {
                     props.mapRef.current! = createMap([props.domainY, props.domainX]);
-                    const { name, color } = props.dict[0];
+                    const { name, color } = props.dict[1];
                     interactive.forEach((item) =>
                         sceneVisit(item, (item) => {
                             if ('datum' in item) {

--- a/packages/graphic-walker/src/components/painter/index.tsx
+++ b/packages/graphic-walker/src/components/painter/index.tsx
@@ -421,7 +421,7 @@ const Painter = ({ dark, themeConfig, themeKey }: { dark?: IDarkMode; themeConfi
                             setY(yf);
                             setLoading(false);
                         });
-                    } else {
+                    } else if (paintInfo.type === 'new') {
                         const getDomain = async (f: IViewField): Promise<IPaintDimension> => {
                             if (f.semanticType === 'quantitative') {
                                 const res = await fieldStat(compuation, f, { range: true, values: false, valuesMeta: false }, allFields);

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -119,10 +119,14 @@ export interface IPaintDimension {
     //   };
 }
 
-export interface IPaintMapV2 {
+export interface IPaintMapFacet {
     dimensions: IPaintDimension[];
     /** compressed array of UInt8[dimensions.reduce((x,d) => x * d.domain.width, 1)] */
     map: string;
+}
+
+export interface IPaintMapV2 {
+    facets: IPaintMapFacet[];
     dict: Record<number, { name: string; color: string }>;
     usedColor: number[];
 }

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -78,6 +78,7 @@ export interface IFieldStats {
     range: [number, number];
 }
 
+/** @deprecated */
 export interface IPaintMap {
     /** fid of x */
     x: string;
@@ -90,6 +91,30 @@ export interface IPaintMap {
     /** compressed array of UInt8[mapwidth][mapwidth] */
     map: string;
     /** map values */
+    dict: Record<number, { name: string; color: string }>;
+    usedColor: number[];
+}
+
+export interface IPaintDimension {
+    fid: string;
+    domain:
+        | {
+              type: 'nominal';
+              value: any[];
+              // = value.length
+              width: number;
+          }
+        | {
+              type: 'quantitative';
+              value: [number, number];
+              width: number;
+          };
+}
+
+export interface IPaintMapV2 {
+    dimensions: IPaintDimension[];
+    /** compressed array of UInt8[dimensions.reduce((x,d) => x * d.domain.width, 1)] */
+    map: string;
     dict: Record<number, { name: string; color: string }>;
     usedColor: number[];
 }
@@ -126,6 +151,10 @@ export type IExpParameter =
     | {
           type: 'sql';
           value: string;
+      }
+    | {
+          type: 'newmap';
+          value: IPaintMapV2;
       };
 
 export interface IExpression {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -109,6 +109,14 @@ export interface IPaintDimension {
               value: [number, number];
               width: number;
           };
+    // TODO: impement the temporal support
+    // | {
+    //       type: 'temporal';
+    //       value: [number, number];
+    //       width: number;
+    //       offset?: number;
+    //       format?: string;
+    //   };
 }
 
 export interface IPaintMapV2 {

--- a/packages/graphic-walker/src/lib/execExp.ts
+++ b/packages/graphic-walker/src/lib/execExp.ts
@@ -1,7 +1,7 @@
-import { IExpParameter, IExpression, IPaintMap, IRow } from '../interfaces';
+import { IExpParameter, IExpression, IPaintMap, IPaintMapV2, IRow } from '../interfaces';
 import dateTimeDrill from './op/dateTimeDrill';
 import dateTimeFeature from './op/dateTimeFeature';
-import { calcMap } from './paint';
+import { calcMap, calcMapV2 } from './paint';
 import { expr } from './sql';
 
 export interface IDataFrame {
@@ -140,12 +140,20 @@ function one(resKey: string, params: IExpParameter[], data: IDataFrame): IDataFr
 }
 
 async function paint(resKey: string, params: IExpParameter[], data: IDataFrame): Promise<IDataFrame> {
-    const param = params.find((x) => x.type === 'map');
-    if (!param) return data;
-    const map: IPaintMap = param.value;
+    const param = params.find((x) => x.type === 'newmap');
+    if (!param) {
+        const oldParam = params.find((x) => x.type === 'map');
+        if (!oldParam) return data;
+        const map: IPaintMap = oldParam.value;
+        return {
+            ...data,
+            [resKey]: await calcMap(data[map.x], data[map.y], map),
+        };
+    }
+    const map: IPaintMapV2 = param.value;
     return {
         ...data,
-        [resKey]: await calcMap(data[map.x], data[map.y], map),
+        [resKey]: await calcMapV2(dataframe2Dataset(data), map),
     };
 }
 

--- a/packages/graphic-walker/src/lib/paint.ts
+++ b/packages/graphic-walker/src/lib/paint.ts
@@ -179,24 +179,28 @@ export function calcIndexsV2(dimensions: IPaintDimension[]) {
 export function IPaintMapAdapter(paintMap: IPaintMap): IPaintMapV2 {
     return {
         dict: paintMap.dict,
-        map: paintMap.map,
         usedColor: paintMap.usedColor,
-        dimensions: [
+        facets: [
             {
-                fid: paintMap.y,
-                domain: {
-                    type: 'quantitative',
-                    value: paintMap.domainY,
-                    width: paintMap.mapwidth,
-                },
-            },
-            {
-                fid: paintMap.x,
-                domain: {
-                    type: 'quantitative',
-                    value: paintMap.domainX,
-                    width: paintMap.mapwidth,
-                },
+                map: paintMap.map,
+                dimensions: [
+                    {
+                        fid: paintMap.y,
+                        domain: {
+                            type: 'quantitative',
+                            value: paintMap.domainY,
+                            width: paintMap.mapwidth,
+                        },
+                    },
+                    {
+                        fid: paintMap.x,
+                        domain: {
+                            type: 'quantitative',
+                            value: paintMap.domainX,
+                            width: paintMap.mapwidth,
+                        },
+                    },
+                ],
             },
         ],
     };
@@ -209,8 +213,13 @@ export function IPaintMapAdapter(paintMap: IPaintMap): IPaintMapV2 {
  * @returns result
  */
 export async function calcMapV2(data: IRow[], paintMap: IPaintMapV2) {
-    const { dict, dimensions, map: raw } = paintMap;
-    const map = await decompressMap(raw);
-    const index = calcIndexsV2(dimensions);
-    return data.map(index).map((x) => dict[map[x]]?.name);
+    const { dict, facets } = paintMap;
+    let result = data.map(() => dict[1].name);
+    for (const { map: raw, dimensions } of facets) {
+        const map = await decompressMap(raw);
+        const index = calcIndexsV2(dimensions);
+        result = data.map(index).map((x, i) => (map[x] !== 0 ? dict[map[x]]?.name : result[i]));
+    }
+
+    return result;
 }

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -134,7 +134,7 @@
         "segments": {
             "vis": "Visualization",
             "data": "Data"
-        }, 
+        },
         "feedback": {
             "vote": "Is the result of Askviz good?",
             "voteup": "Yes",
@@ -203,8 +203,11 @@
                     "export_code": "Export Code",
                     "geojson": "Geography Configuration",
                     "painter": "Open Painter",
-                    "disabled_painter": "disable aggregation to create a paint",
-                    "disabled_painter_temporal": "painter doesn't support temporal fields now"
+                    "disabled_painter": {
+                        "aggergation": "disable aggregation to create a paint",
+                        "temporal": "painter doesn't support temporal fields now",
+                        "count": "drag single field on x and y to create a paint"
+                    }
                 },
                 "paint": {
                     "palette": "Palette",

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -203,7 +203,8 @@
                     "export_code": "Export Code",
                     "geojson": "Geography Configuration",
                     "painter": "Open Painter",
-                    "disabled_painter": "Use quantitative fields on XY and disable aggregation to create a paint"
+                    "disabled_painter": "disable aggregation to create a paint",
+                    "disabled_painter_temporal": "painter doesn't support temporal fields now"
                 },
                 "paint": {
                     "palette": "Palette",

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -197,7 +197,8 @@
                     "export_code": "コードをエクスポート",
                     "geojson": "地理情報設定",
                     "painter": "データキャンバスを開く",
-                    "disabled_painter": "データキャンバスを作るには数量尺度フィールドをXY軸に設置して集計をオフにするが必要"
+                    "disabled_painter": "データキャンバスを作るには集計をオフにするが必要",
+                    "disabled_painter_temporal": "時間的フィールドはまたデータキャンバスで使うことができない"
                 },
                 "paint": {
                     "palette": "パレット",

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -197,8 +197,11 @@
                     "export_code": "コードをエクスポート",
                     "geojson": "地理情報設定",
                     "painter": "データキャンバスを開く",
-                    "disabled_painter": "データキャンバスを作るには集計をオフにするが必要",
-                    "disabled_painter_temporal": "時間的フィールドはまたデータキャンバスで使うことができない"
+                    "disabled_painter": {
+                        "aggergation": "データキャンバスを作るには集計をオフにするが必要",
+                        "temporal": "時間的フィールドはまたデータキャンバスで使うことができない",
+                        "count": "データキャンバスを作るにはフィールドをXY軸に設置してください"
+                    }
                 },
                 "paint": {
                     "palette": "パレット",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -203,8 +203,11 @@
                     "export_code": "导出代码",
                     "geojson": "地理信息配置",
                     "painter": "打开数据绘板",
-                    "disabled_painter": "创建绘制字段需要关闭聚合",
-                    "disabled_painter_temporal": "绘制字段暂不支持时间字段"
+                    "disabled_painter": {
+                        "aggergation": "创建绘制字段需要关闭聚合",
+                        "temporal": "绘制字段暂不支持时间字段",
+                        "count": "在x和y轴上分别放置一个字段来创建绘制字段"
+                    }
                 },
                 "paint": {
                     "palette": "色板",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -203,7 +203,8 @@
                     "export_code": "导出代码",
                     "geojson": "地理信息配置",
                     "painter": "打开数据绘板",
-                    "disabled_painter": "创建绘制字段需要在XY轴使用数据类型并关闭聚合"
+                    "disabled_painter": "创建绘制字段需要关闭聚合",
+                    "disabled_painter_temporal": "绘制字段暂不支持时间字段"
                 },
                 "paint": {
                     "palette": "色板",

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -345,7 +345,7 @@ const actions: {
             );
         }
         const expression: IExpression =
-            'dimensions' in map
+            'facets' in map
                 ? { op: 'paint', as: PAINT_FIELD_ID, params: [{ type: 'newmap', value: map }] }
                 : {
                       op: 'paint',

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -267,6 +267,7 @@ export class VizSpecStore {
             }
             const col = columns[0];
             const row = rows[0];
+            // range on temporal need use a temporal Domain, which is not impemented
             if (col.semanticType === 'temporal' || row.semanticType === 'temporal') {
                 return null;
             }

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -263,13 +263,23 @@ export class VizSpecStore {
         if (!this.currentVis.config.defaultAggregated) {
             const { columns, rows } = this.currentEncodings;
             if (columns.length !== 1 || rows.length !== 1) {
-                return null;
+                return { type: 'error', key: 'count' }as const;
             }
             const col = columns[0];
             const row = rows[0];
             // range on temporal need use a temporal Domain, which is not impemented
             if (col.semanticType === 'temporal' || row.semanticType === 'temporal') {
-                return null;
+                return { type: 'error', key: 'temporal' }as const;
+            }
+            if (
+                col.aggName === 'expr' ||
+                row.aggName === 'expr' ||
+                col.fid === MEA_KEY_ID ||
+                col.fid === MEA_VAL_ID ||
+                row.fid === MEA_KEY_ID ||
+                row.fid === MEA_VAL_ID
+            ) {
+                return { type: 'error', key: 'count' } as const;
             }
             return {
                 type: 'new',
@@ -277,7 +287,7 @@ export class VizSpecStore {
                 y: row,
             } as const;
         }
-        return null;
+        return { type: 'error', key: 'aggergation' } as const;
     }
 
     private appendFilter(index: number, sourceKey: keyof Omit<DraggableFieldState, 'filters'>, sourceIndex: number) {

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -12,6 +12,7 @@ import type {
     IFilterField,
     IChartForExport,
     IMutField,
+    IPaintMapV2,
 } from '../interfaces';
 import { viewEncodingKeys, type VizSpecStore } from '../store/visualSpecStore';
 import { getFilterMeaAggKey, getMeaAggKey, getSort } from '.';
@@ -31,7 +32,7 @@ const walkExpression = (expression: IExpression, each: (field: string) => void):
             each(param.value.x);
             each(param.value.y);
         } else if (param.type === 'newmap') {
-            param.value.facets.flatMap(x => x.dimensions).forEach((x) => each(x.fid));
+            param.value.facets.flatMap((x) => x.dimensions).forEach((x) => each(x.fid));
         }
     }
 };
@@ -386,6 +387,25 @@ export const processExpression = (exp: IExpression, allFields: IMutField[]): IEx
                             ),
                             mapwidth: x.value.mapwidth,
                         } as IPaintMap,
+                    };
+                } else if (x.type === 'newmap') {
+                    const dict = {
+                        ...x.value.dict,
+                        '255': { name: '' },
+                    };
+                    return {
+                        type: 'newmap',
+                        value: {
+                            facets: x.value.facets,
+                            dict: Object.fromEntries(
+                                x.value.usedColor.map((i) => [
+                                    i,
+                                    {
+                                        name: dict[i].name,
+                                    },
+                                ])
+                            ),
+                        } as IPaintMapV2,
                     };
                 } else {
                     return x;

--- a/packages/graphic-walker/src/vis/spec/encode.ts
+++ b/packages/graphic-walker/src/vis/spec/encode.ts
@@ -1,5 +1,5 @@
 import { DATE_TIME_DRILL_LEVELS } from '../../constants';
-import { IPaintMap, IViewField } from '../../interfaces';
+import { IPaintMap, IPaintMapV2, IViewField } from '../../interfaces';
 import { NULL_FIELD } from './field';
 export interface IEncodeProps {
     geomType: string;
@@ -76,10 +76,10 @@ export function channelEncode(props: IEncodeProps) {
                     encoding[c].type = 'quantitative';
                 }
                 if (props[c].semanticType === 'temporal' && props[c].timeUnit) {
-                    encoding[c].timeUnit = encodeTimeunit(props[c].timeUnit);;
+                    encoding[c].timeUnit = encodeTimeunit(props[c].timeUnit);
                 }
                 if (c === 'color' && props[c].expression?.op === 'paint') {
-                    const map: IPaintMap = props[c].expression!.params.find((x) => x.type === 'map')!.value;
+                    const map: IPaintMap = props[c].expression!.params.find((x) => x.type === 'map' || x.type === 'newmap')!.value;
                     const colors = map.usedColor.map((x) => map.dict[x]).filter(Boolean);
                     encoding[c].scale = {
                         domain: colors.map((x) => x.name),

--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -78,6 +78,19 @@ interface IVisualSettings {
     experimentalFeatures?: IExperimentalFeatures;
 }
 
+const KanariesIcon = () => (
+    <a href="https://docs.kanaries.net" target="_blank">
+        <ImageWithFallback
+            id="kanaries-logo"
+            className="p-1.5 opacity-70 hover:opacity-100"
+            src="https://imagedelivery.net/tSvh1MGEu9IgUanmf58srQ/b6bc899f-a129-4c3a-d08f-d406166d0c00/public"
+            fallbackSrc={KanariesLogo}
+            timeout={1000}
+            alt="kanaries documents"
+        />
+    </a>
+)
+
 const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePreference, csvHandler, extra = [], exclude = [], experimentalFeatures }) => {
     const vizStore = useVizStore();
     const { config, layout, canUndo, canRedo, limit, paintInfo } = vizStore;
@@ -583,7 +596,7 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
             },
             {
                 key: 'painter',
-                label: paintInfo === null ? t('button.disabled_painter') : t('button.painter'),
+                label: paintInfo === null ? (defaultAggregated ? t('button.disabled_painter') : t('button.disabled_painter_temporal')) : t('button.painter'),
                 icon: PaintBrushIcon,
                 disabled: paintInfo === null,
                 onClick: () => {
@@ -594,19 +607,8 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
             {
                 key: 'kanaries',
                 label: 'kanaries docs',
-                icon: () => (
-                    // Kanaries brand info is not allowed to be removed or changed unless you are granted with special permission.
-                    <a href="https://docs.kanaries.net" target="_blank">
-                        <ImageWithFallback
-                            id="kanaries-logo"
-                            className="p-1.5 opacity-70 hover:opacity-100"
-                            src="https://imagedelivery.net/tSvh1MGEu9IgUanmf58srQ/b6bc899f-a129-4c3a-d08f-d406166d0c00/public"
-                            fallbackSrc={KanariesLogo}
-                            timeout={1000}
-                            alt="kanaries documents"
-                        />
-                    </a>
-                ),
+                // Kanaries brand info is not allowed to be removed or changed unless you are granted with special permission.
+                icon: KanariesIcon,
             },
         ].filter(Boolean) as ToolbarItemProps[];
 
@@ -639,7 +641,7 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
         limit,
         showTableSummary,
         experimentalFeatures,
-        paintInfo
+        paintInfo,
     ]);
 
     return (

--- a/packages/graphic-walker/src/visualSettings/index.tsx
+++ b/packages/graphic-walker/src/visualSettings/index.tsx
@@ -596,9 +596,9 @@ const VisualSettings: React.FC<IVisualSettings> = ({ rendererHandler, darkModePr
             },
             {
                 key: 'painter',
-                label: paintInfo === null ? (defaultAggregated ? t('button.disabled_painter') : t('button.disabled_painter_temporal')) : t('button.painter'),
+                label: paintInfo.type === 'error' ? t(`button.disabled_painter.${paintInfo.key}`) : t('button.painter'),
                 icon: PaintBrushIcon,
-                disabled: paintInfo === null,
+                disabled: paintInfo.type === 'error',
                 onClick: () => {
                     vizStore.setShowPainter(true);
                 },


### PR DESCRIPTION
Add support for nominal fields and ordinal fields in data painter.
![20240112160103_rec_](https://github.com/Kanaries/graphic-walker/assets/15280968/0b31339a-242e-4cee-9345-571332243eab)
Temproal fields is not support now.