### PR TITLE
chore: change emit contents

### DIFF
--- a/packages/duckdb-wasm-computation/package.json
+++ b/packages/duckdb-wasm-computation/package.json
@@ -21,6 +21,6 @@
     "nanoid": "^5.0.1"
   },
   "devDependencies": {
-    "typescript": "^4.3.2"
+    "typescript": "^5.2.2"
   }
 }

--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --build",
     "build:app": "vite build --config vite-app.config.ts",
     "serve": "vite preview",
     "type": "tsc src/lib.ts --declaration --emitDeclarationOnly --jsx react --esModuleInterop --outDir dist",
@@ -19,17 +19,22 @@
     "name": "Kanaries Data Inc.",
     "email": "support@kanaries.net"
   },
-  "main": "./dist/graphic-walker.umd.js",
+  "sideEffects": ["./dist/graphic-walker.es.js", "./dist/graphic-walker.cjs.js", "./dist/component.es.js", "./dist/component.cjs.js"],
+  "main": "./dist/graphic-walker.cjs.js",
   "module": "./dist/graphic-walker.es.js",
   "exports": {
     ".": {
       "import": "./dist/graphic-walker.es.js",
-      "require": "./dist/graphic-walker.umd.js",
+      "require": "./dist/graphic-walker.cjs.js",
       "types": "./dist/index.d.ts"
     },
     "./dist/style.css": {
       "import": "./dist/style.css",
       "require": "./dist/style.css"
+    },
+    "./*": {
+      "import": "./dist/*.js",
+      "types": "./dist/*.d.ts"
     }
   },
   "prettier": {
@@ -124,7 +129,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "styled-components": "^5.3.6",
     "ts-xor": "^1.3.0",
-    "typescript": "^5.1.6",
+    "typescript": "^5.2.2",
     "vite": "^4.1.1"
   },
   "peerDependencies": {

--- a/packages/graphic-walker/tsconfig.json
+++ b/packages/graphic-walker/tsconfig.json
@@ -14,7 +14,6 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,10 +2016,10 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@*", "@types/react-dom@^18.2.15":
-  version "18.2.18"
-  resolved "https://registry.npmmirror.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
-  integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
+"@types/react-dom@*", "@types/react-dom@^18.2.15", "@types/react-dom@^18.x":
+  version "18.2.19"
+  resolved "https://registry.npmmirror.com/@types/react-dom/-/react-dom-18.2.19.tgz#b84b7c30c635a6c26c6a6dfbb599b2da9788be58"
+  integrity sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==
   dependencies:
     "@types/react" "*"
 
@@ -2030,10 +2030,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.37":
-  version "18.2.55"
-  resolved "https://registry.npmmirror.com/@types/react/-/react-18.2.55.tgz#38141821b7084404b5013742bc4ae08e44da7a67"
-  integrity sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==
+"@types/react@*", "@types/react@^18.2.37", "@types/react@^18.x":
+  version "18.2.61"
+  resolved "https://registry.npmmirror.com/@types/react/-/react-18.2.61.tgz#5607308495037436779939ec0348a5816c08799d"
+  integrity sha512-NURTN0qNnJa7O/k4XUkEW2yfygA+NxS0V5h1+kp9jPwhzZy95q3ADoGMP0+JypMhrZBTTgjKAUlTctde1zzeQA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -5542,12 +5542,7 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.3.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@^5.1.6, typescript@^5.2.2:
+typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==


### PR DESCRIPTION
This PR changes the output of graphic-walker's build, and make users can import minimal items from graphic walkers by codes like:
```
import { chartToWorkflow } from '@kanaries/graphic-walker/utils/workflow';
```