### PR TITLE
feat: modify ui of limit tool

### DIFF
--- a/packages/graphic-walker/src/components/limitSetting.tsx
+++ b/packages/graphic-walker/src/components/limitSetting.tsx
@@ -1,13 +1,15 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { createUseDebounceValueBind } from '../hooks';
+import { createStreamedValueBindHook } from '../hooks';
 import { Checkbox } from './ui/checkbox';
 import { Input } from './ui/input';
+import debounce from 'lodash-es/debounce';
+
+const useDebounceValueBind  = createStreamedValueBindHook((f) => debounce(f, 600));
 
 export default function LimitSetting(props: { value: number; setValue: (v: number) => void }) {
     const { t } = useTranslation('translation', { keyPrefix: 'main.tabpanel.settings' });
-    const [innerValue, setInnerValue] = createUseDebounceValueBind(600)(props.value, (v) => props.setValue(v));
-    const inputValue = useMemo(() => (innerValue > 0 ? innerValue : 0), [innerValue]);
+    const [innerValue, setInnerValue] = useDebounceValueBind(props.value, (v) => props.setValue(v));
 
     return (
         <div className="w-60 mt-2 p-2">
@@ -16,7 +18,7 @@ export default function LimitSetting(props: { value: number; setValue: (v: numbe
                 type='number'
                 min={0}
                 step={10}
-                value={inputValue}
+                value={innerValue}
                 onChange={(e) => setInnerValue(parseInt(e.target.value))}
             />
             <div className="ml-1 mt-3 flex items-center">

--- a/packages/graphic-walker/src/components/limitSetting.tsx
+++ b/packages/graphic-walker/src/components/limitSetting.tsx
@@ -10,7 +10,7 @@ const useDebounceValueBind  = createStreamedValueBindHook((f) => debounce(f, 600
 export default function LimitSetting(props: { value: number; setValue: (v: number) => void }) {
     const { t } = useTranslation('translation', { keyPrefix: 'main.tabpanel.settings' });
     const [enable, setEnable] = React.useState(props.value > 0);
-    const [innerValue, setInnerValue] = useDebounceValueBind(props.value <= 0 ? 100: props.value, (v) => enable && props.setValue(v));
+    const [innerValue, setInnerValue] = useDebounceValueBind(props.value > 0 ? props.value : 100, (v) => enable && props.setValue(v));
 
     return (
         <div className="w-60 mt-2 p-2">

--- a/packages/graphic-walker/src/components/limitSetting.tsx
+++ b/packages/graphic-walker/src/components/limitSetting.tsx
@@ -9,7 +9,8 @@ const useDebounceValueBind  = createStreamedValueBindHook((f) => debounce(f, 600
 
 export default function LimitSetting(props: { value: number; setValue: (v: number) => void }) {
     const { t } = useTranslation('translation', { keyPrefix: 'main.tabpanel.settings' });
-    const [innerValue, setInnerValue] = useDebounceValueBind(props.value, (v) => props.setValue(v));
+    const [enable, setEnable] = React.useState(props.value > 0);
+    const [innerValue, setInnerValue] = useDebounceValueBind(props.value <= 0 ? 100: props.value, (v) => enable && props.setValue(v));
 
     return (
         <div className="w-60 mt-2 p-2">
@@ -19,17 +20,19 @@ export default function LimitSetting(props: { value: number; setValue: (v: numbe
                 min={0}
                 step={10}
                 value={innerValue}
+                disabled={!enable}
                 onChange={(e) => setInnerValue(parseInt(e.target.value))}
             />
             <div className="ml-1 mt-3 flex items-center">
                 <Checkbox
                     className="mr-1"
-                    checked={innerValue > 0}
+                    checked={enable}
                     onCheckedChange={(v) => {
-                        setInnerValue(v ? 30 : -1);
+                        setEnable(!!v);
+                        v ? props.setValue(innerValue) : props.setValue(0);
                     }}
                 ></Checkbox>
-                {`${t('limit')}${innerValue > 0 ? `: ${innerValue}` : ''}`}
+                { t('limit') }
             </div>
         </div>
     );

--- a/packages/graphic-walker/src/components/limitSetting.tsx
+++ b/packages/graphic-walker/src/components/limitSetting.tsx
@@ -1,25 +1,23 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDebounceValueBind } from '../hooks';
+import { createUseDebounceValueBind } from '../hooks';
 import { Checkbox } from './ui/checkbox';
-import { Slider } from './ui/slider';
+import { Input } from './ui/input';
 
 export default function LimitSetting(props: { value: number; setValue: (v: number) => void }) {
     const { t } = useTranslation('translation', { keyPrefix: 'main.tabpanel.settings' });
-    const [innerValue, setInnerValue] = useDebounceValueBind(props.value, (v) => props.setValue(v));
-    const sliderValue = useMemo(() => (innerValue > 0 ? [innerValue] : [0]), [innerValue]);
+    const [innerValue, setInnerValue] = createUseDebounceValueBind(600)(props.value, (v) => props.setValue(v));
+    const inputValue = useMemo(() => (innerValue > 0 ? innerValue : 0), [innerValue]);
 
     return (
         <div className="w-60 mt-2 p-2">
-            <Slider
-                min={1}
-                max={50}
-                step={1}
-                name="limit"
-                className="w-full"
-                disabled={innerValue < 0}
-                onValueChange={([v]) => setInnerValue(v)}
-                value={sliderValue}
+            <Input
+                className='h-8'
+                type='number'
+                min={0}
+                step={10}
+                value={inputValue}
+                onChange={(e) => setInnerValue(parseInt(e.target.value))}
             />
             <div className="ml-1 mt-3 flex items-center">
                 <Checkbox

--- a/packages/graphic-walker/src/hooks/index.ts
+++ b/packages/graphic-walker/src/hooks/index.ts
@@ -30,9 +30,7 @@ export function createStreamedValueBindHook(wrapper: <T>(emitter: (v: T) => void
     };
 }
 
-export const createUseDebounceValueBind = (delay: number) => createStreamedValueBindHook((f) => debounce(f, delay));
-
-export const useDebounceValueBind = createUseDebounceValueBind(200);
+export const useDebounceValueBind = createStreamedValueBindHook((f) => debounce(f, 200));
 
 /**
  * hook of state that change of value will change innerValue inplace, make reduced re-render.

--- a/packages/graphic-walker/src/hooks/index.ts
+++ b/packages/graphic-walker/src/hooks/index.ts
@@ -30,7 +30,9 @@ export function createStreamedValueBindHook(wrapper: <T>(emitter: (v: T) => void
     };
 }
 
-export const useDebounceValueBind = createStreamedValueBindHook((f) => debounce(f, 200));
+export const createUseDebounceValueBind = (delay: number) => createStreamedValueBindHook((f) => debounce(f, delay));
+
+export const useDebounceValueBind = createUseDebounceValueBind(200);
 
 /**
  * hook of state that change of value will change innerValue inplace, make reduced re-render.

--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -222,7 +222,7 @@
                     "cancel": "Cancel",
                     "delete_paint": "Delete Painting"
                 },
-                "limit": "Limit",
+                "limit": "enable query limit (rows)",
                 "size": "Resize",
                 "size_setting": {
                     "width": "Width",

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -216,7 +216,7 @@
                     "cancel": "キャンセル",
                     "delete_paint": "キャンバスを削除"
                 },
-                "limit": "上限",
+                "limit": "クエリ制限 (行数) を有効にする",
                 "size": "サイズ変更",
                 "size_setting": {
                     "width": "幅",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -222,7 +222,7 @@
                     "cancel": "取消改动",
                     "delete_paint": "删除画板"
                 },
-                "limit": "上限",
+                "limit": "启用查询限制（行）",
                 "size": "调整尺寸",
                 "size_setting": {
                     "width": "宽度",


### PR DESCRIPTION
The limit value is a very precise value, and it is not so simple to adjust the limit using a slider.

So I think it might be simpler to allow users to enter the value directly.

![image](https://github.com/Kanaries/graphic-walker/assets/28337703/e8c030ad-5def-4b35-a561-d8315d6f2fc0)
