### PR TITLE
feat: add option to show all geoshapes

### DIFF
--- a/packages/graphic-walker/src/components/leafletRenderer/ChoroplethRenderer.tsx
+++ b/packages/graphic-walker/src/components/leafletRenderer/ChoroplethRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import React, { Fragment, forwardRef, useContext, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
 import { CircleMarker, MapContainer, Polygon, Marker, TileLayer, Tooltip, AttributionControl } from 'react-leaflet';
 import { type Map, divIcon } from 'leaflet';
 import type { DeepReadonly, IChannelScales, IGeoUrl, IRow, IViewField, VegaGlobalConfig } from '../../interfaces';
@@ -14,6 +14,7 @@ import { ChangeView } from './utils';
 import ColorPanel from './color';
 import { getColor } from '@/utils/useTheme';
 import { field } from 'vega';
+import { themeContext } from '@/store/theme';
 
 export interface IChoroplethRendererProps {
     name?: string;
@@ -116,6 +117,8 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
         channelScales,
         tileUrl,
     } = props;
+
+    const darkMode = useContext(themeContext);
 
     useImperativeHandle(ref, () => ({}));
 
@@ -265,6 +268,8 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
         return <div className="flex items-center justify-center w-full h-full">{t('main.tabpanel.settings.geography_settings.loading')}</div>;
     }
 
+    const border = darkMode === 'dark' ? '#fff4' : '#0004';
+
     return (
         <MapContainer
             preferCanvas
@@ -305,7 +310,7 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
                                             opacity={0.8}
                                             fillOpacity={opacity}
                                             fillColor={color}
-                                            color="#0004"
+                                            color={border}
                                             weight={1}
                                             stroke
                                             fill
@@ -329,7 +334,7 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
                                             pathOptions={{
                                                 fillOpacity: opacity * 0.8,
                                                 fillColor: color,
-                                                color: '#0004',
+                                                color: border,
                                                 weight: 1,
                                                 stroke: true,
                                                 fill: true,
@@ -362,7 +367,7 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
                 })}
             {missingDataGeoShapes.map(({ coords, name }, i) => {
                 const opacity = 0.3;
-                const { primaryColor } = getColor(vegaConfig);
+                const color = '#808080';
                 return (
                     <Fragment key={`missing-${i}`}>
                         {coords.map((coord, j) => {
@@ -377,8 +382,8 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
                                         radius={3}
                                         opacity={0.8}
                                         fillOpacity={opacity}
-                                        fillColor={primaryColor}
-                                        color="#0004"
+                                        fillColor={color}
+                                        color={border}
                                         weight={1}
                                         stroke
                                         fill
@@ -401,8 +406,8 @@ const ChoroplethRenderer = forwardRef<IChoroplethRendererRef, IChoroplethRendere
                                         positions={coord}
                                         pathOptions={{
                                             fillOpacity: opacity * 0.8,
-                                            fillColor: primaryColor,
-                                            color: '#0004',
+                                            fillColor: color,
+                                            color: border,
                                             weight: 1,
                                             stroke: true,
                                             fill: true,

--- a/packages/graphic-walker/src/components/leafletRenderer/index.tsx
+++ b/packages/graphic-walker/src/components/leafletRenderer/index.tsx
@@ -40,7 +40,7 @@ const LeafletRenderer = forwardRef<ILeafletRendererRef, ILeafletRendererProps>(f
         defaultAggregated,
         geoms: [markType],
     } = visualConfig;
-    const { geojson, geoKey = '', geoUrl, scaleIncludeUnmatchedChoropleth = false, geoMapTileUrl } = visualLayout;
+    const { geojson, geoKey = '', geoUrl, scaleIncludeUnmatchedChoropleth = false, showAllGeoshapeInChoropleth = false, geoMapTileUrl } = visualLayout;
     const allFields = useMemo(() => [...dimensions, ...measures], [dimensions, measures]);
     const latField = useMemo(() => allFields.find((f) => f.geoRole === 'latitude'), [allFields]);
     const lngField = useMemo(() => allFields.find((f) => f.geoRole === 'longitude'), [allFields]);
@@ -64,7 +64,6 @@ const LeafletRenderer = forwardRef<ILeafletRendererRef, ILeafletRendererProps>(f
     }, [channelScaleRaw, scale]);
 
     const tileUrl = geoMapTileUrl ?? vegaConfig.leafletGeoTileUrl;
-    
 
     if (markType === 'poi') {
         return (
@@ -102,6 +101,7 @@ const LeafletRenderer = forwardRef<ILeafletRendererRef, ILeafletRendererProps>(f
                 details={details}
                 vegaConfig={vegaConfig}
                 scaleIncludeUnmatchedChoropleth={scaleIncludeUnmatchedChoropleth}
+                showAllGeoshapeInChoropleth={showAllGeoshapeInChoropleth}
                 channelScales={channelScales}
             />
         );

--- a/packages/graphic-walker/src/components/visualConfig/index.tsx
+++ b/packages/graphic-walker/src/components/visualConfig/index.tsx
@@ -93,6 +93,7 @@ const VisualConfigPanel: React.FC = () => {
     const [zeroScale, setZeroScale] = useState<boolean>(layout.zeroScale);
     const [svg, setSvg] = useState<boolean>(layout.useSvg ?? false);
     const [scaleIncludeUnmatchedChoropleth, setScaleIncludeUnmatchedChoropleth] = useState<boolean>(layout.scaleIncludeUnmatchedChoropleth ?? false);
+    const [showAllGeoshapeInChoropleth, setShowAllGeoshapeInChoropleth] = useState<boolean>(layout.showAllGeoshapeInChoropleth ?? false);
     const [background, setBackground] = useState<string | undefined>(layout.background);
     const [defaultColor, setDefaultColor] = useState({ r: 91, g: 143, b: 249, a: 1 });
     const [colorEdited, setColorEdited] = useState(false);
@@ -385,6 +386,13 @@ const VisualConfigPanel: React.FC = () => {
                                             setScaleIncludeUnmatchedChoropleth(en);
                                         }}
                                     />
+                                    <Toggle
+                                        label="include shapes without data"
+                                        enabled={showAllGeoshapeInChoropleth}
+                                        onChange={(en) => {
+                                            setShowAllGeoshapeInChoropleth(en);
+                                        }}
+                                    />
                                 </div>
                                 <div className="flex flex-col space-y-2">
                                     <Toggle
@@ -431,6 +439,7 @@ const VisualConfigPanel: React.FC = () => {
                                         ['format', format],
                                         ['zeroScale', zeroScale],
                                         ['scaleIncludeUnmatchedChoropleth', scaleIncludeUnmatchedChoropleth],
+                                        ['showAllGeoshapeInChoropleth', showAllGeoshapeInChoropleth],
                                         ['background', background],
                                         ['resolve', resolve],
                                         ['colorPalette', colorPalette],

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -434,6 +434,7 @@ export interface IVisualLayout {
     background?: string;
     /** @default false */
     scaleIncludeUnmatchedChoropleth?: boolean;
+    showAllGeoshapeInChoropleth?: boolean;
 }
 
 export interface IVisualConfigNew {


### PR DESCRIPTION
This PR add a config to show all shapes in provided geoshape data, and will show them without data in a 0.3 opacity.

![image](https://github.com/Kanaries/graphic-walker/assets/15280968/c6ca8520-3fc1-4361-b94a-042f3cab1061)
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/dfc6b1e8-56fb-4912-b106-e8a350ba3f18)