### PR TITLE
fix: width issue when using color and repeat

### DIFF
--- a/packages/graphic-walker/src/vis/react-vega.tsx
+++ b/packages/graphic-walker/src/vis/react-vega.tsx
@@ -32,7 +32,7 @@ expressionFunction('formatBin', (datum: [number, number] | number, formatString?
 
 const CanvaContainer = styled.div<{ rowSize: number; colSize: number }>`
     display: grid;
-    grid-template-columns: repeat(${(props) => props.colSize}, 1fr);
+    grid-template-columns: repeat(${(props) => props.colSize}, auto);
     grid-template-rows: repeat(${(props) => props.rowSize}, 1fr);
 `;
 


### PR DESCRIPTION
Fixed a issue when using auto layout and color encoding and repeating field, there will be a gap that width equals to color panel.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/3b3080b8-95ad-462d-a797-178684a68e00)
