### PR TITLE
fix: darksource segment darkmode

### DIFF
--- a/packages/graphic-walker/src/dataSource/dataSelection/csvData.tsx
+++ b/packages/graphic-walker/src/dataSource/dataSelection/csvData.tsx
@@ -91,7 +91,7 @@ const CSVData: React.FC<ICSVData> = ({ commonStore }) => {
                                             classNames(
                                                 checked
                                                     ? 'bg-indigo-600 text-white hover:bg-indigo-500'
-                                                    : 'ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800',
+                                                    : 'ring-1 ring-inset ring-gray-300 text-gray-900 dark:text-gray-50 hover:bg-gray-50 dark:hover:bg-gray-800',
                                                 'flex cursor-pointer items-center justify-center rounded py-1 px-8 text-sm font-semibold uppercase sm:flex-1'
                                             )
                                         }

--- a/packages/graphic-walker/src/dataSource/index.tsx
+++ b/packages/graphic-walker/src/dataSource/index.tsx
@@ -8,10 +8,11 @@ import DataSelection from './dataSelection';
 import DefaultButton from '../components/button/default';
 import DropdownSelect from '../components/dropdownSelect';
 import PrimaryButton from '../components/button/primary';
-import { IComputationFunction, IDataSourceEventType, IDataSourceProvider, IMutField } from '../interfaces';
+import { IComputationFunction, IDarkMode, IDataSourceEventType, IDataSourceProvider, IMutField } from '../interfaces';
 import { ShadowDom } from '../shadow-dom';
 import { CommonStore } from '../store/commonStore';
 import { VizSpecStore } from '../store/visualSpecStore';
+import { useCurrentMediaTheme } from '../utils/media';
 
 interface DSSegmentProps {
     commonStore: CommonStore;
@@ -97,6 +98,7 @@ function once<T extends (...args: any[]) => any>(register: (x: T) => () => void,
 export function DataSourceSegmentComponent(props: {
     provider: IDataSourceProvider;
     displayOffset?: number;
+    dark?: IDarkMode;
     children: (props: {
         meta: IMutField[];
         onMetaChange: (fid: string, meta: Partial<IMutField>) => void;
@@ -212,17 +214,21 @@ export function DataSourceSegmentComponent(props: {
         }
     }, [selectedId, props.provider]);
 
+    const darkMode = useCurrentMediaTheme(props.dark);
+
     return (
         <>
             <ShadowDom>
-                <DataSourceSegment
-                    commonStore={commonStore}
-                    dataSources={datasetList}
-                    onSelectId={setSelectedId}
-                    selectedId={selectedId}
-                    onLoad={onLoad}
-                    onSave={onSave}
-                />
+                <div className={`${darkMode === 'dark' ? 'dark' : ''}`}>
+                    <DataSourceSegment
+                        commonStore={commonStore}
+                        dataSources={datasetList}
+                        onSelectId={setSelectedId}
+                        selectedId={selectedId}
+                        onLoad={onLoad}
+                        onSave={onSave}
+                    />
+                </div>
             </ShadowDom>
             <props.children
                 computation={computation}

--- a/packages/graphic-walker/src/vanilla.tsx
+++ b/packages/graphic-walker/src/vanilla.tsx
@@ -6,7 +6,7 @@ import createMemoryProvider from './dataSourceProvider/memory';
 function FullGraphicWalker(props: IGWProps) {
     const provider = useMemo(() => createMemoryProvider(), []);
     return (
-        <DataSourceSegmentComponent provider={provider}>
+        <DataSourceSegmentComponent provider={provider} dark={props.dark}>
             {(p) => {
                 return (
                     <GraphicWalker


### PR DESCRIPTION
add dark mode for datasource segement
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/96bb1169-5c5a-48a1-b8ea-90086bba9f6e)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/02f98aae-3cf8-44c5-a842-9a801bb97681)
