### PR TITLE
Remove dragId from specs

### DIFF
--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -139,7 +139,6 @@ function useFilters(metas: IMutField[]) {
                     fid,
                     rule: null,
                     analyticType: meta.analyticType,
-                    dragId: '',
                     name: meta.name ?? meta.fid,
                     semanticType: meta.semanticType,
                 };

--- a/packages/graphic-walker/src/fields/datasetFields/dimFields.tsx
+++ b/packages/graphic-walker/src/fields/datasetFields/dimFields.tsx
@@ -8,6 +8,7 @@ import ActionMenu from '../../components/actionMenu';
 import { FieldPill } from './fieldPill';
 import { useMenuActions } from './utils';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 interface Props {
     provided: DroppableProvided;
@@ -20,7 +21,7 @@ const DimFields: React.FC<Props> = (props) => {
     return (
         <div {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {dimensions.map((f, index) => (
-                <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
+                <Draggable key={getFieldIdentifier(f)} draggableId={`dimension_${getFieldIdentifier(f)}`} index={index}>
                     {(provided, snapshot) => {
                         return (
                             <ActionMenu title={f.name || f.fid} menu={menuActions[index]} enableContextMenu disabled={snapshot.isDragging}>

--- a/packages/graphic-walker/src/fields/datasetFields/meaFields.tsx
+++ b/packages/graphic-walker/src/fields/datasetFields/meaFields.tsx
@@ -9,6 +9,7 @@ import { useMenuActions } from './utils';
 import { FieldPill } from './fieldPill';
 import { MEA_KEY_ID } from '../../constants';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 interface Props {
     provided: DroppableProvided;
@@ -23,7 +24,7 @@ const MeaFields: React.FC<Props> = (props) => {
     return (
         <div {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {measures.map((f, index) => (
-                <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
+                <Draggable key={getFieldIdentifier(f)} draggableId={`measure_${getFieldIdentifier(f)}`}  index={index}>
                     {(provided, snapshot) => {
                         return (
                             <div className="block">

--- a/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
@@ -12,6 +12,7 @@ import { Draggable, DroppableStateSnapshot } from '@kanaries/react-beautiful-dnd
 import styled from 'styled-components';
 import SelectContext, { type ISelectContextOption } from '../../components/selectContext';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 const PillActions = styled.div`
     overflow: visible !important;
@@ -52,7 +53,7 @@ const SingleEncodeEditor: React.FC<MultiEncodeEditorProps> = (props) => {
         <div className="relative select-none flex flex-col py-0.5 px-1" {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {channelItems.map((channelItem, index) => {
                 return (
-                    <Draggable key={channelItem.dragId} draggableId={channelItem.dragId} index={index}>
+                    <Draggable key={getFieldIdentifier(channelItem)} draggableId={`encode_${dkey.id}_${getFieldIdentifier(channelItem)}`} index={index}>
                         {(provided, snapshot) => {
                             return (
                                 <div

--- a/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
@@ -12,6 +12,7 @@ import { Draggable, DroppableStateSnapshot } from '@kanaries/react-beautiful-dnd
 import styled from 'styled-components';
 import SelectContext, { type ISelectContextOption } from '../../components/selectContext';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 const PillActions = styled.div`
     overflow: visible !important;
@@ -58,7 +59,7 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
                 {t('actions.drop_field')}
             </div>
             {channelItem && (
-                <Draggable key={channelItem.dragId} draggableId={channelItem.dragId} index={0}>
+                <Draggable key={getFieldIdentifier(channelItem)} draggableId={`encode_${dkey.id}_${getFieldIdentifier(channelItem)}`} index={0}>
                     {(provided, snapshot) => {
                         return (
                             <div

--- a/packages/graphic-walker/src/fields/filterField/index.tsx
+++ b/packages/graphic-walker/src/fields/filterField/index.tsx
@@ -10,6 +10,7 @@ import { FilterFieldContainer, FilterFieldsContainer } from '../components';
 import FilterPill from './filterPill';
 import FilterEditDialog from './filterEditDialog';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 
 interface FieldContainerProps {
@@ -26,7 +27,7 @@ const FilterItemContainer: React.FC<FieldContainerProps> = observer(({ provided 
             ref={refMapper(provided.innerRef)}
         >
             {filters.map((f, index) => (
-                <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
+                <Draggable key={getFieldIdentifier(f)} draggableId={`filters_${getFieldIdentifier(f)}`} index={index}>
                     {(provided, snapshot) => {
                         return (
                             <FilterPill

--- a/packages/graphic-walker/src/fields/obComponents/obFContainer.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obFContainer.tsx
@@ -6,6 +6,7 @@ import { Draggable, DroppableProvided } from '@kanaries/react-beautiful-dnd';
 import { IDraggableViewStateKey } from '../../interfaces';
 import OBPill from './obPill';
 import { refMapper } from '../fieldsContext';
+import { getFieldIdentifier } from '@/utils';
 
 interface FieldContainerProps {
     provided: DroppableProvided;
@@ -22,7 +23,7 @@ const OBFieldContainer: React.FC<FieldContainerProps> = (props) => {
         <FieldsContainer {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {/* {provided.placeholder} */}
             {allEncodings[dkey.id].map((f, index) => (
-                <Draggable key={f.dragId} draggableId={f.dragId} index={index}>
+                <Draggable key={getFieldIdentifier(f)} draggableId={`encode_${dkey.id}_${getFieldIdentifier(f)}`} index={index}>
                     {(provided, snapshot) => {
                         return <OBPill dkey={dkey} fIndex={index} provided={provided} />;
                     }}

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -214,6 +214,7 @@ export interface IViewField extends IField {
     sort?: ISortMode;
 }
 
+// shadow type of identifier of a Field, getting it using "getFieldIdentifier" in "@/utils"
 export type FieldIdentifier = string & { _tagFieldId: never };
 
 export interface DataSet {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -211,9 +211,10 @@ export interface IField {
 }
 export type ISortMode = 'none' | 'ascending' | 'descending';
 export interface IViewField extends IField {
-    dragId: string;
     sort?: ISortMode;
 }
+
+export type FieldIdentifier = string & { _tagFieldId: never };
 
 export interface DataSet {
     id: string;
@@ -899,10 +900,7 @@ export interface IVizProps {
         features?: {
             askviz?: string | boolean | ((metas: IViewField[], query: string) => PromiseLike<IVisSpec | IChart> | IVisSpec | IChart);
             feedbackAskviz?: string | boolean | ((data: IAskVizFeedback) => void);
-            vlChat?:
-                | string
-                | boolean
-                | ((metas: IViewField[], chats: IChatMessage[]) => PromiseLike<IVisSpec | IChart> | IVisSpec | IChart);
+            vlChat?: string | boolean | ((metas: IViewField[], chats: IChatMessage[]) => PromiseLike<IVisSpec | IChart> | IVisSpec | IChart);
         };
     };
     geoList?: IGeoDataItem[];

--- a/packages/graphic-walker/src/lib/op/fold.ts
+++ b/packages/graphic-walker/src/lib/op/fold.ts
@@ -31,9 +31,9 @@ export function replaceAggForFold<T extends { aggName?: string }>(x: T, newAggNa
 export function fold2(
     data: IRow,
     defaultAggregated: boolean,
-    allFields: Omit<IViewField, 'dragId'>[],
-    viewMeasures: Omit<IViewField, 'dragId'>[],
-    viewDimensions: Omit<IViewField, 'dragId'>[],
+    allFields: IViewField[],
+    viewMeasures: IViewField[],
+    viewDimensions: IViewField[],
     folds?: string[]
 ) {
     const meaVal = viewMeasures.find((x) => x.fid === MEA_VAL_ID);

--- a/packages/graphic-walker/src/lib/vl2gw.ts
+++ b/packages/graphic-walker/src/lib/vl2gw.ts
@@ -34,7 +34,6 @@ const aggNames = new Set(['sum', 'count', 'max', 'min', 'mean', 'median', 'varia
 const isValidAggregate = (aggName?: string): aggName is AggregateName => !!aggName && aggNames.has(aggName);
 
 const countField: IViewField = {
-    dragId: 'gw_count_fid',
     fid: 'gw_count_fid',
     name: 'Row count',
     analyticType: 'measure',
@@ -106,7 +105,6 @@ function createBinField(field: IViewField): IViewField {
     const newId = `gw_${nanoid(4)}`;
     return {
         fid: newId,
-        dragId: newId,
         name: `bin(${field.name})`,
         semanticType: 'ordinal',
         analyticType: 'dimension',
@@ -357,7 +355,6 @@ export function VegaliteMapper(vl: any, allFields: IViewField[], visId: string, 
                     {
                         name: x.dimensionType,
                         value: binFields.get(x.binDimension.name) ?? x.binDimension,
-                        dragId: `gw_${nanoid(4)}`,
                     },
                 ];
             }
@@ -367,7 +364,6 @@ export function VegaliteMapper(vl: any, allFields: IViewField[], visId: string, 
                     name: x.dimensionType,
                     value: {
                         ...x.dimension,
-                        dragId: `gw_${nanoid(4)}`,
                         analyticType,
                         ...(x.aggregate
                             ? {
@@ -422,7 +418,6 @@ export function VegaliteMapper(vl: any, allFields: IViewField[], visId: string, 
                     const originalField = dict.get(f.fid)!;
                     return {
                         ...originalField,
-                        dragId: `gw_${nanoid(4)}`,
                         rule: f.rule,
                     };
                 }),

--- a/packages/graphic-walker/src/renderer/hooks.ts
+++ b/packages/graphic-walker/src/renderer/hooks.ts
@@ -7,9 +7,9 @@ import { dataQuery } from '../computation';
 import { fold2 } from '../lib/op/fold';
 
 interface UseRendererProps {
-    allFields: Omit<IViewField, 'dragId'>[];
-    viewDimensions: Omit<IViewField, 'dragId'>[];
-    viewMeasures: Omit<IViewField, 'dragId'>[];
+    allFields: IViewField[];
+    viewDimensions: IViewField[];
+    viewMeasures: IViewField[];
     filters: IFilterField[];
     defaultAggregated: boolean;
     sort: 'none' | 'ascending' | 'descending';

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -287,7 +287,7 @@ export class VizSpecStore {
         if (oriF.fid === MEA_KEY_ID || oriF.fid === MEA_VAL_ID || oriF.fid === COUNT_FIELD_ID || oriF.aggName === 'expr') {
             return;
         }
-        this.visList[this.visIndex] = performers.appendFilter(this.visList[this.visIndex], index, sourceKey, sourceIndex, uniqueId());
+        this.visList[this.visIndex] = performers.appendFilter(this.visList[this.visIndex], index, sourceKey, sourceIndex, null);
         this.editingFilterIdx = index;
     }
 

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../constants';
-import { IRow, Filters, IViewField, IFilterField, IKeyWord } from '../interfaces';
+import { IRow, Filters, IViewField, IFilterField, IKeyWord, IField, FieldIdentifier } from '../interfaces';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
@@ -233,7 +233,6 @@ export function applyFilters(dataSource: IRow[], filters: Filters): IRow[] {
 export function createCountField(): IViewField {
     return {
         // viewId: "",
-        dragId: COUNT_FIELD_ID,
         fid: COUNT_FIELD_ID,
         name: i18next.t('constant.row_count'),
         analyticType: 'measure',
@@ -251,14 +250,12 @@ export function createCountField(): IViewField {
 export function createVirtualFields(): IViewField[] {
     return [
         {
-            dragId: MEA_KEY_ID,
             fid: MEA_KEY_ID,
             name: i18next.t('constant.mea_key'),
             analyticType: 'dimension',
             semanticType: 'nominal',
         },
         {
-            dragId: MEA_VAL_ID,
             fid: MEA_VAL_ID,
             name: i18next.t('constant.mea_val'),
             analyticType: 'measure',
@@ -266,6 +263,10 @@ export function createVirtualFields(): IViewField[] {
             aggName: 'sum',
         },
     ];
+}
+
+export function getFieldIdentifier(field: IField): FieldIdentifier {
+    return field.fid as FieldIdentifier;
 }
 
 export function getRange(nums: number[]): [number, number] {
@@ -416,7 +417,7 @@ export function _unstable_encodeRuleValue(value: any) {
     return value;
 }
 
-export function arrayEqual (list1: any[], list2: any[]): boolean {
+export function arrayEqual(list1: any[], list2: any[]): boolean {
     if (list1.length !== list2.length) {
         return false;
     }

--- a/packages/graphic-walker/src/utils/workflow.ts
+++ b/packages/graphic-walker/src/utils/workflow.ts
@@ -126,9 +126,9 @@ export const createFilter = (f: IFilterField): IVisFilter => {
 
 export const toWorkflow = (
     viewFilters: VizSpecStore['viewFilters'],
-    allFields: Omit<IViewField, 'dragId'>[],
-    viewDimensionsRaw: Omit<IViewField, 'dragId'>[],
-    viewMeasuresRaw: Omit<IViewField, 'dragId'>[],
+    allFields: IViewField[],
+    viewDimensionsRaw: IViewField[],
+    viewMeasuresRaw: IViewField[],
     defaultAggregated: VizSpecStore['config']['defaultAggregated'],
     sort: 'none' | 'ascending' | 'descending',
     folds = [] as string[],

--- a/packages/graphic-walker/src/vis/spec/field.ts
+++ b/packages/graphic-walker/src/vis/spec/field.ts
@@ -1,7 +1,6 @@
 import { IViewField } from "../../interfaces";
 
 export const NULL_FIELD: IViewField = {
-    dragId: '',
     fid: '',
     name: '',
     semanticType: 'quantitative',


### PR DESCRIPTION
The dragId field in the graphic walker spec is redundant, and had caused many dragging issue.
This PR removed dragId from the specs, used a method to generate a unique dragId in component, to avoid bugs casued by duplicate dragId in spec.