### PR TITLE
feat: modify ui of limit tool

### DIFF
--- a/packages/graphic-walker/src/locales/en-US.json
+++ b/packages/graphic-walker/src/locales/en-US.json
@@ -222,7 +222,7 @@
                     "cancel": "Cancel",
                     "delete_paint": "Delete Painting"
                 },
-                "limit": "Limit",
+                "limit": "enable query limit (rows)",
                 "size": "Resize",
                 "size_setting": {
                     "width": "Width",

--- a/packages/graphic-walker/src/locales/ja-JP.json
+++ b/packages/graphic-walker/src/locales/ja-JP.json
@@ -216,7 +216,7 @@
                     "cancel": "キャンセル",
                     "delete_paint": "キャンバスを削除"
                 },
-                "limit": "上限",
+                "limit": "クエリ制限 (行数) を有効にする",
                 "size": "サイズ変更",
                 "size_setting": {
                     "width": "幅",

--- a/packages/graphic-walker/src/locales/zh-CN.json
+++ b/packages/graphic-walker/src/locales/zh-CN.json
@@ -222,7 +222,7 @@
                     "cancel": "取消改动",
                     "delete_paint": "删除画板"
                 },
-                "limit": "上限",
+                "limit": "启用查询限制（行）",
                 "size": "调整尺寸",
                 "size_setting": {
                     "width": "宽度",


### PR DESCRIPTION
The limit value is a very precise value, and it is not so simple to adjust the limit using a slider.

So I think it might be simpler to allow users to enter the value directly.

<img width="1897" alt="image" src="https://github.com/Kanaries/graphic-walker/assets/28337703/a3b43ad2-b1c5-4d5f-a0f9-64fa36190a52">
