### PR TITLE
feat: Add config to set timezone to displaying chart

### DIFF
--- a/packages/duckdb-wasm-computation/src/index.ts
+++ b/packages/duckdb-wasm-computation/src/index.ts
@@ -9,7 +9,8 @@ import initWasm, { parser_dsl_with_table } from '@kanaries-temp/gw-dsl-parser';
 import dslWasm from '@kanaries-temp/gw-dsl-parser/gw_dsl_parser_bg.wasm?url';
 import { nanoid } from 'nanoid';
 import { IDataSourceProvider, IMutField, IDataSourceListener, exportFullRaw, fromFields } from '@kanaries/graphic-walker';
-import { MapRow } from 'apache-arrow';
+import { Table } from 'apache-arrow';
+import { bigNumToString } from 'apache-arrow/util/bn';
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     mvp: {
@@ -44,6 +45,19 @@ export async function init() {
     URL.revokeObjectURL(worker_url);
     await initWasm(dslWasm);
 }
+
+const transformData = (table: Table) => {
+    return table
+        .toArray()
+        .map((r) =>
+            Object.fromEntries(
+                Object.entries(r.toJSON()).map(([k, v]) => [
+                    k,
+                    typeof v === 'object' ? parseInt(bigNumToString(v as any)) : typeof v === 'bigint' ? Number(v) : v,
+                ])
+            )
+        );
+};
 
 export async function getMemoryProvider(): Promise<IDataSourceProvider> {
     await init();
@@ -94,11 +108,7 @@ export async function getMemoryProvider(): Promise<IDataSourceProvider> {
             if (process.env.NODE_ENV !== 'production') {
                 console.log(query, sql);
             }
-            const res = await conn
-                .query(sql)
-                .then((x) =>
-                    x.toArray().map((r: MapRow) => Object.fromEntries(Object.entries(r.toJSON()).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])))
-                );
+            const res = await conn.query(sql).then(transformData);
             return res;
         },
         registerCallback(cb) {
@@ -132,11 +142,7 @@ export async function getComputation(data: Record<string, number>[]) {
             if (process.env.NODE_ENV !== 'production') {
                 console.log(query, sql);
             }
-            const res = await conn
-                .query(sql)
-                .then((x) =>
-                    x.toArray().map((r) => Object.fromEntries(Object.entries(r.toJSON()).map(([k, v]) => [k, typeof v === 'bigint' ? Number(v) : v])))
-                );
+            const res = await conn.query(sql).then(transformData);
             return res;
         },
     };

--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -66,7 +66,7 @@ export const TableApp = observer(function VizApp(props: BaseTableProps) {
                 <ComputationContext.Provider value={wrappedComputation}>
                     <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
                         <div className="bg-white dark:bg-zinc-900 dark:text-white">
-                            <DatasetTable size={pageSize} metas={metas} computation={wrappedComputation} />
+                            <DatasetTable size={pageSize} metas={metas} computation={wrappedComputation} displayOffset={props.displayOffset} />
                         </div>
                     </div>
                     <Errorpanel />

--- a/packages/graphic-walker/src/components/computedField/index.tsx
+++ b/packages/graphic-walker/src/components/computedField/index.tsx
@@ -4,7 +4,7 @@ import { useVizStore } from '../../store';
 import DefaultButton from '../button/default';
 import PrimaryButton from '../button/primary';
 import Modal from '../modal';
-import { parseErrorMessage } from '../../utils';
+import { isNotEmpty, parseErrorMessage } from '../../utils';
 import { highlightField } from '../highlightField';
 import { aggFuncs, reservedKeywords, sqlFunctions } from '../../lib/sql';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID, PAINT_FIELD_ID } from '../../constants';
@@ -53,7 +53,7 @@ const ComputedFieldDialog: React.FC = observer(() => {
     }, [vizStore.allFields]);
 
     useEffect(() => {
-        if (editingComputedFieldFid !== undefined) {
+        if (isNotEmpty(editingComputedFieldFid)) {
             if (editingComputedFieldFid === '') {
                 let idx = 1;
                 while (vizStore.allFields.find((x) => x.name === `Computed ${idx}`)) {
@@ -88,7 +88,7 @@ const ComputedFieldDialog: React.FC = observer(() => {
 
     return (
         <Modal
-            show={editingComputedFieldFid !== undefined}
+            show={isNotEmpty(editingComputedFieldFid)}
             onClose={() => {
                 vizStore.setComputedFieldFid();
             }}

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -21,6 +21,7 @@ interface DataTableProps {
     computation: IComputationFunction;
     onMetaChange?: (fid: string, fIndex: number, meta: Partial<IMutField>) => void;
     disableFilter?: boolean;
+    displayOffset?: number;
 }
 const Container = styled.div`
     overflow-x: auto;
@@ -161,16 +162,16 @@ function useFilters(metas: IMutField[]) {
     return { filters, options, editingFilterIdx, onSelectFilter, onDeleteFilter, onWriteFilter, onClose };
 }
 
-function FieldValue(props: { field: IMutField; item: IRow }) {
+function FieldValue(props: { field: IMutField; item: IRow; displayOffset?: number }) {
     const { field, item } = props;
     if (field.semanticType === 'temporal') {
-        return <>{formatDate(newOffsetDate(field.offset)(item[field.fid]))}</>;
+        return <>{formatDate(newOffsetDate(props.displayOffset)(newOffsetDate(field.offset)(item[field.fid])))}</>;
     }
     return <>{`${item[field.fid]}`}</>;
 }
 
 const DataTable: React.FC<DataTableProps> = (props) => {
-    const { size = 10, onMetaChange, metas, computation, disableFilter } = props;
+    const { size = 10, onMetaChange, metas, computation, disableFilter, displayOffset } = props;
     const [pageIndex, setPageIndex] = useState(0);
     const { t } = useTranslation();
     const computationFunction = computation;
@@ -406,7 +407,7 @@ const DataTable: React.FC<DataTableProps> = (props) => {
                                         key={field.fid + index}
                                         className={getHeaderType(field) + ' whitespace-nowrap py-2 px-4 text-xs text-gray-500 dark:text-gray-300'}
                                     >
-                                        <FieldValue field={field} item={row} />
+                                        <FieldValue field={field} item={row} displayOffset={displayOffset} />
                                     </td>
                                 ))}
                             </tr>
@@ -427,6 +428,7 @@ const DataTable: React.FC<DataTableProps> = (props) => {
                             onWriteFilter={onWriteFilter}
                             options={options}
                             viewFilters={filters}
+                            displayOffset={displayOffset}
                         />
                     </div>
                 </ComputationContext.Provider>

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -11,7 +11,7 @@ import { encodeFilterRule } from '../../utils/filter';
 import { PureFilterEditDialog } from '../../fields/filterField/filterEditDialog';
 import { BarsArrowDownIcon, BarsArrowUpIcon, FunnelIcon } from '@heroicons/react/24/outline';
 import { ComputationContext } from '../../store';
-import { newOffsetDate } from '../../lib/op/offset';
+import { parsedOffsetDate } from '../../lib/op/offset';
 import { formatDate } from '../../utils';
 
 interface DataTableProps {
@@ -165,7 +165,7 @@ function useFilters(metas: IMutField[]) {
 function FieldValue(props: { field: IMutField; item: IRow; displayOffset?: number }) {
     const { field, item } = props;
     if (field.semanticType === 'temporal') {
-        return <>{formatDate(newOffsetDate(props.displayOffset)(newOffsetDate(field.offset)(item[field.fid])))}</>;
+        return <>{formatDate(parsedOffsetDate(props.displayOffset, field.offset)(item[field.fid]))}</>;
     }
     return <>{`${item[field.fid]}`}</>;
 }

--- a/packages/graphic-walker/src/components/explainData/index.tsx
+++ b/packages/graphic-walker/src/components/explainData/index.tsx
@@ -1,197 +1,193 @@
-import React, { useEffect, useState, useRef, useMemo } from "react";
-import Modal from "../modal";
-import { observer } from "mobx-react-lite";
-import { useCompututaion, useVizStore } from "../../store";
-import { useTranslation } from "react-i18next";
+import React, { useEffect, useState, useRef, useMemo } from 'react';
+import Modal from '../modal';
+import { observer } from 'mobx-react-lite';
+import { useCompututaion, useVizStore } from '../../store';
+import { useTranslation } from 'react-i18next';
 import { getMeaAggKey } from '../../utils';
 import styled from 'styled-components';
-import embed from "vega-embed";
-import { VegaGlobalConfig, IDarkMode, IThemeKey, IField, IRow, IPredicate } from "../../interfaces";
+import embed from 'vega-embed';
+import { VegaGlobalConfig, IDarkMode, IThemeKey, IField, IRow, IPredicate } from '../../interfaces';
 import { builtInThemes } from '../../vis/theme';
-import { explainBySelection } from "../../lib/insights/explainBySelection"
+import { explainBySelection } from '../../lib/insights/explainBySelection';
 
 const Container = styled.div`
-  height: 50vh;
-  overflow-y: hidden;
+    height: 50vh;
+    overflow-y: hidden;
 `;
 const TabsList = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: stretch;
-  height: 100%;
-  overflow-y: scroll;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: stretch;
+    height: 100%;
+    overflow-y: scroll;
 `;
 
 const Tab = styled.div`
-  margin-block: 0.2em;
-  margin-inline: 0.2em;
-  padding: 0.5em;
-  border: 2px solid gray;
-  cursor: pointer;
+    margin-block: 0.2em;
+    margin-inline: 0.2em;
+    padding: 0.5em;
+    border: 2px solid gray;
+    cursor: pointer;
 `;
 
 const getCategoryName = (row: IRow, field: IField) => {
-  if (field.semanticType === "quantitative") {
-    let id = field.fid;
-    return `${row[id][0].toFixed(2)}-${row[id][1].toFixed(2)}`;
-  } else {
-    return row[field.fid];
-  }
-}
+    if (field.semanticType === 'quantitative') {
+        let id = field.fid;
+        return `${row[id][0].toFixed(2)}-${row[id][1].toFixed(2)}`;
+    } else {
+        return row[field.fid];
+    }
+};
 
 const ExplainData: React.FC<{
-  dark: IDarkMode, 
-  themeKey: IThemeKey
-}> = observer(({dark, themeKey}) => {
+    dark: IDarkMode;
+    themeKey: IThemeKey;
+}> = observer(({ dark, themeKey }) => {
     const vizStore = useVizStore();
     const computationFunction = useCompututaion();
-    const { allFields, viewMeasures, viewDimensions, viewFilters, showInsightBoard, selectedMarkObject } = vizStore;
-    const [ explainDataInfoList, setExplainDataInfoList ] = useState<{ 
-      score: number; 
-      measureField: IField; 
-      targetField: IField; 
-      normalizedData: IRow[]; 
-      normalizedParentData: IRow[] 
-    }[]>([]);
-    const [ selectedInfoIndex, setSelectedInfoIndex ] = useState(0);
+    const { allFields, viewMeasures, viewDimensions, viewFilters, showInsightBoard, selectedMarkObject, config } = vizStore;
+    const { timezoneDisplayOffset } = config;
+    const [explainDataInfoList, setExplainDataInfoList] = useState<
+        {
+            score: number;
+            measureField: IField;
+            targetField: IField;
+            normalizedData: IRow[];
+            normalizedParentData: IRow[];
+        }[]
+    >([]);
+    const [selectedInfoIndex, setSelectedInfoIndex] = useState(0);
     const chartRef = useRef<HTMLDivElement>(null);
 
     const vegaConfig = useMemo<VegaGlobalConfig>(() => {
-      const config: VegaGlobalConfig = {
-        ...builtInThemes[themeKey ?? 'vega']?.[dark],
-      }
-      return config;
-    }, [themeKey, dark])
+        const config: VegaGlobalConfig = {
+            ...builtInThemes[themeKey ?? 'vega']?.[dark],
+        };
+        return config;
+    }, [themeKey, dark]);
 
     const { t } = useTranslation();
-    
+
     const explain = async (predicates) => {
-      const explainInfoList = await explainBySelection({predicates, viewFilters, allFields, viewMeasures, viewDimensions, computationFunction});
-      setExplainDataInfoList(explainInfoList);
-    }
+        const explainInfoList = await explainBySelection({ predicates, viewFilters, allFields, viewMeasures, viewDimensions, computationFunction, timezoneDisplayOffset });
+        setExplainDataInfoList(explainInfoList);
+    };
 
     useEffect(() => {
-      if (!showInsightBoard || Object.keys(selectedMarkObject).length === 0) return;
-      const predicates: IPredicate[] = viewDimensions.map((field) => {
-          return {
-              key: field.fid,
-              type: "discrete",
-              range: new Set([selectedMarkObject[field.fid]])
-          } as IPredicate
-      });
-      explain(predicates)
+        if (!showInsightBoard || Object.keys(selectedMarkObject).length === 0) return;
+        const predicates: IPredicate[] = viewDimensions.map((field) => {
+            return {
+                key: field.fid,
+                type: 'discrete',
+                range: new Set([selectedMarkObject[field.fid]]),
+            } as IPredicate;
+        });
+        explain(predicates);
     }, [viewMeasures, viewDimensions, showInsightBoard, selectedMarkObject]);
 
     useEffect(() => {
-      if (chartRef.current && explainDataInfoList.length > 0) {
-        const { normalizedData, normalizedParentData, targetField, measureField } = explainDataInfoList[selectedInfoIndex];
-        const { semanticType: targetType, name: targetName, fid: targetId } = targetField;
-        const data = [
-          ...normalizedData.map((row) => ({
-            category: getCategoryName(row, targetField),
-            ...row,
-            type: "child",
-          })),
-          ...normalizedParentData.map((row) => ({
-            category: getCategoryName(row, targetField),
-            ...row,
-            type: "parent",
-          })),
-        ];
-        const xField = {
-          x: {
-            field: "category",
-            type: targetType === "quantitative" ? "ordinal" : targetType,
-            axis: {
-              title: `Distribution of Values for ${targetName}`,
-            },
-          },
-        };
-        const spec:any = {
-          data: {
-            values: data,
-          },
-          width: 320,
-          height: 200,
-          encoding: {
-            ...xField,
-            color: {
-              legend: {
-                orient: "bottom",
-              },
-            },
-          },
-          layer: [
-            {
-              mark: {
-                type: "bar",
-                width: 15,
-                opacity: 0.7,
-              },
-              encoding: {
-                y: {
-                  field: getMeaAggKey(measureField.fid, measureField.aggName),
-                  type: "quantitative",
-                  title: `${measureField.aggName} ${measureField.name} for All Marks`,
+        if (chartRef.current && explainDataInfoList.length > 0) {
+            const { normalizedData, normalizedParentData, targetField, measureField } = explainDataInfoList[selectedInfoIndex];
+            const { semanticType: targetType, name: targetName, fid: targetId } = targetField;
+            const data = [
+                ...normalizedData.map((row) => ({
+                    category: getCategoryName(row, targetField),
+                    ...row,
+                    type: 'child',
+                })),
+                ...normalizedParentData.map((row) => ({
+                    category: getCategoryName(row, targetField),
+                    ...row,
+                    type: 'parent',
+                })),
+            ];
+            const xField = {
+                x: {
+                    field: 'category',
+                    type: targetType === 'quantitative' ? 'ordinal' : targetType,
+                    axis: {
+                        title: `Distribution of Values for ${targetName}`,
+                    },
                 },
-                color: { datum: "All Marks" },
-              },
-              transform: [{ filter: "datum.type === 'parent'" }],
-            },
-            {
-              mark: {
-                type: "bar",
-                width: 10,
-                opacity: 0.7,
-              },
-              encoding: {
-                y: {
-                  field: getMeaAggKey(measureField.fid, measureField.aggName),
-                  type: "quantitative",
-                  title: `${measureField.aggName} ${measureField.name} for Selected Mark`,
+            };
+            const spec: any = {
+                data: {
+                    values: data,
                 },
-                color: { datum: "Selected Mark" },
-              },
-              transform: [{ filter: "datum.type === 'child'" }],
-            },
-          ],
-          resolve: { scale: { y: "independent" } },
-        };
-        
-        embed(chartRef.current, spec, { mode: 'vega-lite', actions: false, config: vegaConfig });
-      }
+                width: 320,
+                height: 200,
+                encoding: {
+                    ...xField,
+                    color: {
+                        legend: {
+                            orient: 'bottom',
+                        },
+                    },
+                },
+                layer: [
+                    {
+                        mark: {
+                            type: 'bar',
+                            width: 15,
+                            opacity: 0.7,
+                        },
+                        encoding: {
+                            y: {
+                                field: getMeaAggKey(measureField.fid, measureField.aggName),
+                                type: 'quantitative',
+                                title: `${measureField.aggName} ${measureField.name} for All Marks`,
+                            },
+                            color: { datum: 'All Marks' },
+                        },
+                        transform: [{ filter: "datum.type === 'parent'" }],
+                    },
+                    {
+                        mark: {
+                            type: 'bar',
+                            width: 10,
+                            opacity: 0.7,
+                        },
+                        encoding: {
+                            y: {
+                                field: getMeaAggKey(measureField.fid, measureField.aggName),
+                                type: 'quantitative',
+                                title: `${measureField.aggName} ${measureField.name} for Selected Mark`,
+                            },
+                            color: { datum: 'Selected Mark' },
+                        },
+                        transform: [{ filter: "datum.type === 'child'" }],
+                    },
+                ],
+                resolve: { scale: { y: 'independent' } },
+            };
+
+            embed(chartRef.current, spec, { mode: 'vega-lite', actions: false, config: vegaConfig });
+        }
     }, [explainDataInfoList, chartRef.current, selectedInfoIndex, vegaConfig]);
 
     return (
         <Modal
-          show={showInsightBoard}
-          onClose={() => {
-            vizStore.setShowInsightBoard(false);
-            setSelectedInfoIndex(0);
-          }}
+            show={showInsightBoard}
+            onClose={() => {
+                vizStore.setShowInsightBoard(false);
+                setSelectedInfoIndex(0);
+            }}
         >
-          <Container className="grid grid-cols-4">
-            <TabsList className="col-span-1">
-              {
-                explainDataInfoList.map((option, i) => {
-                    return (
-                      <Tab
-                        key={i}
-                        className={`${selectedInfoIndex === i ? 'border-indigo-400' : ''
-                        } text-xs`}
-                        onClick={() => setSelectedInfoIndex(i)}
-                      >
-                        {option.targetField.name} {option.score.toFixed(2)}
-                      </Tab>
-                    )
-                })
-              }
-            </TabsList>
-            <div className="col-span-3 text-center overflow-y-scroll">
-                <div ref={chartRef}></div>
-            </div>
-          </Container>
+            <Container className="grid grid-cols-4">
+                <TabsList className="col-span-1">
+                    {explainDataInfoList.map((option, i) => {
+                        return (
+                            <Tab key={i} className={`${selectedInfoIndex === i ? 'border-indigo-400' : ''} text-xs`} onClick={() => setSelectedInfoIndex(i)}>
+                                {option.targetField.name} {option.score.toFixed(2)}
+                            </Tab>
+                        );
+                    })}
+                </TabsList>
+                <div className="col-span-3 text-center overflow-y-scroll">
+                    <div ref={chartRef}></div>
+                </div>
+            </Container>
         </Modal>
     );
 });

--- a/packages/graphic-walker/src/components/leafletRenderer/encodings.ts
+++ b/packages/graphic-walker/src/components/leafletRenderer/encodings.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { scaleLinear, scaleOrdinal } from 'd3-scale';
 import type { IChannelScales, IRow, IScale, IViewField, VegaGlobalConfig } from '../../interfaces';
-import { getMeaAggKey } from '../../utils';
+import { getMeaAggKey, isNotEmpty } from '../../utils';
 import { getColor } from '../../utils/useTheme';
 import { resolveScale } from '../../vis/spec/view';
 
@@ -109,14 +109,14 @@ const useDomain = (key: string, data: IRow[], scale?: IScale) => {
                 minDomain = Number(scale.domain[0]);
                 maxDomain = Number(scale.domain[1]);
             }
-            if (scale.domainMin !== undefined) {
+            if (isNotEmpty(scale.domainMin)) {
                 minDomain = scale.domainMin;
             }
-            if (scale.domainMax !== undefined) {
+            if (isNotEmpty(scale.domainMax)) {
                 maxDomain = scale.domainMax;
             }
         }
-        if (minDomain !== undefined && maxDomain !== undefined) {
+        if (isNotEmpty(minDomain) && isNotEmpty(maxDomain)) {
             return [minDomain, maxDomain];
         }
         if (!key) {
@@ -151,10 +151,10 @@ const useRange = (defaultMin: number, defaultMax: number, scale?: IScale) => {
                 minRange = Number(scale.range[0]);
                 maxRange = Number(scale.range[1]);
             }
-            if (scale.rangeMin !== undefined) {
+            if (isNotEmpty(scale.rangeMin)) {
                 minRange = scale.rangeMin;
             }
-            if (scale.rangeMax !== undefined) {
+            if (isNotEmpty(scale.rangeMax)) {
                 maxRange = scale.rangeMax;
             }
         }

--- a/packages/graphic-walker/src/components/painter/index.tsx
+++ b/packages/graphic-walker/src/components/painter/index.tsx
@@ -110,6 +110,7 @@ const PainterContent = (props: {
     onChangeDict: (d: typeof defaultScheme) => void;
     paintMapRef: React.MutableRefObject<Uint8Array | undefined>;
     allFields: IViewField[];
+    displayOffset?: number;
     onReset: () => void;
     onDelete: () => void;
     onCancel: () => void;
@@ -146,6 +147,7 @@ const PainterContent = (props: {
         sort: 'none',
         viewDimensions: emptyField,
         viewMeasures: fields,
+        timezoneDisplayOffset: props.displayOffset,
     });
     const indexes = useMemo(() => viewData.map(calcIndexesByDimensions([props.domainY, props.domainX])), [viewData, props.domainX, props.domainY]);
     const [data, loadingResult] = useAsyncMemo(async () => {
@@ -452,7 +454,7 @@ function toZeroscaled([min, max]: [number, number]): [number, number] {
 const Painter = ({ dark, themeConfig, themeKey }: { dark?: IDarkMode; themeConfig?: GWGlobalConfig; themeKey?: IThemeKey }) => {
     const vizStore = useVizStore();
     const { showPainterPanel, allFields, layout, config } = vizStore;
-    const { geoms } = config;
+    const { geoms, timezoneDisplayOffset } = config;
     const { zeroScale } = layout;
     const { t } = useTranslation();
     const compuation = useCompututaion();
@@ -636,6 +638,7 @@ const Painter = ({ dark, themeConfig, themeKey }: { dark?: IDarkMode; themeConfi
                     onChangeDict={setDict}
                     paintMapRef={paintMapRef}
                     onReset={onReset}
+                    displayOffset={timezoneDisplayOffset}
                 />
             )}
         </Modal>

--- a/packages/graphic-walker/src/components/pivotTable/index.tsx
+++ b/packages/graphic-walker/src/components/pivotTable/index.tsx
@@ -154,8 +154,19 @@ const PivotTable: React.FC<PivotTableProps> = observer(function PivotTableCompon
         appRef.current?.updateRenderStatus('computing');
         const groupbyPromises: Promise<IRow[]>[] = groupbyCombList.map((dimComb) => {
             if (!vizStore) return Promise.resolve([]);
-            const { viewFilters, allFields, viewMeasures, sort, limit } = vizStore;
-            const workflow = toWorkflow(viewFilters, allFields, dimComb, viewMeasures, defaultAggregated, sort, folds ?? [], limit > 0 ? limit : undefined);
+            const { viewFilters, allFields, viewMeasures, sort, limit, config } = vizStore;
+            const { timezoneDisplayOffset } = config;
+            const workflow = toWorkflow(
+                viewFilters,
+                allFields,
+                dimComb,
+                viewMeasures,
+                defaultAggregated,
+                sort,
+                folds ?? [],
+                limit > 0 ? limit : undefined,
+                timezoneDisplayOffset
+            );
             return dataQuery(computation, workflow, limit > 0 ? limit : undefined)
                 .then((res) => fold2(res, defaultAggregated, allFields, viewMeasures, dimComb, folds))
                 .catch((err) => {

--- a/packages/graphic-walker/src/components/visualConfig/timezone.ts
+++ b/packages/graphic-walker/src/components/visualConfig/timezone.ts
@@ -1,130 +1,154 @@
 export const timezones = [
     {
-        value: 720,
-        name: '(UTC-12:00) International Date Line West',
+        "name": "(UTC-12:00) Etc/GMT+12",
+        "value": 720
     },
     {
-        value: 660,
-        name: '(UTC-11:00) Coordinated Universal Time-11',
+        "name": "(UTC-11:00) Etc/GMT+11, Pacific/Midway, Pacific/Niue, Pacific/Pago_Pago, Pacific/Samoa, US/Samoa",
+        "value": 660
     },
     {
-        value: 600,
-        name: '(UTC-10:00) Hawaii',
+        "name": "(UTC-10:00) America/Adak, America/Atka, Etc/GMT+10, HST, Pacific/Honolulu, Pacific/Johnston, Pacific/Rarotonga, Pacific/Tahiti, US/Aleutian, US/Hawaii",
+        "value": 600
     },
     {
-        value: 480,
-        name: '(UTC-09:00) Alaska, Pacific Standard Time (US & Canada',
+        "name": "(UTC-09:30) Pacific/Marquesas",
+        "value": 570
     },
     {
-        value: 420,
-        name: '(UTC-08:00) Baja California, Pacific Daylight Time (US & Canada, Arizona',
+        "name": "(UTC-09:00) America/Anchorage, America/Juneau, America/Metlakatla, America/Nome, America/Sitka, America/Yakutat, Etc/GMT+9, Pacific/Gambier, US/Alaska",
+        "value": 540
     },
     {
-        value: 360,
-        name: '(UTC-07:00) Chihuahua, La Paz, Mazatlan, Mountain Time (US & Canada, Central America, Saskatchewan',
+        "name": "(UTC-08:00) America/Ensenada, America/Los_Angeles, America/Santa_Isabel, America/Tijuana, America/Vancouver, Canada/Pacific, Etc/GMT+8, Mexico/BajaNorte, PST8PDT, Pacific/Pitcairn, US/Pacific",
+        "value": 480
     },
     {
-        value: 300,
-        name: '(UTC-06:00) Central Time (US & Canada, Guadalajara, Mexico City, Monterrey, Bogota, Lima, Quito, Eastern Time (US & Canada, Indiana (East',
+        "name": "(UTC-07:00) America/Boise, America/Cambridge_Bay, America/Ciudad_Juarez, America/Creston, America/Dawson, America/Dawson_Creek, America/Denver, America/Edmonton, America/Fort_Nelson, America/Hermosillo, America/Inuvik, America/Mazatlan, America/Phoenix, America/Shiprock, America/Whitehorse, America/Yellowknife, Canada/Mountain, Canada/Yukon, Etc/GMT+7, MST, MST7MDT, Mexico/BajaSur, Navajo, US/Arizona, US/Mountain",
+        "value": 420
     },
     {
-        value: 240,
-        name: '(UTC-04:00) Eastern Daylight Time (US & Canada, Asuncion, Cuiaba, Georgetown, La Paz, Manaus, San Juan, Santiago',
+        "name": "(UTC-06:00) America/Bahia_Banderas, America/Belize, America/Chicago, America/Chihuahua, America/Costa_Rica, America/El_Salvador, America/Guatemala, America/Indiana/Knox, America/Indiana/Tell_City, America/Knox_IN, America/Managua, America/Matamoros, America/Menominee, America/Merida, America/Mexico_City, America/Monterrey, America/North_Dakota/Beulah, America/North_Dakota/Center, America/North_Dakota/New_Salem, America/Ojinaga, America/Rainy_River, America/Rankin_Inlet, America/Regina, America/Resolute, America/Swift_Current, America/Tegucigalpa, America/Winnipeg, CST6CDT, Canada/Central, Canada/Saskatchewan, Etc/GMT+6, Mexico/General, Pacific/Galapagos, US/Central, US/Indiana-Starke",
+        "value": 360
     },
     {
-        value: 270,
-        name: '(UTC-04:30) Caracas',
+        "name": "(UTC-05:00) America/Atikokan, America/Bogota, America/Cancun, America/Cayman, America/Coral_Harbour, America/Detroit, America/Eirunepe, America/Fort_Wayne, America/Grand_Turk, America/Guayaquil, America/Havana, America/Indiana/Indianapolis, America/Indiana/Marengo, America/Indiana/Petersburg, America/Indiana/Vevay, America/Indiana/Vincennes, America/Indiana/Winamac, America/Indianapolis, America/Iqaluit, America/Jamaica, America/Kentucky/Louisville, America/Kentucky/Monticello, America/Lima, America/Louisville, America/Montreal, America/Nassau, America/New_York, America/Nipigon, America/Panama, America/Pangnirtung, America/Port-au-Prince, America/Porto_Acre, America/Rio_Branco, America/Thunder_Bay, America/Toronto, Brazil/Acre, Canada/Eastern, Chile/EasterIsland, Cuba, EST, EST5EDT, Etc/GMT+5, Jamaica, Pacific/Easter, US/East-Indiana, US/Eastern, US/Michigan",
+        "value": 300
     },
     {
-        value: 180,
-        name: '(UTC-04:00) Atlantic Time (Canada, Brasilia, Buenos Aires, Cayenne, Fortaleza, Greenland, Montevideo, Salvador',
+        "name": "(UTC-04:00) America/Anguilla, America/Antigua, America/Aruba, America/Barbados, America/Blanc-Sablon, America/Boa_Vista, America/Campo_Grande, America/Caracas, America/Cuiaba, America/Curacao, America/Dominica, America/Glace_Bay, America/Goose_Bay, America/Grenada, America/Guadeloupe, America/Guyana, America/Halifax, America/Kralendijk, America/La_Paz, America/Lower_Princes, America/Manaus, America/Marigot, America/Martinique, America/Moncton, America/Montserrat, America/Port_of_Spain, America/Porto_Velho, America/Puerto_Rico, America/Santo_Domingo, America/St_Barthelemy, America/St_Kitts, America/St_Lucia, America/St_Thomas, America/St_Vincent, America/Thule, America/Tortola, America/Virgin, Atlantic/Bermuda, Brazil/West, Canada/Atlantic, Etc/GMT+4",
+        "value": 240
     },
     {
-        value: 150,
-        name: '(UTC-03:30) Newfoundland',
+        "name": "(UTC-03:30) America/St_Johns, Canada/Newfoundland",
+        "value": 210
     },
     {
-        value: 120,
-        name: '(UTC-02:00) Coordinated Universal Time-02',
+        "name": "(UTC-03:00) America/Araguaina, America/Argentina/Buenos_Aires, America/Argentina/Catamarca, America/Argentina/ComodRivadavia, America/Argentina/Cordoba, America/Argentina/Jujuy, America/Argentina/La_Rioja, America/Argentina/Mendoza, America/Argentina/Rio_Gallegos, America/Argentina/Salta, America/Argentina/San_Juan, America/Argentina/San_Luis, America/Argentina/Tucuman, America/Argentina/Ushuaia, America/Asuncion, America/Bahia, America/Belem, America/Buenos_Aires, America/Catamarca, America/Cayenne, America/Cordoba, America/Fortaleza, America/Jujuy, America/Maceio, America/Mendoza, America/Miquelon, America/Montevideo, America/Paramaribo, America/Punta_Arenas, America/Recife, America/Rosario, America/Santarem, America/Santiago, America/Sao_Paulo, Antarctica/Palmer, Antarctica/Rothera, Atlantic/Stanley, Brazil/East, Chile/Continental, Etc/GMT+3",
+        "value": 180
     },
     {
-        value: 60,
-        name: '(UTC-02:00) Mid-Atlantic - Old, Cape Verde Is.',
+        "name": "(UTC-02:00) America/Godthab, America/Noronha, America/Nuuk, Atlantic/South_Georgia, Brazil/DeNoronha, Etc/GMT+2",
+        "value": 120
     },
     {
-        value: 0,
-        name: '(UTC-01:00) Azores, Coordinated Universal Time, Edinburgh, London, Monrovia, Reykjavik',
+        "name": "(UTC-01:00) America/Scoresbysund, Atlantic/Azores, Atlantic/Cape_Verde, Etc/GMT+1",
+        "value": 60
     },
     {
-        value: -60,
-        name: '(UTC) Casablanca, Edinburgh, London, Dublin, Lisbon, West Central Africa, Windhoek',
+        "name": "(UTC+00:00) Africa/Abidjan, Africa/Accra, Africa/Bamako, Africa/Banjul, Africa/Bissau, Africa/Conakry, Africa/Dakar, Africa/Freetown, Africa/Lome, Africa/Monrovia, Africa/Nouakchott, Africa/Ouagadougou, Africa/Sao_Tome, Africa/Timbuktu, America/Danmarkshavn, Antarctica/Troll, Atlantic/Canary, Atlantic/Faeroe, Atlantic/Faroe, Atlantic/Madeira, Atlantic/Reykjavik, Atlantic/St_Helena, Eire, Etc/GMT, Etc/GMT+0, Etc/GMT-0, Etc/GMT0, Etc/Greenwich, Etc/UCT, Etc/UTC, Etc/Universal, Etc/Zulu, Europe/Belfast, Europe/Dublin, Europe/Guernsey, Europe/Isle_of_Man, Europe/Jersey, Europe/Lisbon, Europe/London, GB, GB-Eire, GMT, GMT+0, GMT-0, GMT0, Greenwich, Iceland, Portugal, UCT, UTC, Universal, WET, Zulu",
+        "value": 0
     },
     {
-        value: -120,
-        name: '(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna, Belgrade, Bratislava, Budapest, Ljubljana, Prague, Brussels, Copenhagen, Madrid, Paris, Sarajevo, Skopje, Warsaw, Zagreb, Cairo, Harare, Pretoria, Tripoli',
+        "name": "(UTC+01:00) Africa/Algiers, Africa/Bangui, Africa/Brazzaville, Africa/Casablanca, Africa/Ceuta, Africa/Douala, Africa/El_Aaiun, Africa/Kinshasa, Africa/Lagos, Africa/Libreville, Africa/Luanda, Africa/Malabo, Africa/Ndjamena, Africa/Niamey, Africa/Porto-Novo, Africa/Tunis, Arctic/Longyearbyen, Atlantic/Jan_Mayen, CET, Etc/GMT-1, Europe/Amsterdam, Europe/Andorra, Europe/Belgrade, Europe/Berlin, Europe/Bratislava, Europe/Brussels, Europe/Budapest, Europe/Busingen, Europe/Copenhagen, Europe/Gibraltar, Europe/Ljubljana, Europe/Luxembourg, Europe/Madrid, Europe/Malta, Europe/Monaco, Europe/Oslo, Europe/Paris, Europe/Podgorica, Europe/Prague, Europe/Rome, Europe/San_Marino, Europe/Sarajevo, Europe/Skopje, Europe/Stockholm, Europe/Tirane, Europe/Vaduz, Europe/Vatican, Europe/Vienna, Europe/Warsaw, Europe/Zagreb, Europe/Zurich, MET, Poland",
+        "value": -60
     },
     {
-        value: -180,
-        name: '(UTC+02:00) Athens, Bucharest, Beirut, Damascus, E. Europe, Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius, Istanbul, Jerusalem, Amman, Baghdad, Kaliningrad, Kuwait, Riyadh, Nairobi, Moscow, St. Petersburg, Volgograd, Minsk',
+        "name": "(UTC+02:00) Africa/Blantyre, Africa/Bujumbura, Africa/Cairo, Africa/Gaborone, Africa/Harare, Africa/Johannesburg, Africa/Juba, Africa/Khartoum, Africa/Kigali, Africa/Lubumbashi, Africa/Lusaka, Africa/Maputo, Africa/Maseru, Africa/Mbabane, Africa/Tripoli, Africa/Windhoek, Asia/Beirut, Asia/Famagusta, Asia/Gaza, Asia/Hebron, Asia/Jerusalem, Asia/Nicosia, Asia/Tel_Aviv, EET, Egypt, Etc/GMT-2, Europe/Athens, Europe/Bucharest, Europe/Chisinau, Europe/Helsinki, Europe/Kaliningrad, Europe/Kiev, Europe/Kyiv, Europe/Mariehamn, Europe/Nicosia, Europe/Riga, Europe/Sofia, Europe/Tallinn, Europe/Tiraspol, Europe/Uzhgorod, Europe/Vilnius, Europe/Zaporozhye, Israel, Libya",
+        "value": -120
     },
     {
-        value: -240,
-        name: '(UTC+04:00) Samara, Ulyanovsk, Saratov, Abu Dhabi, Muscat, Port Louis, Tbilisi, Yerevan',
+        "name": "(UTC+03:00) Africa/Addis_Ababa, Africa/Asmara, Africa/Asmera, Africa/Dar_es_Salaam, Africa/Djibouti, Africa/Kampala, Africa/Mogadishu, Africa/Nairobi, Antarctica/Syowa, Asia/Aden, Asia/Amman, Asia/Baghdad, Asia/Bahrain, Asia/Damascus, Asia/Istanbul, Asia/Kuwait, Asia/Qatar, Asia/Riyadh, Etc/GMT-3, Europe/Istanbul, Europe/Kirov, Europe/Minsk, Europe/Moscow, Europe/Simferopol, Europe/Volgograd, Indian/Antananarivo, Indian/Comoro, Indian/Mayotte, Turkey, W-SU",
+        "value": -180
     },
     {
-        value: -270,
-        name: '(UTC+03:30) Tehran, Kabul',
+        "name": "(UTC+03:30) Asia/Tehran, Iran",
+        "value": -210
     },
     {
-        value: -300,
-        name: '(UTC+04:00) Baku, Ashgabat, Tashkent, Yekaterinburg, Islamabad, Karachi',
+        "name": "(UTC+04:00) Asia/Baku, Asia/Dubai, Asia/Muscat, Asia/Tbilisi, Asia/Yerevan, Etc/GMT-4, Europe/Astrakhan, Europe/Samara, Europe/Saratov, Europe/Ulyanovsk, Indian/Mahe, Indian/Mauritius, Indian/Reunion",
+        "value": -240
     },
     {
-        value: -330,
-        name: '(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi, Sri Jayawardenepura',
+        "name": "(UTC+04:30) Asia/Kabul",
+        "value": -270
     },
     {
-        value: -345,
-        name: '(UTC+05:45) Kathmandu',
+        "name": "(UTC+05:00) Antarctica/Mawson, Asia/Aqtau, Asia/Aqtobe, Asia/Ashgabat, Asia/Ashkhabad, Asia/Atyrau, Asia/Dushanbe, Asia/Karachi, Asia/Oral, Asia/Qyzylorda, Asia/Samarkand, Asia/Tashkent, Asia/Yekaterinburg, Etc/GMT-5, Indian/Kerguelen, Indian/Maldives",
+        "value": -300
     },
     {
-        value: -360,
-        name: '(UTC+06:00) Nur-Sultan (Astana, Dhaka',
+        "name": "(UTC+05:30) Asia/Calcutta, Asia/Colombo, Asia/Kolkata",
+        "value": -330
     },
     {
-        value: -390,
-        name: '(UTC+06:30) Yangon (Rangoon',
+        "name": "(UTC+05:45) Asia/Kathmandu, Asia/Katmandu",
+        "value": -345
     },
     {
-        value: -420,
-        name: '(UTC+07:00) Bangkok, Hanoi, Jakarta, Novosibirsk',
+        "name": "(UTC+06:00) Antarctica/Vostok, Asia/Almaty, Asia/Bishkek, Asia/Dacca, Asia/Dhaka, Asia/Kashgar, Asia/Omsk, Asia/Qostanay, Asia/Thimbu, Asia/Thimphu, Asia/Urumqi, Etc/GMT-6, Indian/Chagos",
+        "value": -360
     },
     {
-        value: -480,
-        name: '(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi, Krasnoyarsk, Kuala Lumpur, Singapore, Perth, Taipei, Ulaanbaatar, Irkutsk',
+        "name": "(UTC+06:30) Asia/Rangoon, Asia/Yangon, Indian/Cocos",
+        "value": -390
     },
     {
-        value: -540,
-        name: '(UTC+09:00) Osaka, Sapporo, Tokyo, Seoul, Yakutsk',
+        "name": "(UTC+07:00) Antarctica/Davis, Asia/Bangkok, Asia/Barnaul, Asia/Ho_Chi_Minh, Asia/Hovd, Asia/Jakarta, Asia/Krasnoyarsk, Asia/Novokuznetsk, Asia/Novosibirsk, Asia/Phnom_Penh, Asia/Pontianak, Asia/Saigon, Asia/Tomsk, Asia/Vientiane, Etc/GMT-7, Indian/Christmas",
+        "value": -420
     },
     {
-        value: -570,
-        name: '(UTC+09:30) Adelaide, Darwin',
+        "name": "(UTC+08:00) Asia/Shanghai, Asia/Brunei, Asia/Choibalsan, Asia/Chongqing, Asia/Chungking, Asia/Harbin, Asia/Hong_Kong, Asia/Irkutsk, Asia/Kuala_Lumpur, Asia/Kuching, Asia/Macao, Asia/Macau, Asia/Makassar, Asia/Manila, Asia/Singapore, Asia/Taipei, Asia/Ujung_Pandang, Asia/Ulaanbaatar, Asia/Ulan_Bator, Australia/Perth, Australia/West, Etc/GMT-8, Hongkong, PRC, ROC, Singapore",
+        "value": -480
     },
     {
-        value: -600,
-        name: '(UTC+10:00) Brisbane, Canberra, Melbourne, Sydney, Guam, Port Moresby, Hobart',
+        "name": "(UTC+08:45) Australia/Eucla",
+        "value": -525
     },
     {
-        value: -660,
-        name: '(UTC+11:00) Solomon Is., New Caledonia, Vladivostok',
+        "name": "(UTC+09:00) Asia/Chita, Asia/Dili, Asia/Jayapura, Asia/Khandyga, Asia/Pyongyang, Asia/Seoul, Asia/Tokyo, Asia/Yakutsk, Etc/GMT-9, Japan, Pacific/Palau, ROK",
+        "value": -540
     },
     {
-        value: -720,
-        name: '(UTC+12:00) Auckland, Wellington, Coordinated Universal Time+12, Fiji, Magadan',
+        "name": "(UTC+09:30) Australia/Darwin, Australia/North",
+        "value": -570
     },
     {
-        value: -780,
-        name: "(UTC+12:00) Petropavlovsk-Kamchatsky - Old, Nuku'alofa, Samoa",
+        "name": "(UTC+10:00) Antarctica/DumontDUrville, Asia/Ust-Nera, Asia/Vladivostok, Australia/Brisbane, Australia/Lindeman, Australia/Queensland, Etc/GMT-10, Pacific/Chuuk, Pacific/Guam, Pacific/Port_Moresby, Pacific/Saipan, Pacific/Truk, Pacific/Yap",
+        "value": -600
     },
+    {
+        "name": "(UTC+10:30) Australia/Adelaide, Australia/Broken_Hill, Australia/South, Australia/Yancowinna",
+        "value": -630
+    },
+    {
+        "name": "(UTC+11:00) Antarctica/Casey, Antarctica/Macquarie, Asia/Magadan, Asia/Sakhalin, Asia/Srednekolymsk, Australia/ACT, Australia/Canberra, Australia/Currie, Australia/Hobart, Australia/LHI, Australia/Lord_Howe, Australia/Melbourne, Australia/NSW, Australia/Sydney, Australia/Tasmania, Australia/Victoria, Etc/GMT-11, Pacific/Bougainville, Pacific/Efate, Pacific/Guadalcanal, Pacific/Kosrae, Pacific/Noumea, Pacific/Pohnpei, Pacific/Ponape",
+        "value": -660
+    },
+    {
+        "name": "(UTC+12:00) Asia/Anadyr, Asia/Kamchatka, Etc/GMT-12, Kwajalein, Pacific/Fiji, Pacific/Funafuti, Pacific/Kwajalein, Pacific/Majuro, Pacific/Nauru, Pacific/Norfolk, Pacific/Tarawa, Pacific/Wake, Pacific/Wallis",
+        "value": -720
+    },
+    {
+        "name": "(UTC+13:00) Antarctica/McMurdo, Antarctica/South_Pole, Etc/GMT-13, NZ, Pacific/Apia, Pacific/Auckland, Pacific/Enderbury, Pacific/Fakaofo, Pacific/Kanton, Pacific/Tongatapu",
+        "value": -780
+    },
+    {
+        "name": "(UTC+13:45) NZ-CHAT, Pacific/Chatham",
+        "value": -825
+    },
+    {
+        "name": "(UTC+14:00) Etc/GMT-14, Pacific/Kiritimati",
+        "value": -840
+    }
 ];

--- a/packages/graphic-walker/src/components/visualConfig/timezone.ts
+++ b/packages/graphic-walker/src/components/visualConfig/timezone.ts
@@ -1,0 +1,130 @@
+export const timezones = [
+    {
+        value: 720,
+        name: '(UTC-12:00) International Date Line West',
+    },
+    {
+        value: 660,
+        name: '(UTC-11:00) Coordinated Universal Time-11',
+    },
+    {
+        value: 600,
+        name: '(UTC-10:00) Hawaii',
+    },
+    {
+        value: 480,
+        name: '(UTC-09:00) Alaska, Pacific Standard Time (US & Canada',
+    },
+    {
+        value: 420,
+        name: '(UTC-08:00) Baja California, Pacific Daylight Time (US & Canada, Arizona',
+    },
+    {
+        value: 360,
+        name: '(UTC-07:00) Chihuahua, La Paz, Mazatlan, Mountain Time (US & Canada, Central America, Saskatchewan',
+    },
+    {
+        value: 300,
+        name: '(UTC-06:00) Central Time (US & Canada, Guadalajara, Mexico City, Monterrey, Bogota, Lima, Quito, Eastern Time (US & Canada, Indiana (East',
+    },
+    {
+        value: 240,
+        name: '(UTC-04:00) Eastern Daylight Time (US & Canada, Asuncion, Cuiaba, Georgetown, La Paz, Manaus, San Juan, Santiago',
+    },
+    {
+        value: 270,
+        name: '(UTC-04:30) Caracas',
+    },
+    {
+        value: 180,
+        name: '(UTC-04:00) Atlantic Time (Canada, Brasilia, Buenos Aires, Cayenne, Fortaleza, Greenland, Montevideo, Salvador',
+    },
+    {
+        value: 150,
+        name: '(UTC-03:30) Newfoundland',
+    },
+    {
+        value: 120,
+        name: '(UTC-02:00) Coordinated Universal Time-02',
+    },
+    {
+        value: 60,
+        name: '(UTC-02:00) Mid-Atlantic - Old, Cape Verde Is.',
+    },
+    {
+        value: 0,
+        name: '(UTC-01:00) Azores, Coordinated Universal Time, Edinburgh, London, Monrovia, Reykjavik',
+    },
+    {
+        value: -60,
+        name: '(UTC) Casablanca, Edinburgh, London, Dublin, Lisbon, West Central Africa, Windhoek',
+    },
+    {
+        value: -120,
+        name: '(UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna, Belgrade, Bratislava, Budapest, Ljubljana, Prague, Brussels, Copenhagen, Madrid, Paris, Sarajevo, Skopje, Warsaw, Zagreb, Cairo, Harare, Pretoria, Tripoli',
+    },
+    {
+        value: -180,
+        name: '(UTC+02:00) Athens, Bucharest, Beirut, Damascus, E. Europe, Helsinki, Kyiv, Riga, Sofia, Tallinn, Vilnius, Istanbul, Jerusalem, Amman, Baghdad, Kaliningrad, Kuwait, Riyadh, Nairobi, Moscow, St. Petersburg, Volgograd, Minsk',
+    },
+    {
+        value: -240,
+        name: '(UTC+04:00) Samara, Ulyanovsk, Saratov, Abu Dhabi, Muscat, Port Louis, Tbilisi, Yerevan',
+    },
+    {
+        value: -270,
+        name: '(UTC+03:30) Tehran, Kabul',
+    },
+    {
+        value: -300,
+        name: '(UTC+04:00) Baku, Ashgabat, Tashkent, Yekaterinburg, Islamabad, Karachi',
+    },
+    {
+        value: -330,
+        name: '(UTC+05:30) Chennai, Kolkata, Mumbai, New Delhi, Sri Jayawardenepura',
+    },
+    {
+        value: -345,
+        name: '(UTC+05:45) Kathmandu',
+    },
+    {
+        value: -360,
+        name: '(UTC+06:00) Nur-Sultan (Astana, Dhaka',
+    },
+    {
+        value: -390,
+        name: '(UTC+06:30) Yangon (Rangoon',
+    },
+    {
+        value: -420,
+        name: '(UTC+07:00) Bangkok, Hanoi, Jakarta, Novosibirsk',
+    },
+    {
+        value: -480,
+        name: '(UTC+08:00) Beijing, Chongqing, Hong Kong, Urumqi, Krasnoyarsk, Kuala Lumpur, Singapore, Perth, Taipei, Ulaanbaatar, Irkutsk',
+    },
+    {
+        value: -540,
+        name: '(UTC+09:00) Osaka, Sapporo, Tokyo, Seoul, Yakutsk',
+    },
+    {
+        value: -570,
+        name: '(UTC+09:30) Adelaide, Darwin',
+    },
+    {
+        value: -600,
+        name: '(UTC+10:00) Brisbane, Canberra, Melbourne, Sydney, Guam, Port Moresby, Hobart',
+    },
+    {
+        value: -660,
+        name: '(UTC+11:00) Solomon Is., New Caledonia, Vladivostok',
+    },
+    {
+        value: -720,
+        name: '(UTC+12:00) Auckland, Wellington, Coordinated Universal Time+12, Fiji, Magadan',
+    },
+    {
+        value: -780,
+        name: "(UTC+12:00) Petropavlovsk-Kamchatsky - Old, Nuku'alofa, Samoa",
+    },
+];

--- a/packages/graphic-walker/src/components/visualConfig/timezone.ts
+++ b/packages/graphic-walker/src/components/visualConfig/timezone.ts
@@ -1,154 +1,80 @@
 export const timezones = [
+    { value: 720, name: '(UTC-12:00) Dateline Standard Time' },
+    { value: 660, name: '(UTC-11:00) Niue Time, Samoa Standard Time' },
+    { value: 600, name: '(UTC-10:00) Cook Is. Time, Hawaii Standard Time, Tahiti Time' },
+    { value: 570, name: '(UTC-09:30) Marquesas Time' },
+    { value: 540, name: '(UTC-09:00) Gambier Time, Hawaii Daylight Time' },
+    { value: 480, name: '(UTC-08:00) Alaska Daylight Time, Pacific Standard Time, Pitcairn Standard Time' },
+    { value: 420, name: '(UTC-07:00) Mountain Standard Time, Pacific Daylight Time' },
+    { value: 360, name: '(UTC-06:00) Central Standard Time, Galapagos Time, Mountain Daylight Time' },
+    { value: 300, name: '(UTC-05:00) Acre Time, Central Daylight Time, Colombia Time, Easter Is. Time, Eastern Standard Time, Ecuador Time, Peru Time' },
+    { value: 270, name: '(UTC-04:30) Venezuela Time' },
     {
-        "name": "(UTC-12:00) Etc/GMT+12",
-        "value": 720
+        value: 240,
+        name: '(UTC-04:00) Amazon Time, Atlantic Standard Time, Bolivia Time, Cuba Daylight Time, Eastern Daylight Time, Guyana Time, Paraguay Time',
     },
     {
-        "name": "(UTC-11:00) Etc/GMT+11, Pacific/Midway, Pacific/Niue, Pacific/Pago_Pago, Pacific/Samoa, US/Samoa",
-        "value": 660
+        value: 180,
+        name: '(UTC-03:00) Argentine Time, Atlantic Daylight Time, Brasilia Time, Chile Time, Falkland Is. Time, French Guiana Time, Rothera Time, Suriname Time, Uruguay Time',
+    },
+    { value: 150, name: '(UTC-02:30) Newfoundland Daylight Time' },
+    {
+        value: 120,
+        name: '(UTC-02:00) Fernando de Noronha Time, Pierre & Miquelon Daylight Time, South Georgia Standard Time, Western Greenland Summer Time',
+    },
+    { value: 60, name: '(UTC-01:00) Cape Verde Time' },
+    { value: 0, name: '(UTC) Azores Summer Time, Coordinated Universal Time, Eastern Greenland Summer Time, Ghana Mean Time, Greenwich Mean Time' },
+    { value: -60, name: '(UTC+01:00) British Summer Time, Central European Time, Irish Summer Time, Western African Time, Western European Summer Time' },
+    {
+        value: -120,
+        name: '(UTC+02:00) Central African Time, Central European Summer Time, Eastern European Time, Middle Europe Summer Time, South Africa Standard Time',
     },
     {
-        "name": "(UTC-10:00) America/Adak, America/Atka, Etc/GMT+10, HST, Pacific/Honolulu, Pacific/Johnston, Pacific/Rarotonga, Pacific/Tahiti, US/Aleutian, US/Hawaii",
-        "value": 600
+        value: -180,
+        name: '(UTC+03:00) Arabia Standard Time, Eastern African Time, Eastern European Summer Time, Israel Daylight Time, Moscow Standard Time, Syowa Time',
+    },
+    { value: -240, name: '(UTC+04:00) Armenia Time, Georgia Time, Gulf Standard Time, Mauritius Time, Reunion Time, Samara Time, Seychelles Time' },
+    { value: -270, name: '(UTC+04:30) Afghanistan Time, Iran Daylight Time' },
+    {
+        value: -300,
+        name: '(UTC+05:00) Aqtau Time, Aqtobe Time, Azerbaijan Summer Time, French Southern & Antarctic Lands Time, Maldives Time, Mawson Time, Oral Time, Pakistan Time, Tajikistan Time, Turkmenistan Time, Uzbekistan Time, Yekaterinburg Time',
+    },
+    { value: -330, name: '(UTC+05:30) India Standard Time' },
+    { value: -345, name: '(UTC+05:45) Nepal Time' },
+    {
+        value: -360,
+        name: '(UTC+06:00) Alma-Ata Time, Bangladesh Time, Bhutan Time, Indian Ocean Territory Time, Kirgizstan Time, Novosibirsk Time, Omsk Time, Qyzylorda Time, Vostok Time, Xinjiang Standard Time',
+    },
+    { value: -390, name: '(UTC+06:30) Cocos Islands Time, Myanmar Time' },
+    { value: -420, name: '(UTC+07:00) Christmas Island Time, Davis Time, Indochina Time, Krasnoyarsk Time, West Indonesia Time' },
+    {
+        value: -480,
+        name: '(UTC+08:00) Australian Western Standard Time, Brunei Time, Central Indonesia Time, China Standard Time, Hong Kong Time, Hovd Summer Time, Irkutsk Time, Malaysia Time, Philippines Time, Singapore Time',
+    },
+    { value: -525, name: '(UTC+08:45) Australian Central Western Standard Time' },
+    {
+        value: -540,
+        name: '(UTC+09:00) Choibalsan Summer Time, East Indonesia Time, Japan Standard Time, Khandyga Time, Korea Standard Time, Palau Time, Timor-Leste Time, Ulaanbaatar Summer Time, Yakutsk Time',
     },
     {
-        "name": "(UTC-09:30) Pacific/Marquesas",
-        "value": 570
+        value: -570,
+        name: '(UTC+09:30) Australian Central Standard Time (Northern Territory), Australian Central Standard Time (South Australia), Australian Central Standard Time (South Australia/New South Wales)',
     },
     {
-        "name": "(UTC-09:00) America/Anchorage, America/Juneau, America/Metlakatla, America/Nome, America/Sitka, America/Yakutat, Etc/GMT+9, Pacific/Gambier, US/Alaska",
-        "value": 540
+        value: -600,
+        name: "(UTC+10:00) Australian Eastern Standard Time (New South Wales), Australian Eastern Standard Time (Queensland), Australian Eastern Standard Time (Tasmania), Australian Eastern Standard Time (Victoria), Chamorro Standard Time, Chuuk Time, Dumont-d'Urville Time, Magadan Time, Papua New Guinea Time, Sakhalin Time, Ust-Nera Time, Vladivostok Time",
     },
+    { value: -630, name: '(UTC+10:30) Lord Howe Standard Time' },
     {
-        "name": "(UTC-08:00) America/Ensenada, America/Los_Angeles, America/Santa_Isabel, America/Tijuana, America/Vancouver, Canada/Pacific, Etc/GMT+8, Mexico/BajaNorte, PST8PDT, Pacific/Pitcairn, US/Pacific",
-        "value": 480
+        value: -660,
+        name: '(UTC+11:00) Bougainville Standard Time, Kosrae Time, Macquarie Island Standard Time, New Caledonia Time, Pohnpei Time, Solomon Is. Time, Srednekolymsk Time, Vanuatu Time',
     },
+    { value: -690, name: '(UTC+11:30) Norfolk Time' },
     {
-        "name": "(UTC-07:00) America/Boise, America/Cambridge_Bay, America/Ciudad_Juarez, America/Creston, America/Dawson, America/Dawson_Creek, America/Denver, America/Edmonton, America/Fort_Nelson, America/Hermosillo, America/Inuvik, America/Mazatlan, America/Phoenix, America/Shiprock, America/Whitehorse, America/Yellowknife, Canada/Mountain, Canada/Yukon, Etc/GMT+7, MST, MST7MDT, Mexico/BajaSur, Navajo, US/Arizona, US/Mountain",
-        "value": 420
+        value: -720,
+        name: '(UTC+12:00) Anadyr Time, Fiji Time, Gilbert Is. Time, Marshall Islands Time, Nauru Time, New Zealand Standard Time, Petropavlovsk-Kamchatski Time, Tuvalu Time, Wake Time, Wallis & Futuna Time',
     },
-    {
-        "name": "(UTC-06:00) America/Bahia_Banderas, America/Belize, America/Chicago, America/Chihuahua, America/Costa_Rica, America/El_Salvador, America/Guatemala, America/Indiana/Knox, America/Indiana/Tell_City, America/Knox_IN, America/Managua, America/Matamoros, America/Menominee, America/Merida, America/Mexico_City, America/Monterrey, America/North_Dakota/Beulah, America/North_Dakota/Center, America/North_Dakota/New_Salem, America/Ojinaga, America/Rainy_River, America/Rankin_Inlet, America/Regina, America/Resolute, America/Swift_Current, America/Tegucigalpa, America/Winnipeg, CST6CDT, Canada/Central, Canada/Saskatchewan, Etc/GMT+6, Mexico/General, Pacific/Galapagos, US/Central, US/Indiana-Starke",
-        "value": 360
-    },
-    {
-        "name": "(UTC-05:00) America/Atikokan, America/Bogota, America/Cancun, America/Cayman, America/Coral_Harbour, America/Detroit, America/Eirunepe, America/Fort_Wayne, America/Grand_Turk, America/Guayaquil, America/Havana, America/Indiana/Indianapolis, America/Indiana/Marengo, America/Indiana/Petersburg, America/Indiana/Vevay, America/Indiana/Vincennes, America/Indiana/Winamac, America/Indianapolis, America/Iqaluit, America/Jamaica, America/Kentucky/Louisville, America/Kentucky/Monticello, America/Lima, America/Louisville, America/Montreal, America/Nassau, America/New_York, America/Nipigon, America/Panama, America/Pangnirtung, America/Port-au-Prince, America/Porto_Acre, America/Rio_Branco, America/Thunder_Bay, America/Toronto, Brazil/Acre, Canada/Eastern, Chile/EasterIsland, Cuba, EST, EST5EDT, Etc/GMT+5, Jamaica, Pacific/Easter, US/East-Indiana, US/Eastern, US/Michigan",
-        "value": 300
-    },
-    {
-        "name": "(UTC-04:00) America/Anguilla, America/Antigua, America/Aruba, America/Barbados, America/Blanc-Sablon, America/Boa_Vista, America/Campo_Grande, America/Caracas, America/Cuiaba, America/Curacao, America/Dominica, America/Glace_Bay, America/Goose_Bay, America/Grenada, America/Guadeloupe, America/Guyana, America/Halifax, America/Kralendijk, America/La_Paz, America/Lower_Princes, America/Manaus, America/Marigot, America/Martinique, America/Moncton, America/Montserrat, America/Port_of_Spain, America/Porto_Velho, America/Puerto_Rico, America/Santo_Domingo, America/St_Barthelemy, America/St_Kitts, America/St_Lucia, America/St_Thomas, America/St_Vincent, America/Thule, America/Tortola, America/Virgin, Atlantic/Bermuda, Brazil/West, Canada/Atlantic, Etc/GMT+4",
-        "value": 240
-    },
-    {
-        "name": "(UTC-03:30) America/St_Johns, Canada/Newfoundland",
-        "value": 210
-    },
-    {
-        "name": "(UTC-03:00) America/Araguaina, America/Argentina/Buenos_Aires, America/Argentina/Catamarca, America/Argentina/ComodRivadavia, America/Argentina/Cordoba, America/Argentina/Jujuy, America/Argentina/La_Rioja, America/Argentina/Mendoza, America/Argentina/Rio_Gallegos, America/Argentina/Salta, America/Argentina/San_Juan, America/Argentina/San_Luis, America/Argentina/Tucuman, America/Argentina/Ushuaia, America/Asuncion, America/Bahia, America/Belem, America/Buenos_Aires, America/Catamarca, America/Cayenne, America/Cordoba, America/Fortaleza, America/Jujuy, America/Maceio, America/Mendoza, America/Miquelon, America/Montevideo, America/Paramaribo, America/Punta_Arenas, America/Recife, America/Rosario, America/Santarem, America/Santiago, America/Sao_Paulo, Antarctica/Palmer, Antarctica/Rothera, Atlantic/Stanley, Brazil/East, Chile/Continental, Etc/GMT+3",
-        "value": 180
-    },
-    {
-        "name": "(UTC-02:00) America/Godthab, America/Noronha, America/Nuuk, Atlantic/South_Georgia, Brazil/DeNoronha, Etc/GMT+2",
-        "value": 120
-    },
-    {
-        "name": "(UTC-01:00) America/Scoresbysund, Atlantic/Azores, Atlantic/Cape_Verde, Etc/GMT+1",
-        "value": 60
-    },
-    {
-        "name": "(UTC+00:00) Africa/Abidjan, Africa/Accra, Africa/Bamako, Africa/Banjul, Africa/Bissau, Africa/Conakry, Africa/Dakar, Africa/Freetown, Africa/Lome, Africa/Monrovia, Africa/Nouakchott, Africa/Ouagadougou, Africa/Sao_Tome, Africa/Timbuktu, America/Danmarkshavn, Antarctica/Troll, Atlantic/Canary, Atlantic/Faeroe, Atlantic/Faroe, Atlantic/Madeira, Atlantic/Reykjavik, Atlantic/St_Helena, Eire, Etc/GMT, Etc/GMT+0, Etc/GMT-0, Etc/GMT0, Etc/Greenwich, Etc/UCT, Etc/UTC, Etc/Universal, Etc/Zulu, Europe/Belfast, Europe/Dublin, Europe/Guernsey, Europe/Isle_of_Man, Europe/Jersey, Europe/Lisbon, Europe/London, GB, GB-Eire, GMT, GMT+0, GMT-0, GMT0, Greenwich, Iceland, Portugal, UCT, UTC, Universal, WET, Zulu",
-        "value": 0
-    },
-    {
-        "name": "(UTC+01:00) Africa/Algiers, Africa/Bangui, Africa/Brazzaville, Africa/Casablanca, Africa/Ceuta, Africa/Douala, Africa/El_Aaiun, Africa/Kinshasa, Africa/Lagos, Africa/Libreville, Africa/Luanda, Africa/Malabo, Africa/Ndjamena, Africa/Niamey, Africa/Porto-Novo, Africa/Tunis, Arctic/Longyearbyen, Atlantic/Jan_Mayen, CET, Etc/GMT-1, Europe/Amsterdam, Europe/Andorra, Europe/Belgrade, Europe/Berlin, Europe/Bratislava, Europe/Brussels, Europe/Budapest, Europe/Busingen, Europe/Copenhagen, Europe/Gibraltar, Europe/Ljubljana, Europe/Luxembourg, Europe/Madrid, Europe/Malta, Europe/Monaco, Europe/Oslo, Europe/Paris, Europe/Podgorica, Europe/Prague, Europe/Rome, Europe/San_Marino, Europe/Sarajevo, Europe/Skopje, Europe/Stockholm, Europe/Tirane, Europe/Vaduz, Europe/Vatican, Europe/Vienna, Europe/Warsaw, Europe/Zagreb, Europe/Zurich, MET, Poland",
-        "value": -60
-    },
-    {
-        "name": "(UTC+02:00) Africa/Blantyre, Africa/Bujumbura, Africa/Cairo, Africa/Gaborone, Africa/Harare, Africa/Johannesburg, Africa/Juba, Africa/Khartoum, Africa/Kigali, Africa/Lubumbashi, Africa/Lusaka, Africa/Maputo, Africa/Maseru, Africa/Mbabane, Africa/Tripoli, Africa/Windhoek, Asia/Beirut, Asia/Famagusta, Asia/Gaza, Asia/Hebron, Asia/Jerusalem, Asia/Nicosia, Asia/Tel_Aviv, EET, Egypt, Etc/GMT-2, Europe/Athens, Europe/Bucharest, Europe/Chisinau, Europe/Helsinki, Europe/Kaliningrad, Europe/Kiev, Europe/Kyiv, Europe/Mariehamn, Europe/Nicosia, Europe/Riga, Europe/Sofia, Europe/Tallinn, Europe/Tiraspol, Europe/Uzhgorod, Europe/Vilnius, Europe/Zaporozhye, Israel, Libya",
-        "value": -120
-    },
-    {
-        "name": "(UTC+03:00) Africa/Addis_Ababa, Africa/Asmara, Africa/Asmera, Africa/Dar_es_Salaam, Africa/Djibouti, Africa/Kampala, Africa/Mogadishu, Africa/Nairobi, Antarctica/Syowa, Asia/Aden, Asia/Amman, Asia/Baghdad, Asia/Bahrain, Asia/Damascus, Asia/Istanbul, Asia/Kuwait, Asia/Qatar, Asia/Riyadh, Etc/GMT-3, Europe/Istanbul, Europe/Kirov, Europe/Minsk, Europe/Moscow, Europe/Simferopol, Europe/Volgograd, Indian/Antananarivo, Indian/Comoro, Indian/Mayotte, Turkey, W-SU",
-        "value": -180
-    },
-    {
-        "name": "(UTC+03:30) Asia/Tehran, Iran",
-        "value": -210
-    },
-    {
-        "name": "(UTC+04:00) Asia/Baku, Asia/Dubai, Asia/Muscat, Asia/Tbilisi, Asia/Yerevan, Etc/GMT-4, Europe/Astrakhan, Europe/Samara, Europe/Saratov, Europe/Ulyanovsk, Indian/Mahe, Indian/Mauritius, Indian/Reunion",
-        "value": -240
-    },
-    {
-        "name": "(UTC+04:30) Asia/Kabul",
-        "value": -270
-    },
-    {
-        "name": "(UTC+05:00) Antarctica/Mawson, Asia/Aqtau, Asia/Aqtobe, Asia/Ashgabat, Asia/Ashkhabad, Asia/Atyrau, Asia/Dushanbe, Asia/Karachi, Asia/Oral, Asia/Qyzylorda, Asia/Samarkand, Asia/Tashkent, Asia/Yekaterinburg, Etc/GMT-5, Indian/Kerguelen, Indian/Maldives",
-        "value": -300
-    },
-    {
-        "name": "(UTC+05:30) Asia/Calcutta, Asia/Colombo, Asia/Kolkata",
-        "value": -330
-    },
-    {
-        "name": "(UTC+05:45) Asia/Kathmandu, Asia/Katmandu",
-        "value": -345
-    },
-    {
-        "name": "(UTC+06:00) Antarctica/Vostok, Asia/Almaty, Asia/Bishkek, Asia/Dacca, Asia/Dhaka, Asia/Kashgar, Asia/Omsk, Asia/Qostanay, Asia/Thimbu, Asia/Thimphu, Asia/Urumqi, Etc/GMT-6, Indian/Chagos",
-        "value": -360
-    },
-    {
-        "name": "(UTC+06:30) Asia/Rangoon, Asia/Yangon, Indian/Cocos",
-        "value": -390
-    },
-    {
-        "name": "(UTC+07:00) Antarctica/Davis, Asia/Bangkok, Asia/Barnaul, Asia/Ho_Chi_Minh, Asia/Hovd, Asia/Jakarta, Asia/Krasnoyarsk, Asia/Novokuznetsk, Asia/Novosibirsk, Asia/Phnom_Penh, Asia/Pontianak, Asia/Saigon, Asia/Tomsk, Asia/Vientiane, Etc/GMT-7, Indian/Christmas",
-        "value": -420
-    },
-    {
-        "name": "(UTC+08:00) Asia/Shanghai, Asia/Brunei, Asia/Choibalsan, Asia/Chongqing, Asia/Chungking, Asia/Harbin, Asia/Hong_Kong, Asia/Irkutsk, Asia/Kuala_Lumpur, Asia/Kuching, Asia/Macao, Asia/Macau, Asia/Makassar, Asia/Manila, Asia/Singapore, Asia/Taipei, Asia/Ujung_Pandang, Asia/Ulaanbaatar, Asia/Ulan_Bator, Australia/Perth, Australia/West, Etc/GMT-8, Hongkong, PRC, ROC, Singapore",
-        "value": -480
-    },
-    {
-        "name": "(UTC+08:45) Australia/Eucla",
-        "value": -525
-    },
-    {
-        "name": "(UTC+09:00) Asia/Chita, Asia/Dili, Asia/Jayapura, Asia/Khandyga, Asia/Pyongyang, Asia/Seoul, Asia/Tokyo, Asia/Yakutsk, Etc/GMT-9, Japan, Pacific/Palau, ROK",
-        "value": -540
-    },
-    {
-        "name": "(UTC+09:30) Australia/Darwin, Australia/North",
-        "value": -570
-    },
-    {
-        "name": "(UTC+10:00) Antarctica/DumontDUrville, Asia/Ust-Nera, Asia/Vladivostok, Australia/Brisbane, Australia/Lindeman, Australia/Queensland, Etc/GMT-10, Pacific/Chuuk, Pacific/Guam, Pacific/Port_Moresby, Pacific/Saipan, Pacific/Truk, Pacific/Yap",
-        "value": -600
-    },
-    {
-        "name": "(UTC+10:30) Australia/Adelaide, Australia/Broken_Hill, Australia/South, Australia/Yancowinna",
-        "value": -630
-    },
-    {
-        "name": "(UTC+11:00) Antarctica/Casey, Antarctica/Macquarie, Asia/Magadan, Asia/Sakhalin, Asia/Srednekolymsk, Australia/ACT, Australia/Canberra, Australia/Currie, Australia/Hobart, Australia/LHI, Australia/Lord_Howe, Australia/Melbourne, Australia/NSW, Australia/Sydney, Australia/Tasmania, Australia/Victoria, Etc/GMT-11, Pacific/Bougainville, Pacific/Efate, Pacific/Guadalcanal, Pacific/Kosrae, Pacific/Noumea, Pacific/Pohnpei, Pacific/Ponape",
-        "value": -660
-    },
-    {
-        "name": "(UTC+12:00) Asia/Anadyr, Asia/Kamchatka, Etc/GMT-12, Kwajalein, Pacific/Fiji, Pacific/Funafuti, Pacific/Kwajalein, Pacific/Majuro, Pacific/Nauru, Pacific/Norfolk, Pacific/Tarawa, Pacific/Wake, Pacific/Wallis",
-        "value": -720
-    },
-    {
-        "name": "(UTC+13:00) Antarctica/McMurdo, Antarctica/South_Pole, Etc/GMT-13, NZ, Pacific/Apia, Pacific/Auckland, Pacific/Enderbury, Pacific/Fakaofo, Pacific/Kanton, Pacific/Tongatapu",
-        "value": -780
-    },
-    {
-        "name": "(UTC+13:45) NZ-CHAT, Pacific/Chatham",
-        "value": -825
-    },
-    {
-        "name": "(UTC+14:00) Etc/GMT-14, Pacific/Kiritimati",
-        "value": -840
-    }
+    { value: -765, name: '(UTC+12:45) Chatham Standard Time' },
+    { value: -780, name: '(UTC+13:00) Phoenix Is. Time, Tokelau Time, Tonga Time, West Samoa Standard Time' },
+    { value: -840, name: '(UTC+14:00) Line Is. Time' },
 ];

--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -88,13 +88,8 @@ export const dataReadRaw = async (
 };
 
 export const dataQuery = async (service: IComputationFunction, workflow: IDataQueryWorkflowStep[], limit?: number): Promise<IRow[]> => {
-    const viewWorkflow = workflow.find(x => x.type === 'view') as IViewWorkflowStep | undefined;
-    if (
-        viewWorkflow &&
-        viewWorkflow.query.length === 1 &&
-        viewWorkflow.query[0].op === 'raw' &&
-        viewWorkflow.query[0].fields.length === 0
-    ) {
+    const viewWorkflow = workflow.find((x) => x.type === 'view') as IViewWorkflowStep | undefined;
+    if (viewWorkflow && viewWorkflow.query.length === 1 && viewWorkflow.query[0].op === 'raw' && viewWorkflow.query[0].fields.length === 0) {
         return [];
     }
     const res = await service({
@@ -411,12 +406,14 @@ export async function getTemporalRange(service: IComputationFunction, field: str
                                 agg: 'min',
                                 asFieldKey: MIN_ID,
                                 format,
+                                offset: offset ?? defaultOffset,
                             },
                             {
                                 field,
                                 agg: 'max',
                                 asFieldKey: MAX_ID,
                                 format,
+                                offset: offset ?? defaultOffset,
                             },
                         ],
                     },

--- a/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
+++ b/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
@@ -15,6 +15,7 @@ const DatasetConfig: React.FC = () => {
                 size={100}
                 metas={metas}
                 computation={computation}
+                displayOffset={vizStore.config.timezoneDisplayOffset}
                 onMetaChange={(fid, fIndex, diffMeta) => {
                     vizStore.updateCurrentDatasetMetas(fid, diffMeta);
                 }}

--- a/packages/graphic-walker/src/dataSource/index.tsx
+++ b/packages/graphic-walker/src/dataSource/index.tsx
@@ -29,7 +29,7 @@ const DataSourceSegment: React.FC<DSSegmentProps> = observer((props) => {
 
     const { showDSPanel } = commonStore;
     return (
-        <div className="flex items-center m-4 p-4 border border-gray-200 dark:border-gray-700">
+        <div className="font-sans flex items-center m-4 p-4 border border-gray-200 dark:border-gray-700">
             {props.onLoad && <GwFile onImport={props.onLoad} fileRef={gwFileRef} />}
             {/* <label className="text-xs mr-1 whitespace-nowrap self-center h-4">
                 {t("DataSource.labels.cur_dataset")}

--- a/packages/graphic-walker/src/dataSource/index.tsx
+++ b/packages/graphic-walker/src/dataSource/index.tsx
@@ -96,6 +96,7 @@ function once<T extends (...args: any[]) => any>(register: (x: T) => () => void,
 
 export function DataSourceSegmentComponent(props: {
     provider: IDataSourceProvider;
+    displayOffset?: number;
     children: (props: {
         meta: IMutField[];
         onMetaChange: (fid: string, meta: Partial<IMutField>) => void;
@@ -170,7 +171,11 @@ export function DataSourceSegmentComponent(props: {
         [props.provider, selectedId]
     );
 
-    const commonStore = useMemo(() => new CommonStore(props.provider, setSelectedId), [props.provider]);
+    const commonStore = useMemo(() => new CommonStore(props.provider, setSelectedId, { displayOffset: props.displayOffset }), [props.provider]);
+
+    useEffect(() => {
+        commonStore.setDisplayOffset(props.displayOffset);
+    }, [props.displayOffset, commonStore]);
 
     const onLoad = useMemo(() => {
         const importFile = props.provider.onImportFile;

--- a/packages/graphic-walker/src/dataSource/table.tsx
+++ b/packages/graphic-walker/src/dataSource/table.tsx
@@ -11,7 +11,7 @@ interface TableProps {
 }
 
 const Table: React.FC<TableProps> = ({ commonStore, size = 10 }) => {
-    const { tmpDSRawFields, tmpDataSource } = commonStore;
+    const { tmpDSRawFields, tmpDataSource, displayOffset } = commonStore;
 
     const metas = toJS(tmpDSRawFields);
 
@@ -23,6 +23,7 @@ const Table: React.FC<TableProps> = ({ commonStore, size = 10 }) => {
                 size={size}
                 metas={metas}
                 computation={computation}
+                displayOffset={displayOffset}
                 onMetaChange={(fid, fIndex, diffMeta) => {
                     commonStore.updateTempDatasetMetas(fid, diffMeta);
                 }}

--- a/packages/graphic-walker/src/fields/datasetFields/utils.ts
+++ b/packages/graphic-walker/src/fields/datasetFields/utils.ts
@@ -15,7 +15,6 @@ export const useMenuActions = (channel: 'dimensions' | 'measures'): IActionMenuI
     const fields = vizStore.currentVis.encodings[channel];
     const { t } = useTranslation('translation', { keyPrefix: 'field_menu' });
     const computation = useCompututaion();
-    const defaultOffset = new Date().getTimezoneOffset();
 
     return useMemo<IActionMenuItem[][]>(() => {
         return fields.map((f, index) => {
@@ -119,7 +118,7 @@ export const useMenuActions = (channel: 'dimensions' | 'measures'): IActionMenuI
                                         level,
                                         `${t(`drill.levels.${level}`)} (${originField.name || originField.fid})`,
                                         format,
-                                        f.offset ?? defaultOffset
+                                        f.offset
                                     )
                                 );
                         },
@@ -147,7 +146,7 @@ export const useMenuActions = (channel: 'dimensions' | 'measures'): IActionMenuI
                                         level,
                                         `${t(`drill.levels.${level}`)} [${originField.name || originField.fid}]`,
                                         format,
-                                        f.offset ?? defaultOffset
+                                        f.offset
                                     )
                                 );
                         },

--- a/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterEditDialog.tsx
@@ -21,20 +21,20 @@ const aggregationList = GLOBAL_CONFIG.AGGREGATOR_LIST.map(
     })
 ).concat([{ label: '-', value: '' }]);
 
-const QuantitativeRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange }) => {
-    return <Tabs field={field} onChange={onChange} tabs={['range', 'one of']} rawFields={rawFields} />;
+const QuantitativeRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange, displayOffset }) => {
+    return <Tabs field={field} onChange={onChange} tabs={['range', 'one of']} rawFields={rawFields} displayOffset={displayOffset} />;
 };
 
-const NominalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange }) => {
-    return <Tabs field={field} onChange={onChange} tabs={['one of']} rawFields={rawFields} />;
+const NominalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange, displayOffset }) => {
+    return <Tabs field={field} onChange={onChange} tabs={['one of']} rawFields={rawFields} displayOffset={displayOffset} />;
 };
 
-const OrdinalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange }) => {
-    return <Tabs field={field} onChange={onChange} tabs={['range', 'one of']} rawFields={rawFields} />;
+const OrdinalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange, displayOffset }) => {
+    return <Tabs field={field} onChange={onChange} tabs={['range', 'one of']} rawFields={rawFields} displayOffset={displayOffset} />;
 };
 
-const TemporalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange }) => {
-    return <Tabs field={field} onChange={onChange} tabs={['temporal range', 'one of']} rawFields={rawFields} />;
+const TemporalRuleForm: React.FC<RuleFormProps> = ({ rawFields, field, onChange, displayOffset }) => {
+    return <Tabs field={field} onChange={onChange} tabs={['temporal range', 'one of']} rawFields={rawFields} displayOffset={displayOffset} />;
 };
 
 const EmptyForm: React.FC<RuleFormProps> = () => <React.Fragment />;
@@ -44,6 +44,7 @@ export const PureFilterEditDialog = (props: {
     options: { label: string; value: string }[];
     meta: IMutField[];
     editingFilterIdx: number | null;
+    displayOffset?: number;
     onSelectFilter: (field: string) => void;
     onWriteFilter: (index: number, rule: IFilterRule | null) => void;
     onSelectAgg?: (index: number, aggName: IAggregator | null) => void;
@@ -115,7 +116,7 @@ export const PureFilterEditDialog = (props: {
                         </div>
                     )}
                 </div>
-                <Form rawFields={meta} key={getFilterMeaAggKey(uncontrolledField)} field={uncontrolledField} onChange={handleChange} />
+                <Form rawFields={meta} key={getFilterMeaAggKey(uncontrolledField)} field={uncontrolledField} onChange={handleChange} displayOffset={props.displayOffset} />
                 <div className="mt-4">
                     <PrimaryButton onClick={handleSubmit} text={t('btn.confirm')} />
                     <DefaultButton className="ml-2" onClick={onClose} text={t('btn.cancel')} />
@@ -127,7 +128,8 @@ export const PureFilterEditDialog = (props: {
 
 const FilterEditDialog: React.FC = observer(() => {
     const vizStore = useVizStore();
-    const { editingFilterIdx, viewFilters, dimensions, measures, meta, allFields, viewDimensions } = vizStore;
+    const { editingFilterIdx, viewFilters, dimensions, measures, meta, allFields, viewDimensions, config } = vizStore;
+    const { timezoneDisplayOffset } = config;
 
     const computation = useCompututaion();
 
@@ -142,7 +144,17 @@ const FilterEditDialog: React.FC = observer(() => {
 
     const transformedComputation = useMemo((): IComputationFunction => {
         if (originalField && viewDimensions.length > 0) {
-            const preWorkflow = toWorkflow([], allFields, viewDimensions, [{ ...originalField, aggName: filterAggName }], true, 'none').map((x) => {
+            const preWorkflow = toWorkflow(
+                [],
+                allFields,
+                viewDimensions,
+                [{ ...originalField, aggName: filterAggName }],
+                true,
+                'none',
+                [],
+                undefined,
+                timezoneDisplayOffset
+            ).map((x) => {
                 if (x.type === 'view') {
                     return {
                         ...x,
@@ -209,6 +221,7 @@ const FilterEditDialog: React.FC = observer(() => {
             <PureFilterEditDialog
                 options={allFieldOptions}
                 editingFilterIdx={editingFilterIdx}
+                displayOffset={timezoneDisplayOffset}
                 meta={meta}
                 onClose={handelClose}
                 onSelectFilter={handleSelectFilterField}

--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { PencilSquareIcon } from '@heroicons/react/24/solid';
 import { useVizStore } from '../../store';
 import { refMapper } from '../fieldsContext';
+import { formatDate } from '../../utils';
+import { newOffsetDate } from '../../lib/op/offset';
 
 interface FilterPillProps {
     provided: DraggableProvided;
@@ -82,7 +84,9 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
                             : field.rule.type === 'range'
                             ? `range: [${field.rule.value[0]}, ${field.rule.value[1]}]`
                             : field.rule.type === 'temporal range'
-                            ? `range: [${new Date(field.rule.value[0])}, ${new Date(field.rule.value[1])}]`
+                            ? `range: [${formatDate(newOffsetDate(field.rule.offset)(field.rule.value[0]))}, ${formatDate(
+                                  newOffsetDate(field.rule.offset)(field.rule.value[1])
+                              )}]`
                             : field.rule.type === 'not in'
                             ? `notIn: [${[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]`
                             : null}

--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -60,7 +60,9 @@ const Pill = styled.div`
 const FilterPill: React.FC<FilterPillProps> = observer((props) => {
     const { provided, fIndex } = props;
     const vizStore = useVizStore();
-    const { viewFilters } = vizStore;
+    const { viewFilters, config } = vizStore;
+
+    const { timezoneDisplayOffset } = config;
 
     const field = viewFilters[fIndex];
 
@@ -79,17 +81,19 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
             >
                 {field.rule ? (
                     <span className="flex-1">
-                        {field.rule.type === 'one of'
-                            ? `oneOf: [${[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]`
-                            : field.rule.type === 'range'
-                            ? `range: [${field.rule.value[0]}, ${field.rule.value[1]}]`
-                            : field.rule.type === 'temporal range'
-                            ? `range: [${formatDate(newOffsetDate(field.rule.offset)(field.rule.value[0]))}, ${formatDate(
-                                  newOffsetDate(field.rule.offset)(field.rule.value[1])
-                              )}]`
-                            : field.rule.type === 'not in'
-                            ? `notIn: [${[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]`
-                            : null}
+                        {field.rule.type === 'one of' && <>oneOf: [{[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]</>}
+                        {field.rule.type === 'range' && (
+                            <>
+                                range: [{field.rule.value[0]}, {field.rule.value[1]}]
+                            </>
+                        )}
+                        {field.rule.type === 'not in' && <>notIn: [{[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]</>}
+                        {field.rule.type === 'temporal range' && (
+                            <>
+                                range: [{formatDate(newOffsetDate(timezoneDisplayOffset)(newOffsetDate(field.rule.offset)(field.rule.value[0])))},{' '}
+                                {formatDate(newOffsetDate(timezoneDisplayOffset)(newOffsetDate(field.rule.offset)(field.rule.value[1])))}]
+                            </>
+                        )}
                     </span>
                 ) : (
                     <span className="text-gray-600 flex-1">{t('empty_rule')}</span>

--- a/packages/graphic-walker/src/fields/filterField/filterPill.tsx
+++ b/packages/graphic-walker/src/fields/filterField/filterPill.tsx
@@ -7,7 +7,7 @@ import { PencilSquareIcon } from '@heroicons/react/24/solid';
 import { useVizStore } from '../../store';
 import { refMapper } from '../fieldsContext';
 import { formatDate } from '../../utils';
-import { newOffsetDate } from '../../lib/op/offset';
+import { parsedOffsetDate } from '../../lib/op/offset';
 
 interface FilterPillProps {
     provided: DraggableProvided;
@@ -90,8 +90,8 @@ const FilterPill: React.FC<FilterPillProps> = observer((props) => {
                         {field.rule.type === 'not in' && <>notIn: [{[...field.rule.value].map((d) => JSON.stringify(d)).join(', ')}]</>}
                         {field.rule.type === 'temporal range' && (
                             <>
-                                range: [{formatDate(newOffsetDate(timezoneDisplayOffset)(newOffsetDate(field.rule.offset)(field.rule.value[0])))},{' '}
-                                {formatDate(newOffsetDate(timezoneDisplayOffset)(newOffsetDate(field.rule.offset)(field.rule.value[1])))}]
+                                range: [{formatDate(parsedOffsetDate(timezoneDisplayOffset, field.rule.offset)(field.rule.value[0]))},{' '}
+                                {formatDate(parsedOffsetDate(timezoneDisplayOffset, field.rule.offset)(field.rule.value[1]))}]
                             </>
                         )}
                     </span>

--- a/packages/graphic-walker/src/fields/filterField/tabs.tsx
+++ b/packages/graphic-walker/src/fields/filterField/tabs.tsx
@@ -531,20 +531,22 @@ export const FilterOneOfRule: React.FC<RuleFormProps & { active: boolean }> = ({
 interface CalendarInputProps {
     min: number;
     max: number;
+    offset?: number;
     value: number;
     onChange: (value: number) => void;
 }
 
 export const CalendarInput: React.FC<CalendarInputProps> = (props) => {
-    const { min, max, value, onChange } = props;
+    const { min, max, value, onChange, offset } = props;
     const dateStringFormatter = (timestamp: number) => {
-        const date = new Date(timestamp);
+        const date = newOffsetDate(offset)(timestamp);
         if (Number.isNaN(date.getTime())) return '';
         return formatDate(date);
     };
     const handleSubmitDate = (value: string) => {
-        if (new Date(value).getTime() <= max && new Date(value).getTime() >= min) {
-            onChange(new Date(value).getTime());
+        const timestamp = newOffsetDate(offset)(value).getTime();
+        if (timestamp <= max && timestamp >= min) {
+            onChange(timestamp);
         }
     };
     return (
@@ -613,6 +615,7 @@ export const FilterTemporalRangeRule: React.FC<RuleFormProps & { active: boolean
                 <div className="calendar-input">
                     <div className="my-1">{t('filters.range.start_value')}</div>
                     <CalendarInput
+                        offset={field.rule.offset}
                         min={min}
                         max={field.rule.value[1]}
                         value={field.rule.value[0]}
@@ -622,6 +625,7 @@ export const FilterTemporalRangeRule: React.FC<RuleFormProps & { active: boolean
                 <div className="calendar-input">
                     <div className="my-1">{t('filters.range.end_value')}</div>
                     <CalendarInput
+                        offset={field.rule.offset}
                         min={field.rule.value[0]}
                         max={max}
                         value={field.rule.value[1]}

--- a/packages/graphic-walker/src/fields/filterField/tabs.tsx
+++ b/packages/graphic-walker/src/fields/filterField/tabs.tsx
@@ -10,7 +10,7 @@ import { fieldStat, getTemporalRange, withComputedField } from '../../computatio
 import Slider from './slider';
 import { getFilterMeaAggKey, formatDate } from '../../utils';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { newOffsetDate } from '../../lib/op/offset';
+import { newOffsetDate, parsedOffsetDate } from '../../lib/op/offset';
 
 export type RuleFormProps = {
     rawFields: IMutField[];
@@ -493,8 +493,7 @@ export const FilterOneOfRule: React.FC<RuleFormProps & { active: boolean }> = ({
                         const id = `rule_checkbox_${idx}`;
                         const checked =
                             (field.rule?.type === 'one of' && field.rule.value.has(value)) || (field.rule?.type === 'not in' && !field.rule.value.has(value));
-                        const displayValue =
-                            field.semanticType === 'temporal' ? formatDate(newOffsetDate(displayOffset)(newOffsetDate(field.offset)(value))) : `${value}`;
+                        const displayValue = field.semanticType === 'temporal' ? formatDate(parsedOffsetDate(displayOffset, field.offset)(value)) : `${value}`;
                         return (
                             <TableRow
                                 key={idx}

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -645,7 +645,7 @@ export type IResponse<T> =
 export interface IAggQuery {
     op: 'aggregate';
     groupBy: string[];
-    measures: { field: string; agg: IAggregator; asFieldKey: string; format?: string }[];
+    measures: { field: string; agg: IAggregator; asFieldKey: string; format?: string; offset?: number }[];
 }
 
 export interface IFoldQuery {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -169,6 +169,10 @@ export type IExpParameter =
     | {
           type: 'newmap';
           value: IPaintMapV2;
+      }
+    | {
+          type: 'displayOffset';
+          value: number;
       };
 
 export interface IExpression {
@@ -427,6 +431,7 @@ export interface IVisualConfigNew {
     coordSystem?: ICoordMode;
     limit: number;
     folds?: string[];
+    timezoneDisplayOffset?: number;
 }
 
 export interface IGeoUrl {
@@ -914,7 +919,7 @@ export interface IComputationContextProps {
     computationTimeout?: number;
 }
 
-export type IComputationProps = XOR<IRemoteComputationProps,ILocalComputationProps>;
+export type IComputationProps = XOR<IRemoteComputationProps, ILocalComputationProps>;
 
 export type IGWProps = IAppI18nProps &
     IVizProps &
@@ -931,6 +936,7 @@ export interface ISpecProps {
 
 export interface ITableSpecProps {
     pageSize?: number;
+    displayOffset?: number;
 }
 
 export interface IVizAppProps extends IAppI18nProps, IVizProps, IThemeProps, IErrorHandlerProps, IVizStoreProps, ISpecProps {}

--- a/packages/graphic-walker/src/lib/inferMeta.ts
+++ b/packages/graphic-walker/src/lib/inferMeta.ts
@@ -12,22 +12,13 @@ const COMMON_TIME_FORMAT: RegExp[] = [
     /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T\d{2}:\d{2}:\d{2}.\d{3}Z$/, // YYYY-MM-DDTHH:MM:SS.gggZ (ISO-8601)
 ];
 
-const TIME_FORMAT = [
-    '%Y-%m-%d',
-    '%m/%d/%Y',
-    '%d/%m/%Y',
-    '%Y/%m/%d',
-    '%Y.%m.%d',
-    '%Y-%m-%d %H:%M:%S',
-    '%Y-%m-%dT%H:%M:%S',
-    '%Y-%m-%dT%H:%M:%S.%gZ'
-]
+const TIME_FORMAT = ['%Y-%m-%d', '%m/%d/%Y', '%d/%m/%Y', '%Y/%m/%d', '%Y.%m.%d', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%S.%gZ'];
 
 export function getTimeFormat(data: string | number) {
     if (typeof data === 'number') return 'timestamp';
-    const i = COMMON_TIME_FORMAT.findIndex(x => x.test(data));
+    const i = COMMON_TIME_FORMAT.findIndex((x) => x.test(data));
     if (i >= 0) return TIME_FORMAT[i];
-    return ''
+    return '';
 }
 
 /**
@@ -100,6 +91,7 @@ export function inferMeta(props: { dataSource: IRow[]; fields: IUncertainMutFiel
             semanticType,
             basename: field.basename || field.name || field.fid,
             path: field.path,
+            offset: semanticType === 'temporal' ? new Date().getTimezoneOffset() : undefined,
         });
     }
     return finalFieldMetas;

--- a/packages/graphic-walker/src/lib/op/aggregate.ts
+++ b/packages/graphic-walker/src/lib/op/aggregate.ts
@@ -3,6 +3,7 @@ import { getMeaAggKey } from '../../utils';
 import { IAggQuery } from '../../interfaces';
 import { sum, mean, median, stdev, variance, max, min, count, distinctCount } from './stat';
 import { expr } from '../sql';
+import { newOffsetDate } from './offset';
 
 const aggregatorMap = {
     sum,
@@ -50,11 +51,12 @@ export function aggregate(data: IRow[], query: IAggQuery): IRow[] {
                 }
                 aggRow[aggMeaKey] = result;
             } else {
+                const newDate = newOffsetDate(mea.offset);
                 const values: number[] = subGroup
                     .map((r) => r[mea.field])
                     .map((x) => {
                         if (mea.format) {
-                            return new Date(x).getTime();
+                            return newDate(x).getTime();
                         }
                         return x;
                     });

--- a/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
+++ b/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
@@ -8,18 +8,21 @@ const formatDate = (date: Date) => date.getTime();
 function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame): IDataFrame {
     const fieldKey = params.find((p) => p.type === 'field')?.value;
     const drillLevel = params.find((p) => p.type === 'value')?.value as (typeof DATE_TIME_DRILL_LEVELS)[number] | undefined;
-    const offset = params.find((p) => p.type === 'offset')?.value ?? new Date().getTimezoneOffset();
+    const offset = params.find((p) => p.type === 'offset')?.value;
+    const displayOffset = params.find((p) => p.type === 'displayOffset')?.value;
     if (!fieldKey || !drillLevel) {
         return data;
     }
     const fieldValues = data[fieldKey];
-    const newDate = newOffsetDate(offset);
+    const prepareDate = newOffsetDate(offset);
+    const toOffsetDate = newOffsetDate(displayOffset);
+    const newDate = ((...x: []) => toOffsetDate(prepareDate(...x))) as typeof prepareDate;
     switch (drillLevel) {
         case 'year': {
             const newValues = fieldValues.map((v) => {
                 const date = newDate(v);
                 const Y = date.getFullYear();
-                return formatDate(newDate(Y, 0, 1));
+                return formatDate(toOffsetDate(Y, 0, 1));
             });
             return {
                 ...data,
@@ -31,7 +34,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const Q = Math.floor(date.getMonth() / 3);
-                return formatDate(newDate(Y, Q * 3, 1));
+                return formatDate(toOffsetDate(Y, Q * 3, 1));
             });
             return {
                 ...data,
@@ -43,7 +46,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();
-                return formatDate(newDate(Y, M, 1));
+                return formatDate(toOffsetDate(Y, M, 1));
             });
             return {
                 ...data,
@@ -57,7 +60,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const Y = date.getFullYear();
                 const M = date.getMonth();
                 const D = date.getDate();
-                return formatDate(newDate(Y, M, D));
+                return formatDate(toOffsetDate(Y, M, D));
             });
             return {
                 ...data,
@@ -70,7 +73,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const Y = date.getFullYear();
                 const M = date.getMonth();
                 const D = date.getDate();
-                return formatDate(newDate(Y, M, D));
+                return formatDate(toOffsetDate(Y, M, D));
             });
             return {
                 ...data,
@@ -84,7 +87,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const M = date.getMonth();
                 const D = date.getDate();
                 const H = date.getHours();
-                return formatDate(newDate(Y, M, D, H));
+                return formatDate(toOffsetDate(Y, M, D, H));
             });
             return {
                 ...data,
@@ -99,7 +102,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const D = date.getDate();
                 const H = date.getHours();
                 const m = date.getMinutes();
-                return formatDate(newDate(Y, M, D, H, m));
+                return formatDate(toOffsetDate(Y, M, D, H, m));
             });
             return {
                 ...data,
@@ -115,7 +118,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
                 const H = date.getHours();
                 const m = date.getMinutes();
                 const s = date.getSeconds();
-                return formatDate(newDate(Y, M, D, H, m, s));
+                return formatDate(toOffsetDate(Y, M, D, H, m, s));
             });
             return {
                 ...data,

--- a/packages/graphic-walker/src/lib/op/dateTimeFeature.ts
+++ b/packages/graphic-walker/src/lib/op/dateTimeFeature.ts
@@ -6,12 +6,15 @@ import { newOffsetDate } from './offset';
 function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame): IDataFrame {
     const fieldKey = params.find((p) => p.type === 'field')?.value;
     const drillLevel = params.find((p) => p.type === 'value')?.value as (typeof DATE_TIME_FEATURE_LEVELS)[number] | undefined;
-    const offset = params.find((p) => p.type === 'offset')?.value ?? new Date().getTimezoneOffset();
+    const offset = params.find((p) => p.type === 'offset')?.value;
+    const displayOffset = params.find((p) => p.type === 'displayOffset')?.value;
     if (!fieldKey || !drillLevel) {
         return data;
     }
     const fieldValues = data[fieldKey];
-    const newDate = newOffsetDate(offset);
+    const prepareDate = newOffsetDate(offset);
+    const toOffsetDate = newOffsetDate(displayOffset);
+    const newDate = ((...x: []) => toOffsetDate(prepareDate(...x))) as typeof prepareDate;
     switch (drillLevel) {
         case 'year': {
             const newValues = fieldValues.map((v) => {

--- a/packages/graphic-walker/src/lib/op/offset.ts
+++ b/packages/graphic-walker/src/lib/op/offset.ts
@@ -60,3 +60,7 @@ export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
     }
     return creator;
 }
+// TODO remove
+try {
+    window['newOffsetDate'] = newOffsetDate;
+}catch{}

--- a/packages/graphic-walker/src/lib/op/offset.ts
+++ b/packages/graphic-walker/src/lib/op/offset.ts
@@ -22,8 +22,8 @@ export function getOffsetDate(date: Date, offset: number): OffsetDate {
 const unexceptedUTCParsedPattern = [
     /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/, // YYYY-MM-DD
     /^\d{4}-(0[1-9]|1[0-2])$/, // YYYY-MM
-    /^\d{4}$/,// YYYY
-]
+    /^\d{4}$/, // YYYY
+];
 
 export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
     function creator(): OffsetDate;
@@ -42,7 +42,7 @@ export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
                 return getOffsetDate(v, offset);
             }
             if (typeof v === 'string') {
-                if (unexceptedUTCParsedPattern.find(regex => regex.test(v))) {
+                if (unexceptedUTCParsedPattern.find((regex) => regex.test(v))) {
                     const utcDate = new Date(v).getTime();
                     return getOffsetDate(new Date(utcDate + offset * 60000), offset);
                 }
@@ -60,7 +60,15 @@ export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
     }
     return creator;
 }
-// TODO remove
-try {
-    window['newOffsetDate'] = newOffsetDate;
-}catch{}
+
+export function parsedOffsetDate(displayOffset = new Date().getTimezoneOffset(), parseOffset = new Date().getTimezoneOffset()) {
+    const toOffset = newOffsetDate(displayOffset);
+    const parse = newOffsetDate(parseOffset);
+    function creator(): OffsetDate;
+    function creator(value: number | string | Date): OffsetDate;
+    function creator(year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): OffsetDate;
+    function creator(...args: []): OffsetDate {
+        return toOffset(parse(...args));
+    }
+    return creator;
+}

--- a/packages/graphic-walker/src/lib/op/offset.ts
+++ b/packages/graphic-walker/src/lib/op/offset.ts
@@ -19,11 +19,13 @@ export function getOffsetDate(date: Date, offset: number): OffsetDate {
     }) as OffsetDate;
 }
 
-const unexceptedUTCParsedPattern = [
+export const unexceptedUTCParsedPattern = [
     /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$/, // YYYY-MM-DD
     /^\d{4}-(0[1-9]|1[0-2])$/, // YYYY-MM
     /^\d{4}$/, // YYYY
 ];
+
+export const unexceptedUTCParsedPatternFormats = ['%Y', '%Y-%m', '%Y-%m-%d'];
 
 export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
     function creator(): OffsetDate;

--- a/packages/graphic-walker/src/lib/op/stat.ts
+++ b/packages/graphic-walker/src/lib/op/stat.ts
@@ -1,3 +1,5 @@
+import { isNotEmpty } from "../../utils";
+
 export function mean(nums: number[]): number {
     return nums.reduce((a, b) => a + b, 0) / nums.length;
 }
@@ -46,7 +48,7 @@ export function count(nums: any[]): number {
 }
 
 export function countTruly(nums: any[]): number {
-    return nums.filter(x => x !== undefined && x !== null).length;
+    return nums.filter(isNotEmpty).length;
 }
 
 export function distinctCount(datas: any[]) {

--- a/packages/graphic-walker/src/lib/vega.ts
+++ b/packages/graphic-walker/src/lib/vega.ts
@@ -26,6 +26,7 @@ export function toVegaSpec({
     channelScales,
     mediaTheme,
     vegaConfig,
+    displayOffset,
 }: {
     rows: readonly IViewField[];
     columns: readonly IViewField[];
@@ -48,6 +49,7 @@ export function toVegaSpec({
     channelScales?: IChannelScales;
     mediaTheme: 'dark' | 'light';
     vegaConfig: VegaGlobalConfig;
+    displayOffset?: number;
 }) {
     const guard = defaultAggregated ? (x?: IViewField) => x ?? NULL_FIELD : (x?: IViewField) => (x ? (x.aggName === 'expr' ? NULL_FIELD : x) : NULL_FIELD);
     const rows = rowsRaw.map(guard).filter((x) => x !== NULL_FIELD);
@@ -123,12 +125,16 @@ export function toVegaSpec({
             defaultAggregated,
             stack,
             geomType,
+            displayOffset,
         });
         const singleView = channelScales ? resolveScales(channelScales, v, dataSource, mediaTheme) : v;
 
         spec.mark = singleView.mark;
         if ('encoding' in singleView) {
             spec.encoding = singleView.encoding;
+        }
+        if ('transform' in singleView && singleView.transform.length > 0) {
+            spec.transform = singleView.transform;
         }
 
         spec.resolve ||= {};
@@ -181,6 +187,7 @@ export function toVegaSpec({
                     stack,
                     geomType,
                     hideLegend: !hasLegend,
+                    displayOffset,
                 });
                 const singleView = channelScales ? resolveScales(channelScales, v, dataSource, mediaTheme) : v;
                 let commonSpec = { ...spec };

--- a/packages/graphic-walker/src/lib/vega.ts
+++ b/packages/graphic-walker/src/lib/vega.ts
@@ -126,6 +126,7 @@ export function toVegaSpec({
             stack,
             geomType,
             displayOffset,
+            dataSource
         });
         const singleView = channelScales ? resolveScales(channelScales, v, dataSource, mediaTheme) : v;
 
@@ -188,6 +189,7 @@ export function toVegaSpec({
                     geomType,
                     hideLegend: !hasLegend,
                     displayOffset,
+                    dataSource,
                 });
                 const singleView = channelScales ? resolveScales(channelScales, v, dataSource, mediaTheme) : v;
                 let commonSpec = { ...spec };

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -23,7 +23,8 @@
         "formatGuidesDocs": "Format guides docs",
         "readHere": "read here",
         "svg": "Use SVG",
-        "customTile": "Use a Custom Tile for map"
+        "customTile": "Use a Custom Tile for map",
+        "customOffset": "Use a Specific timezone"
     },
     "constant": {
         "row_count": "Row count",

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -23,7 +23,8 @@
         "formatGuidesDocs": "フォーマットガイド",
         "readHere": "ここを読む",
         "svg": "SVGを使う",
-        "customTile": "地図タイルをカスタマイズ"
+        "customTile": "地図タイルをカスタマイズ",
+        "customOffset": "タイムゾーンをカスタマイズ"
     },
     "constant": {
         "row_count": "行数",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -23,7 +23,8 @@
         "formatGuidesDocs": "格式指南",
         "readHere": "阅读此处",
         "svg": "使用SVG",
-        "customTile": "使用自定义的地图区块"
+        "customTile": "使用自定义的地图区块",
+        "customOffset": "使用自定义的时区"
     },
     "constant": {
         "row_count": "行数",

--- a/packages/graphic-walker/src/main.tsx
+++ b/packages/graphic-walker/src/main.tsx
@@ -14,5 +14,5 @@ embedGraphicWalker(document.getElementById('root') as HTMLElement, {
             type: 'GeoJSON',
             url: 'https://raw.githubusercontent.com/drei01/geojson-world-cities/f2a988af4bc15463df55586afbbffbd3068b7218/cities.geojson',
         },
-    ]
+    ],
 });

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -22,7 +22,7 @@ import {
     IPaintMapV2,
 } from '../interfaces';
 import type { FeatureCollection } from 'geojson';
-import { createCountField, createVirtualFields } from '../utils';
+import { createCountField, createVirtualFields, isNotEmpty } from '../utils';
 import { decodeFilterRule, encodeFilterRule } from '../utils/filter';
 import { emptyEncodings, emptyVisualConfig, emptyVisualLayout } from '../utils/save';
 import { AssertSameKey, KVTuple, insert, mutPath, remove, replace, uniqueId } from './utils';
@@ -247,7 +247,7 @@ const actions: {
                               } as const,
                           ]
                         : []),
-                    ...(offset !== undefined
+                    ...(isNotEmpty(offset)
                         ? [
                               {
                                   type: 'offset',
@@ -290,7 +290,7 @@ const actions: {
                               } as const,
                           ]
                         : []),
-                    ...(offset !== undefined
+                    ...(isNotEmpty(offset)
                         ? [
                               {
                                   type: 'offset',

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -577,6 +577,7 @@ export function newChart(fields: IMutField[], name: string, visId?: string): ICh
                     basename: f.basename || f.name || f.fid,
                     semanticType: f.semanticType,
                     analyticType: f.analyticType,
+                    offset: f.offset
                 })
             )
             .concat(extraDimensions),
@@ -591,6 +592,7 @@ export function newChart(fields: IMutField[], name: string, visId?: string): ICh
                     analyticType: f.analyticType,
                     semanticType: f.semanticType,
                     aggName: 'sum',
+                    offset: f.offset
                 })
             )
             .concat(extraMeasures),

--- a/packages/graphic-walker/src/renderer/hooks.ts
+++ b/packages/graphic-walker/src/renderer/hooks.ts
@@ -16,6 +16,7 @@ interface UseRendererProps {
     limit: number;
     computationFunction: IComputationFunction;
     folds?: string[];
+    timezoneDisplayOffset?: number;
 }
 
 interface UseRendererResult {
@@ -27,12 +28,12 @@ interface UseRendererResult {
 }
 
 export const useRenderer = (props: UseRendererProps): UseRendererResult => {
-    const { allFields, viewDimensions, viewMeasures, filters, defaultAggregated, sort, limit, computationFunction, folds } = props;
+    const { allFields, viewDimensions, viewMeasures, filters, defaultAggregated, sort, limit, computationFunction, folds, timezoneDisplayOffset } = props;
     const [computing, setComputing] = useState(false);
     const taskIdRef = useRef(0);
 
     const workflow = useMemo(() => {
-        return toWorkflow(filters, allFields, viewDimensions, viewMeasures, defaultAggregated, sort, folds, limit > 0 ? limit : undefined);
+        return toWorkflow(filters, allFields, viewDimensions, viewMeasures, defaultAggregated, sort, folds, limit > 0 ? limit : undefined, timezoneDisplayOffset);
     }, [filters, allFields, viewDimensions, viewMeasures, defaultAggregated, sort, folds, limit]);
 
     const [viewData, setViewData] = useState<IRow[]>([]);

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -66,6 +66,7 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
         limit: limit,
         folds: visualConfig.folds,
         computationFunction,
+        timezoneDisplayOffset: visualConfig.timezoneDisplayOffset,
     });
 
     useEffect(() => {

--- a/packages/graphic-walker/src/renderer/pureRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/pureRenderer.tsx
@@ -110,6 +110,7 @@ const PureRenderer = forwardRef<IReactVegaHandler, IPureRendererProps & (LocalPr
         folds: visualConfig.folds,
         limit,
         computationFunction: computation,
+        timezoneDisplayOffset: visualConfig['timezoneDisplayOffset'],
     });
     // Dependencies that should not trigger effect individually
     const latestFromRef = useRef({ data });

--- a/packages/graphic-walker/src/renderer/specRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/specRenderer.tsx
@@ -51,7 +51,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
     ref
 ) {
     // const { draggableFieldState, visualConfig } = vizStore;
-    const { geoms, defaultAggregated, coordSystem } = visualConfig;
+    const { geoms, defaultAggregated, coordSystem, timezoneDisplayOffset } = visualConfig;
     const {
         interactiveScale,
 
@@ -234,6 +234,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                     dark={dark}
                     scale={scale}
                     onReportSpec={onReportSpec}
+                    displayOffset={timezoneDisplayOffset}
                 />
             )}
         </Resizable>

--- a/packages/graphic-walker/src/store/commonStore.ts
+++ b/packages/graphic-walker/src/store/commonStore.ts
@@ -9,9 +9,11 @@ export class CommonStore {
     public showDSPanel: boolean = false;
     public provider: IDataSourceProvider;
     private onCommitDS: (datasetId: string) => void;
-    constructor(provider: IDataSourceProvider, onCommitDS: (datasetId: string) => void) {
+    public displayOffset: number | undefined;
+    constructor(provider: IDataSourceProvider, onCommitDS: (datasetId: string) => void, config: {displayOffset?: number}) {
         this.provider = provider;
         this.onCommitDS = onCommitDS;
+        this.displayOffset = config.displayOffset;
         makeAutoObservable(this, {
             tmpDataSource: observable.ref,
         });
@@ -80,5 +82,9 @@ export class CommonStore {
     public startDSBuildingTask() {
         this.initTempDS();
         this.showDSPanel = true;
+    }
+
+    public setDisplayOffset(displayOffset?: number) {
+        this.displayOffset = displayOffset;
     }
 }

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -225,7 +225,8 @@ export class VizSpecStore {
             this.config.defaultAggregated,
             this.sort,
             this.config.folds,
-            this.config.limit
+            this.config.limit,
+            this.config.timezoneDisplayOffset
         );
     }
 
@@ -479,7 +480,7 @@ export class VizSpecStore {
         drillLevel: (typeof DATE_TIME_DRILL_LEVELS)[number],
         name: string,
         format: string,
-        offset: number
+        offset: number | undefined
     ) {
         this.visList[this.visIndex] = performers.createDateDrillField(
             this.visList[this.visIndex],
@@ -489,7 +490,7 @@ export class VizSpecStore {
             uniqueId(),
             name,
             format,
-            offset
+            offset ?? new Date().getTimezoneOffset()
         );
     }
 
@@ -499,7 +500,7 @@ export class VizSpecStore {
         drillLevel: (typeof DATE_TIME_FEATURE_LEVELS)[number],
         name: string,
         format: string,
-        offset: number
+        offset: number | undefined
     ) {
         this.visList[this.visIndex] = performers.createDateFeatureField(
             this.visList[this.visIndex],
@@ -509,7 +510,7 @@ export class VizSpecStore {
             uniqueId(),
             name,
             format,
-            offset
+            offset ?? new Date().getTimezoneOffset()
         );
     }
 

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -356,3 +356,7 @@ export const formatDate = (date: Date) => {
     const pad = (x: number) => `${x}`.padStart(2, '0');
     return `${Y}-${pad(M)}-${pad(D)} ${pad(H)}:${pad(m)}:${pad(s)}`;
 };
+
+export const isNotEmpty = <T>(x: T | undefined | null): x is T => {
+    return x !== undefined && x !== null;
+};

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -112,12 +112,13 @@ export const toWorkflow = (
                 },
             };
         } else if (rule.type === 'temporal range') {
-            const range = [new Date(rule.value[0]).getTime(), new Date(rule.value[1]).getTime()] as const;
             return {
                 fid,
                 rule: {
                     type: 'temporal range',
-                    value: range,
+                    value: rule.value,
+                    offset: rule.offset,
+                    format: rule.format,
                 },
             };
         } else if (rule.type === 'not in') {

--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -79,6 +79,7 @@ interface ReactVegaProps {
         size: IConfigScale;
     };
     onReportSpec?: (spec: string) => void;
+    displayOffset?: number
 }
 
 const click$ = new Subject<ScenegraphEvent>();
@@ -134,6 +135,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
         useSvg,
         channelScales: channelScaleRaw,
         scale,
+        displayOffset,
     } = props;
     const [viewPlaceholders, setViewPlaceholders] = useState<React.MutableRefObject<HTMLDivElement>[]>([]);
     const mediaTheme = useCurrentMediaTheme(dark);
@@ -267,6 +269,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
                 text,
                 theta,
                 vegaConfig,
+                displayOffset
             }),
         [
             guardedCols,
@@ -289,6 +292,7 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
             size,
             text,
             theta,
+            displayOffset,
         ]
     );
     // Render

--- a/packages/graphic-walker/src/vis/spec/encode.ts
+++ b/packages/graphic-walker/src/vis/spec/encode.ts
@@ -1,5 +1,6 @@
 import { DATE_TIME_DRILL_LEVELS } from '../../constants';
 import { IPaintMap, IPaintMapV2, IViewField } from '../../interfaces';
+import { isNotEmpty } from '../../utils';
 import { NULL_FIELD } from './field';
 export interface IEncodeProps {
     geomType: string;
@@ -17,6 +18,7 @@ export interface IEncodeProps {
     radius: IViewField;
     details: Readonly<IViewField[]>;
     text: IViewField;
+    displayOffset?: number;
 }
 export function availableChannels(geomType: string): Set<string> {
     if (geomType === 'text') {
@@ -75,11 +77,14 @@ export function channelEncode(props: IEncodeProps) {
                 if (props[c].analyticType === 'measure') {
                     encoding[c].type = 'quantitative';
                 }
+                if (props[c].semanticType === 'temporal' && isNotEmpty(props.displayOffset)) {
+                    encoding[c].scale = { type: 'utc' };
+                }
                 if (props[c].semanticType === 'temporal' && props[c].timeUnit) {
                     encoding[c].timeUnit = encodeTimeunit(props[c].timeUnit);
                 }
                 if (c === 'color' && props[c].expression?.op === 'paint') {
-                    const map: IPaintMap = props[c].expression!.params.find((x) => x.type === 'map' || x.type === 'newmap')!.value;
+                    const map: IPaintMap | IPaintMapV2 = props[c].expression!.params.find((x) => x.type === 'map' || x.type === 'newmap')!.value;
                     const colors = map.usedColor.map((x) => map.dict[x]).filter(Boolean);
                     encoding[c].scale = {
                         domain: colors.map((x) => x.name),

--- a/packages/graphic-walker/src/vis/spec/tooltip.ts
+++ b/packages/graphic-walker/src/vis/spec/tooltip.ts
@@ -14,6 +14,11 @@ export function addTooltipEncode(encoding: { [key: string]: any }, details: Read
                           timeUnit: encoding[ck].timeUnit,
                       }
                     : {}),
+                ...(encoding[ck].scale
+                    ? {
+                          scale: encoding[ck].scale,
+                      }
+                    : {}),
             };
         })
         .concat(

--- a/packages/graphic-walker/src/vis/spec/view.ts
+++ b/packages/graphic-walker/src/vis/spec/view.ts
@@ -63,7 +63,7 @@ export function getSingleView(props: SingleViewProps) {
         .map((f) => {
             let offsetTime = (displayOffset ?? new Date().getTimezoneOffset() - (f.offset ?? new Date().getTimezoneOffset())) * -60000;
             const fid = encodeFid(f.fid);
-            const sample = dataSource[0][f.fid];
+            const sample = dataSource[0]?.[f.fid];
             if (sample) {
                 const format = getTimeFormat(sample);
                 if (format !== 'timestamp') {


### PR DESCRIPTION
Add a config in GraphicWalker to change the timezone to display date.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/92f0a36a-6bd8-4f25-9afd-91d2645a9cc2)

before:(UTC-5)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/071c698a-3998-4e32-ae22-8d9119827b87)
change to UTC:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/4e7cfc18-b134-40fd-915f-e4b8b97b91eb)

Also effect with DateTimeDrill and DateTimeFeature.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/359b18a4-0fdb-46da-92ba-f62cf864902a)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/907a8833-2379-4dce-8135-c9ad933661da)
