### PR TITLE
chore: add workflow tab in export

### DIFF
--- a/packages/graphic-walker/src/components/codeExport/index.tsx
+++ b/packages/graphic-walker/src/components/codeExport/index.tsx
@@ -50,6 +50,10 @@ const CodeExport: React.FC = observer((props) => {
             key: 'vega-lite',
             label: 'Vega-Lite',
         },
+        {
+            key: 'workflow',
+            label: 'Workflow',
+        },
     ];
 
     useEffect(() => {
@@ -57,8 +61,13 @@ const CodeExport: React.FC = observer((props) => {
             if (tabKey === 'graphic-walker') {
                 const res = vizStore.exportCode();
                 setCode(res);
-            } else {
+            } else if (tabKey === 'vega-lite') {
                 setCode(vizStore.lastSpec);
+            } else if (tabKey === 'workflow') {
+                const workflow = vizStore.workflow;
+                setCode(workflow);
+            } else {
+                console.error('unknown tabKey');
             }
         }
     }, [tabKey, showCodeExportPanel, vizStore]);
@@ -74,7 +83,9 @@ const CodeExport: React.FC = observer((props) => {
                 <Tabs value={tabKey} onValueChange={setTabKey}>
                     <TabsList className="my-1">
                         {specTabs.map((tab) => (
-                            <TabsTrigger key={tab.key} value={tab.key}>{tab.label}</TabsTrigger>
+                            <TabsTrigger key={tab.key} value={tab.key}>
+                                {tab.label}
+                            </TabsTrigger>
                         ))}
                     </TabsList>
                     <div className="border rounded-md overflow-hidden">

--- a/packages/graphic-walker/src/components/codeExport/index.tsx
+++ b/packages/graphic-walker/src/components/codeExport/index.tsx
@@ -50,10 +50,14 @@ const CodeExport: React.FC = observer((props) => {
             key: 'vega-lite',
             label: 'Vega-Lite',
         },
-        {
-            key: 'workflow',
-            label: 'Workflow',
-        },
+        ...(vizStore.layout.showActions
+            ? [
+                  {
+                      key: 'workflow',
+                      label: 'Workflow',
+                  },
+              ]
+            : []),
     ];
 
     useEffect(() => {


### PR DESCRIPTION
Added a workflow tab to show workflow of current chart.
![image](https://github.com/Kanaries/graphic-walker/assets/15280968/de425047-bcd5-4445-8eee-eb881828519a)
