### PR TITLE
fix: auto facet layout

### DIFF
--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -504,7 +504,10 @@ const ReactVega = forwardRef<IReactVegaHandler, ReactVegaProps>(function ReactVe
     useVegaExportApi(name, vegaRefs, ref, renderTaskRefs, containerRef);
 
     return (
-        <div className="w-full h-full relative" style={{ overflow: layoutMode === 'auto' ? 'visible' : 'hidden' }}>
+        <div
+            className={layoutMode === 'auto' ? 'w-fit h-fit relative' : 'w-full h-full relative'}
+            style={{ overflow: layoutMode === 'auto' ? 'visible' : 'hidden' }}
+        >
             <div ref={areaRef} className="inset-0 absolute" />
             <CanvaContainer
                 style={{


### PR DESCRIPTION
fixed a issue when using auto layout & facet view, the charts will be spaced between each other.

problem screenshot:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/1639d23e-cf3d-4c6a-9938-9bca6ab6a63a)

fixed:
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/1fdbedfe-bf5d-4f6a-9a6c-ce5519963547)
