### PR TITLE
fix: sql field highlight replace order

### DIFF
--- a/packages/graphic-walker/src/components/computedField/index.tsx
+++ b/packages/graphic-walker/src/components/computedField/index.tsx
@@ -31,6 +31,11 @@ const ComputedFieldDialog: React.FC = observer(() => {
             .join('|');
         const fieldRegex = fields.length > 0 ? new RegExp(`\\b(${fields})\\b`, 'gi') : null;
         return highlightField((sql: string) => {
+            // highlight field
+            if (fieldRegex) {
+                sql = sql.replace(fieldRegex, '<span class="text-blue-700 dark:text-blue-600">$1</span>');
+            }
+
             // highlight keyword
             sql = sql.replace(keywordRegex, '<span class="text-fuchsia-700 dark:text-fuchsia-600">$1</span>');
 
@@ -42,11 +47,6 @@ const ComputedFieldDialog: React.FC = observer(() => {
 
             // highlight string
             sql = sql.replace(stringRegex, '<span class="text-green-700 dark:text-green-600">$1</span>');
-
-            // highlight field
-            if (fieldRegex) {
-                sql = sql.replace(fieldRegex, '<span class="text-blue-700 dark:text-blue-600">$1</span>');
-            }
 
             return sql;
         });

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -378,7 +378,6 @@ export class VizSpecStore {
     }
 
     setVisualConfig(...args: KVTuple<IVisualConfigNew>) {
-        console.log('setConfig');
         this.visList[this.visIndex] = performers.setConfig(this.visList[this.visIndex], ...args);
     }
 


### PR DESCRIPTION
fixed the issue when there is field that named as "dark", "className", "div", ...etc, and the computed field editor will be broken.