### PR TITLE
feat: add tag flag in profiling computation

### DIFF
--- a/packages/graphic-walker/src/components/dataTable/profiling.tsx
+++ b/packages/graphic-walker/src/components/dataTable/profiling.tsx
@@ -1,15 +1,14 @@
 import { ComponentType, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { IComputationFunction, ISemanticType } from '../../interfaces';
-import { profileNonmialField, profileQuantitativeField } from '../../computation';
+import { profileNonmialField, profileQuantitativeField, wrapComputationWithTag } from '../../computation';
 import React from 'react';
 import { formatDate, isNotEmpty } from '../../utils';
 import Tooltip from '../tooltip';
-import { uiThemeContext, themeContext, vegaThemeContext } from '../../store/theme';
+import { themeContext, vegaThemeContext } from '../../store/theme';
 import { parsedOffsetDate } from '../../lib/op/offset';
 import embed, { VisualizationSpec } from 'vega-embed';
 import { format } from 'd3-format';
 import { getTheme } from '../../utils/useTheme';
-import { parseColorToHSL } from '@/utils/colors';
 
 export interface FieldProfilingProps {
     field: string;
@@ -19,7 +18,7 @@ export interface FieldProfilingProps {
 function NominalProfiling({ computation, field, valueRenderer = (s) => `${s}` }: FieldProfilingProps & { valueRenderer?: (v: string | number) => string }) {
     const [stat, setStat] = useState<Awaited<ReturnType<typeof profileNonmialField>>>();
     useEffect(() => {
-        profileNonmialField(computation, field).then(setStat);
+        profileNonmialField(wrapComputationWithTag(computation, "profiling"), field).then(setStat);
     }, [computation, field]);
 
     if (!isNotEmpty(stat)) {
@@ -85,7 +84,7 @@ const formatter = format('~s');
 function QuantitativeProfiling({ computation, field }: FieldProfilingProps) {
     const [stat, setStat] = useState<Awaited<ReturnType<typeof profileQuantitativeField>>>();
     useEffect(() => {
-        profileQuantitativeField(computation, field).then(setStat);
+        profileQuantitativeField(wrapComputationWithTag(computation, "profiling"), field).then(setStat);
     }, [computation, field]);
     if (!isNotEmpty(stat)) {
         return <div className="h-24 flex items-center justify-center">Loading...</div>;

--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -640,3 +640,12 @@ export async function profileQuantitativeField(service: IComputationFunction, fi
         binValues,
     };
 }
+
+export function wrapComputationWithTag(service: IComputationFunction, tag: string) {
+    return (payload: IDataQueryPayload) => {
+        return service({
+            ...payload,
+            tag,
+        });
+    };
+}

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -631,6 +631,7 @@ export type IDataQueryWorkflowStep = IFilterWorkflowStep | ITransformWorkflowSte
 
 export interface IDataQueryPayload {
     workflow: IDataQueryWorkflowStep[];
+    tag?: string;
     limit?: number;
     offset?: number;
 }


### PR DESCRIPTION
Since profiling is a feature that consumes a lot of computing resources.

The field is needed to identify profiling when performing computing, and base on this field to make some additional operations (such as caching).

