### PR TITLE
feat: add default config for configuing timezone offset

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useCallback } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
-import { ISegmentKey, IAppI18nProps, IVizProps, IErrorHandlerProps, IVizAppProps, ISpecProps, IComputationContextProps, IRemoteComputationProps, IComputationProps } from './interfaces';
+import { ISegmentKey, IAppI18nProps, IVizProps, IErrorHandlerProps, IVizAppProps, ISpecProps, IComputationContextProps, IComputationProps } from './interfaces';
 import type { IReactVegaHandler } from './vis/react-vega';
 import VisualSettings from './visualSettings';
 import PosFields from './fields/posFields';
@@ -265,7 +265,13 @@ export function VizAppWithContext(props: IVizAppProps & IComputationProps) {
 
     return (
         <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
-            <VizStoreWrapper onMetaChange={onMetaChange} meta={safeMetas} keepAlive={props.keepAlive} storeRef={props.storeRef}>
+            <VizStoreWrapper
+                onMetaChange={onMetaChange}
+                meta={safeMetas}
+                keepAlive={props.keepAlive}
+                storeRef={props.storeRef}
+                defaultConfig={props.defaultConfig}
+            >
                 <FieldsContextWrapper>
                     <VizApp
                         darkMode={darkMode}

--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -59,7 +59,7 @@ export const TableApp = observer(function VizApp(props: BaseTableProps) {
     );
 
     const metas = toJS(vizStore.meta);
-    
+
     return (
         <ErrorContext value={{ reportError }}>
             <ErrorBoundary fallback={<div>Something went wrong</div>} onError={props.onError}>
@@ -101,7 +101,13 @@ export function TableAppWithContext(props: ITableProps & IComputationProps) {
 
     return (
         <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-white dark:bg-zinc-900 dark:text-white m-0 p-0`}>
-            <VizStoreWrapper onMetaChange={props.onMetaChange} meta={safeMetas} keepAlive={props.keepAlive} storeRef={props.storeRef}>
+            <VizStoreWrapper
+                onMetaChange={props.onMetaChange}
+                meta={safeMetas}
+                keepAlive={props.keepAlive}
+                storeRef={props.storeRef}
+                defaultConfig={props.defaultConfig}
+            >
                 <TableApp
                     darkMode={darkMode}
                     i18nLang={props.i18nLang}

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -894,11 +894,17 @@ export interface IExperimentalFeatures {
     computedField?: boolean;
 }
 
+export interface IDefaultConfig {
+    config?: Partial<IVisualConfigNew>,
+    layout?: Partial<IVisualLayout>
+}
+
 export interface IVizStoreProps {
     storeRef?: React.MutableRefObject<VizSpecStore | null>;
     keepAlive?: boolean | string;
     rawFields: IMutField[];
     onMetaChange?: (fid: string, meta: Partial<IMutField>) => void;
+    defaultConfig?: IDefaultConfig;
 }
 
 export interface ILocalComputationProps {

--- a/packages/graphic-walker/src/store/index.tsx
+++ b/packages/graphic-walker/src/store/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo, useEffect, createContext, useRef } from 'react';
 import { VizSpecStore } from './visualSpecStore';
-import { IComputationFunction, IMutField, IRow } from '../interfaces';
+import { IComputationFunction, IDefaultConfig, IMutField, IRow } from '../interfaces';
 
 function createKeepAliveContext<T, U extends any[]>(create: (...args: U) => T) {
     const dict: Record<string, T> = {};
@@ -20,6 +20,7 @@ const getVizStore = createKeepAliveContext(
         opts?: {
             empty?: boolean;
             onMetaChange?: (fid: string, diffMeta: Partial<IMutField>) => void;
+            defaultConfig?: IDefaultConfig;
         }
     ) => new VizSpecStore(meta, opts)
 );
@@ -34,11 +35,12 @@ interface VizStoreWrapperProps {
     children?: React.ReactNode;
     meta: IMutField[];
     onMetaChange?: (fid: string, meta: Partial<IMutField>) => void;
+    defaultConfig?: IDefaultConfig;
 }
 
 export const VizStoreWrapper = (props: VizStoreWrapperProps) => {
     const storeKey = props.keepAlive ? `${props.keepAlive}` : '';
-    const store = useMemo(() => getVizStore(storeKey, props.meta, { onMetaChange: props.onMetaChange }), [storeKey]);
+    const store = useMemo(() => getVizStore(storeKey, props.meta, { onMetaChange: props.onMetaChange, defaultConfig: props.defaultConfig }), [storeKey]);
     const lastMeta = useRef(props.meta);
     useEffect(() => {
         if (lastMeta.current !== props.meta) {
@@ -53,6 +55,14 @@ export const VizStoreWrapper = (props: VizStoreWrapperProps) => {
             lastOnMetaChange.current = props.onMetaChange;
         }
     }, [props.meta, store]);
+
+    const lastDefaultConfig = useRef(props.defaultConfig);
+    useEffect(() => {
+        if (lastDefaultConfig.current !== props.defaultConfig) {
+            store.setDefaultConfig(props.defaultConfig);
+            lastDefaultConfig.current = props.defaultConfig;
+        }
+    }, [props.defaultConfig, store]);
 
     useEffect(() => {
         if (props.storeRef) {

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -39,6 +39,7 @@ import {
     IChartForExport,
     IPaintMap,
     IPaintMapV2,
+    IDefaultConfig,
 } from '../interfaces';
 import { GLOBAL_CONFIG } from '../config';
 import { COUNT_FIELD_ID, DATE_TIME_DRILL_LEVELS, DATE_TIME_FEATURE_LEVELS, PAINT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../constants';
@@ -103,6 +104,7 @@ export class VizSpecStore {
     showAskvizFeedbackIndex: number | undefined = 0;
     lastSpec: string = '';
     editingComputedFieldFid: string | undefined = undefined;
+    defaultConfig: IDefaultConfig | undefined;
 
     private onMetaChange?: (fid: string, diffMeta: Partial<IMutField>) => void;
 
@@ -111,11 +113,13 @@ export class VizSpecStore {
         options?: {
             empty?: boolean;
             onMetaChange?: (fid: string, diffMeta: Partial<IMutField>) => void;
+            defaultConfig?: IDefaultConfig
         }
     ) {
         this.meta = meta;
-        this.visList = options?.empty ? [] : [fromFields(meta, 'Chart 1')];
+        this.visList = options?.empty ? [] : [fromFields(meta, 'Chart 1', options?.defaultConfig)];
         this.createdVis = this.visList.length;
+        this.defaultConfig = options?.defaultConfig;
         this.onMetaChange = options?.onMetaChange;
         makeAutoObservable(this, {
             visList: observable.shallow,
@@ -326,14 +330,18 @@ export class VizSpecStore {
         this.onMetaChange = onMetaChange;
     }
 
+    setDefaultConfig(defaultConfig?: IDefaultConfig) {
+        this.defaultConfig = defaultConfig;
+    }
+
     resetVisualization(name = 'Chart 1') {
-        this.visList = [fromFields(this.meta, name)];
+        this.visList = [fromFields(this.meta, name, this.defaultConfig)];
         this.createdVis = 1;
     }
 
     addVisualization(defaultName?: string | ((index: number) => string)) {
         const name = defaultName ? (typeof defaultName === 'function' ? defaultName(this.createdVis + 1) : defaultName) : 'Chart ' + (this.createdVis + 1);
-        this.visList.push(fromFields(this.meta, name));
+        this.visList.push(fromFields(this.meta, name, this.defaultConfig));
         this.createdVis += 1;
         this.visIndex = this.visList.length - 1;
     }

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -364,14 +364,14 @@ export const processExpression = (exp: IExpression, allFields: IMutField[], conf
             ],
         };
     }
-    if (isNotEmpty(config.timezoneDisplayOffset) && (exp.op === 'dateTimeDrill' || exp.op === 'dateTimeFeature')) {
+    if (exp.op === 'dateTimeDrill' || exp.op === 'dateTimeFeature') {
         return {
             ...exp,
             params: [
                 ...exp.params,
                 {
                     type: 'displayOffset',
-                    value: config.timezoneDisplayOffset,
+                    value: config.timezoneDisplayOffset ?? new Date().getTimezoneOffset(),
                 },
             ],
         };


### PR DESCRIPTION
Added a new prop: defaultConfig.
usage: 
`<GraphicWalker defaultConfig={{ config: { timezoneDisplayOffset: 0 }, layout: { size: { mode: 'full', width: 100, height: 100 } } }}></GraphicWalker>`
so developer can provide some config for user to have as default.