### PR TITLE
fix: filter out agg field from fold

### DIFF
--- a/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
@@ -41,7 +41,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
     }, []);
 
     const foldOptions = useMemo<ISelectContextOption[]>(() => {
-        const validFoldBy = allFields.filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID);
+        const validFoldBy = allFields.filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID && f.aggName !== 'expr');
         return validFoldBy.map<ISelectContextOption>((f) => ({
             key: f.fid,
             label: f.name,

--- a/packages/graphic-walker/src/fields/obComponents/obPill.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obPill.tsx
@@ -32,7 +32,7 @@ const OBPill: React.FC<PillProps> = (props) => {
     }, []);
 
     const foldOptions = useMemo<ISelectContextOption[]>(() => {
-        const validFoldBy = allFields.filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID);
+        const validFoldBy = allFields.filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID && f.aggName !== 'expr');
         return validFoldBy.map<ISelectContextOption>((f) => ({
             key: f.fid,
             label: f.name,

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -314,7 +314,9 @@ const actions: {
         let data = originalData;
         const originalField = data.encodings[from][findex];
         if (!data.config.folds) {
-            const validFoldBy = [...data.encodings.measures, ...data.encodings.details].filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID);
+            const validFoldBy = [...data.encodings.measures, ...data.encodings.details].filter(
+                (f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID && f.aggName !== 'expr'
+            );
             data = actions[Methods.setConfig](
                 data,
                 'folds',
@@ -502,7 +504,7 @@ type reducerMiddleware<T> = (item: T, original: T) => T;
 
 const diffLinter: reducerMiddleware<IChart> = (item, original) => {
     const diffs = diffChangedEncodings(original, item);
-    if (Object.keys(diffs).length === 0) return item; 
+    if (Object.keys(diffs).length === 0) return item;
     return mutPath(item, 'encodings', (x) => ({ ...x, ...algebraLint(diffs), ...lintExtraFields(diffs) }));
 };
 


### PR DESCRIPTION
In #280 , when created a aggergation computed field, using it in Measure Fields will cause a error.
Currently there is no nice resolution for it, so just hide it from Measure Fields may be a good option.
this PR filtered the aggergation computed fields out from Measure Fields to avoid the error.  