### PR TITLE
feat: use multi encode editor for detail

### DIFF
--- a/packages/graphic-walker/src/fields/aestheticFields.tsx
+++ b/packages/graphic-walker/src/fields/aestheticFields.tsx
@@ -5,6 +5,8 @@ import { AestheticFieldContainer } from './components';
 import SingleEncodeEditor from './encodeFields/singleEncodeEditor';
 import { observer } from 'mobx-react-lite';
 import { useVizStore } from '../store';
+import MultiEncodeEditor from './encodeFields/multiEncodeEditor';
+import { GLOBAL_CONFIG } from '../config';
 
 type aestheticFields = 'color' | 'opacity' | 'size' | 'shape' | 'details' | 'text';
 
@@ -39,18 +41,28 @@ const AestheticFields: React.FC = (props) => {
                 return aestheticFields.filter((f) => f.id !== 'text');
         }
     }, [geoms[0]]);
+
     return (
         <div>
-            {channels.map((dkey, i, { length }) => (
-                <AestheticFieldContainer name={dkey.id} key={dkey.id} style={{ position: 'relative' }}>
-                    <Droppable droppableId={dkey.id} direction="horizontal">
-                        {(provided, snapshot) => (
-                            // <OBFieldContainer dkey={dkey} provided={provided} />
-                            <SingleEncodeEditor dkey={dkey} provided={provided} snapshot={snapshot} />
-                        )}
-                    </Droppable>
-                </AestheticFieldContainer>
-            ))}
+            {channels.map((dkey, i, { length }) => {
+                if (GLOBAL_CONFIG.CHANNEL_LIMIT[dkey.id] === 1) {
+                    return (
+                        <AestheticFieldContainer name={dkey.id} key={dkey.id} style={{ position: 'relative' }}>
+                            <Droppable droppableId={dkey.id} direction="horizontal">
+                                {(provided, snapshot) => <SingleEncodeEditor dkey={dkey} provided={provided} snapshot={snapshot} />}
+                            </Droppable>
+                        </AestheticFieldContainer>
+                    );
+                } else {
+                    return (
+                        <AestheticFieldContainer name={dkey.id} key={dkey.id} style={{ position: 'relative' }}>
+                            <Droppable droppableId={dkey.id} direction="vertical">
+                                {(provided, snapshot) => <MultiEncodeEditor dkey={dkey} provided={provided} snapshot={snapshot} />}
+                            </Droppable>
+                        </AestheticFieldContainer>
+                    );
+                }
+            })}
         </div>
     );
 };

--- a/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
@@ -1,0 +1,128 @@
+import React, { useMemo } from 'react';
+import { DraggableFieldState, IAggregator, IDraggableStateKey } from '../../interfaces';
+import { observer } from 'mobx-react-lite';
+import { useVizStore } from '../../store';
+import { DroppableProvided } from 'react-beautiful-dnd';
+import { ChevronUpDownIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../../constants';
+import DropdownContext from '../../components/dropdownContext';
+import { GLOBAL_CONFIG } from '../../config';
+import { Draggable, DroppableStateSnapshot } from '@kanaries/react-beautiful-dnd';
+import styled from 'styled-components';
+import SelectContext, { type ISelectContextOption } from '../../components/selectContext';
+import { refMapper } from '../fieldsContext';
+
+const PillActions = styled.div`
+    overflow: visible !important;
+    width: calc(100% - 1.875rem);
+`;
+
+interface MultiEncodeEditorProps {
+    dkey: {
+        id: keyof Omit<DraggableFieldState, 'filters'>;
+    };
+    provided: DroppableProvided;
+    snapshot: DroppableStateSnapshot;
+}
+const SingleEncodeEditor: React.FC<MultiEncodeEditorProps> = (props) => {
+    const { dkey, provided, snapshot } = props;
+    const vizStore = useVizStore();
+    const { allEncodings, config, allFields } = vizStore;
+    const folds = config.folds ?? [];
+    const channelItems = allEncodings[dkey.id];
+    const { t } = useTranslation();
+
+    const aggregationOptions = useMemo(() => {
+        return GLOBAL_CONFIG.AGGREGATOR_LIST.map((op) => ({
+            value: op,
+            label: t(`constant.aggregator.${op}`),
+        }));
+    }, []);
+
+    const foldOptions = useMemo<ISelectContextOption[]>(() => {
+        const validFoldBy = allFields.filter((f) => f.analyticType === 'measure' && f.fid !== MEA_VAL_ID);
+        return validFoldBy.map<ISelectContextOption>((f) => ({
+            key: f.fid,
+            label: f.name,
+        }));
+    }, [allFields]);
+
+    return (
+        <div className="relative select-none flex flex-col py-0.5 px-1" {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
+            {channelItems.map((channelItem, index) => {
+                return (
+                    <Draggable key={channelItem.dragId} draggableId={channelItem.dragId} index={index}>
+                        {(provided, snapshot) => {
+                            return (
+                                <div
+                                    ref={refMapper(provided.innerRef)}
+                                    {...provided.draggableProps}
+                                    {...provided.dragHandleProps}
+                                    className={
+                                        'flex items-stretch h-[30px] my-0.5 relative' +
+                                        (provided.draggableProps.style?.transform ? ' z-10' : '') +
+                                        (channelItem.aggName === 'expr' && !config.defaultAggregated ? ' !opacity-50' : '')
+                                    }
+                                >
+                                    <div
+                                        onClick={() => {
+                                            vizStore.removeField(dkey.id, 0);
+                                        }}
+                                        className="grow-0 shrink-0 px-1.5 flex items-center justify-center bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 cursor-pointer"
+                                    >
+                                        <TrashIcon className="w-4" />
+                                    </div>
+                                    <PillActions className="flex-1 flex items-center border border-gray-200 dark:border-gray-700 border-l-0 px-2 space-x-2 truncate">
+                                        {channelItem.fid === MEA_KEY_ID && (
+                                            <SelectContext
+                                                options={foldOptions}
+                                                selectedKeys={folds}
+                                                onSelect={(keys) => {
+                                                    vizStore.setVisualConfig('folds', keys);
+                                                }}
+                                                className="flex-1"
+                                            >
+                                                <span className="flex-1 truncate" title={channelItem.name}>
+                                                    {channelItem.name}
+                                                </span>
+                                            </SelectContext>
+                                        )}
+                                        {channelItem.fid !== MEA_KEY_ID && <span className="flex-1 truncate">{channelItem.name}</span>}{' '}
+                                        {channelItem.analyticType === 'measure' &&
+                                            channelItem.fid !== COUNT_FIELD_ID &&
+                                            config.defaultAggregated &&
+                                            channelItem.aggName !== 'expr' && (
+                                                <DropdownContext
+                                                    options={aggregationOptions}
+                                                    onSelect={(value) => {
+                                                        vizStore.setFieldAggregator(dkey.id, 0, value as IAggregator);
+                                                    }}
+                                                >
+                                                    <span className="bg-transparent text-gray-700 dark:text-gray-200 float-right focus:outline-none focus:border-gray-500 dark:focus:border-gray-400 flex items-center ml-2">
+                                                        {channelItem.aggName || ''}
+                                                        <ChevronUpDownIcon className="w-3" />
+                                                    </span>
+                                                </DropdownContext>
+                                            )}
+                                    </PillActions>
+                                </div>
+                            );
+                        }}
+                    </Draggable>
+                );
+            })}
+            {channelItems.length !== 0 && provided.placeholder}
+            {channelItems.length === 0 && <div className={`h-[34px] w-full`} />}
+            <div
+                className={`p-1.5 m-1 bg-gray-50 dark:bg-gray-900 pointer-events-none border border-gray-200 dark:border-gray-700 flex item-center justify-center grow text-gray-500 dark:text-gray-400 ${
+                    (snapshot.draggingFromThisWith && channelItems.length === 1) || channelItems.length === 0 ? 'opacity-100' : 'opacity-0'
+                } absolute inset-0 z-0`}
+            >
+                {t('actions.drop_field')}
+            </div>
+        </div>
+    );
+};
+
+export default observer(SingleEncodeEditor);


### PR DESCRIPTION
This PR allows the details channel to display multiple fields within it, instead of hiding them as before.
![20240124143213_rec_](https://github.com/Kanaries/graphic-walker/assets/15280968/4b8d7e52-d2fa-43c4-8de3-15d5dd6a9a5d)
