### PR TITLE
fix: lighten OBPill's border color

### DIFF
--- a/packages/graphic-walker/src/fields/components.tsx
+++ b/packages/graphic-walker/src/fields/components.tsx
@@ -112,7 +112,7 @@ export const FilterFieldSegment = styled.div`
 
 export const Pill = styled.div<{ colType: 'discrete' | 'continuous' }>`
     background-color: ${(props) => (props.colType === 'continuous' ? 'hsl(var(--background))' : 'hsl(var(--primary))')};
-    border-color: ${(props) => (props.colType === 'continuous' ? 'hsl(var(--border))' : 'hsl(var(--background))')};
+    border-color: ${(props) => (props.colType === 'continuous' ? 'hsl(var(--muted-foreground))' : 'hsl(var(--background))')};
     color: ${(props) => (props.colType === 'continuous' ? 'hsl(var(--foreground))' : 'hsl(var(--primary-foreground))')};
     -moz-user-select: none;
     -ms-user-select: none;


### PR DESCRIPTION
fixed the contrast of badge border in X-Y axis.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/47807261-bef4-4bba-abdc-68a44e84741f)
