### PR TITLE
feat: add table filter ref and example

### DIFF
--- a/packages/graphic-walker/src/Table.tsx
+++ b/packages/graphic-walker/src/Table.tsx
@@ -85,6 +85,7 @@ export const TableApp = observer(function VizApp(props: BaseTableProps) {
                     <div className={`${darkMode === 'dark' ? 'dark' : ''} App font-sans bg-background text-foreground h-full m-0 p-0`}>
                         <div className="bg-background text-foreground h-full">
                             <DatasetTable
+                                ref={props.tableFilterRef}
                                 onMetaChange={vizStore.onMetaChange ? (fid, fIndex, diffMeta) => {
                                     vizStore.updateCurrentDatasetMetas(fid, diffMeta);
                                 } : undefined}

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useEffect, useCallback } from 'react';
+import React, { useMemo, useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle, ForwardedRef } from 'react';
 import styled from 'styled-components';
 import type { IMutField, IRow, IComputationFunction, IFilterFiledSimple, IFilterRule, IFilterField, IFilterWorkflowStep, IField } from '../../interfaces';
 import { useTranslation } from 'react-i18next';
@@ -232,7 +232,13 @@ function TruncateDector(props: { value: string }) {
     );
 }
 
-const DataTable: React.FC<DataTableProps> = (props) => {
+const DataTable = forwardRef(
+    (
+        props: DataTableProps,
+        ref: ForwardedRef<{
+            getFilters: () => IFilterField[];
+        }>
+    ) => {
     const { size = 10, onMetaChange, metas, computation, disableFilter, displayOffset, hidePaginationAtOnepage, hideProfiling } = props;
     const [pageIndex, setPageIndex] = useState(0);
     const { t } = useTranslation();
@@ -252,6 +258,13 @@ const DataTable: React.FC<DataTableProps> = (props) => {
     const [sorting, setSorting] = useState<{ fid: string; sort: 'ascending' | 'descending' } | undefined>();
 
     const { filters, editingFilterIdx, onClose, onDeleteFilter, onSelectFilter, onWriteFilter, options } = useFilters(metas);
+
+    const filtersRef = useRef(filters);
+    filtersRef.current = filters;
+
+    useImperativeHandle(ref, () => ({
+        getFilters: () => filtersRef.current,
+    }));
 
     const [total, setTotal] = useState(0);
     const [statLoading, setStatLoading] = useState(false);
@@ -541,7 +554,7 @@ const DataTable: React.FC<DataTableProps> = (props) => {
             )}
         </Container>
     );
-};
+});
 
 export default DataTable;
 

--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle, ForwardedRef } from 'react';
 import styled from 'styled-components';
-import type { IMutField, IRow, IComputationFunction, IFilterFiledSimple, IFilterRule, IFilterField, IFilterWorkflowStep, IField } from '../../interfaces';
+import type { IMutField, IRow, IComputationFunction, IFilterFiledSimple, IFilterRule, IFilterField, IFilterWorkflowStep, IField, IVisFilter } from '../../interfaces';
 import { useTranslation } from 'react-i18next';
 import LoadingLayer from '../loadingLayer';
 import { dataReadRaw } from '../../computation';
@@ -236,7 +236,7 @@ const DataTable = forwardRef(
     (
         props: DataTableProps,
         ref: ForwardedRef<{
-            getFilters: () => IFilterField[];
+            getFilters: () => IVisFilter[];
         }>
     ) => {
     const { size = 10, onMetaChange, metas, computation, disableFilter, displayOffset, hidePaginationAtOnepage, hideProfiling } = props;
@@ -263,7 +263,7 @@ const DataTable = forwardRef(
     filtersRef.current = filters;
 
     useImperativeHandle(ref, () => ({
-        getFilters: () => filtersRef.current,
+        getFilters: () => filtersRef.current.filter(x => x.rule) as IVisFilter[],
     }));
 
     const [total, setTotal] = useState(0);

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -987,7 +987,7 @@ export interface ITableSpecProps {
     themeConfig?: GWGlobalConfig;
     vizThemeConfig?: IThemeKey | GWGlobalConfig;
     tableFilterRef?: React.Ref<{
-        getFilters: () => IFilterField[];
+        getFilters: () => IVisFilter[];
     }>;
 }
 

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -986,6 +986,9 @@ export interface ITableSpecProps {
     /** @deprecated use vizThemeConfig instead */
     themeConfig?: GWGlobalConfig;
     vizThemeConfig?: IThemeKey | GWGlobalConfig;
+    tableFilterRef?: React.Ref<{
+        getFilters: () => IFilterField[];
+    }>;
 }
 
 export interface IVizAppProps extends IAppI18nProps, IVizProps, IThemeProps, IErrorHandlerProps, IVizStoreProps, ISpecProps {}

--- a/packages/playground/src/examples/pages/table.stories.tsx
+++ b/packages/playground/src/examples/pages/table.stories.tsx
@@ -1,11 +1,58 @@
-import { useContext } from 'react';
-import { TableWalker } from '@kanaries/graphic-walker';
+import { useContext, useRef } from 'react';
+import { getComputation, IFilterField, IVisFilter, TableWalker } from '@kanaries/graphic-walker';
 import { themeContext } from '../context';
 import { useFetch, IDataSource } from '../util';
 
 export default function GraphicWalkerComponent() {
     const { theme } = useContext(themeContext);
     const { dataSource, fields } = useFetch<IDataSource>('https://pub-2422ed4100b443659f588f2382cfc7b1.r2.dev/datasets/ds-students-service.json');
+    const tableRef = useRef<{ getFilters: () => IFilterField[] }>(null);
 
-    return <TableWalker fields={fields} data={dataSource} appearance={theme} pageSize={50} />;
+    const downloadCSV = async () => {
+        const filters = (tableRef.current?.getFilters() ?? []).filter((x) => x.rule);
+
+        const result = await getComputation(dataSource)({
+            workflow: [
+                ...(filters.length > 0 ? [{ type: 'filter' as const, filters: filters.map((x): IVisFilter => ({ ...x, rule: x.rule! })) }] : []),
+                {
+                    type: 'view',
+                    query: [
+                        {
+                            op: 'raw',
+                            fields: fields.map((x) => x.fid),
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const header = fields.map((x) => x.name).join(',');
+        const data = result
+            .map((row) =>
+                fields
+                    .map((x) => row[x.fid] ?? '')
+                    .map((x) => (typeof x === 'string' ? `"${x}"` : `${x}`))
+                    .join(',')
+            )
+            .join('\n');
+        const blob = new Blob([header + '\n' + data], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `Student.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    return (
+        <div className="flex flex-col gap-2">
+            <button
+                onClick={downloadCSV}
+                className="h-9 px-4 py-2 bg-primary text-primary-foreground shadow hover:bg-primary/90 inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+            >
+                Export CSV
+            </button>
+            <TableWalker tableFilterRef={tableRef} fields={fields} data={dataSource} appearance={theme} pageSize={50} />
+        </div>
+    );
 }

--- a/packages/playground/src/examples/pages/table.stories.tsx
+++ b/packages/playground/src/examples/pages/table.stories.tsx
@@ -48,11 +48,11 @@ export default function GraphicWalkerComponent() {
         <div className="flex flex-col gap-2">
             <button
                 onClick={downloadCSV}
-                className="h-9 px-4 py-2 bg-primary text-primary-foreground shadow hover:bg-primary/90 inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+                className="h-9 px-4 py-2 w-fit m-2 bg-zinc-950 text-white shadow hover:bg-primary/90 inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
             >
                 Export CSV
             </button>
-            <TableWalker tableFilterRef={tableRef} fields={fields} data={dataSource} appearance={theme} pageSize={50} />
+            <TableWalker tableFilterRef={tableRef} fields={fields} data={dataSource} appearance={theme} pageSize={50} vizThemeConfig="g2" />
         </div>
     );
 }

--- a/packages/playground/src/examples/pages/table.stories.tsx
+++ b/packages/playground/src/examples/pages/table.stories.tsx
@@ -1,19 +1,23 @@
 import { useContext, useRef } from 'react';
-import { getComputation, IFilterField, IVisFilter, TableWalker } from '@kanaries/graphic-walker';
+import { getComputation, IVisFilter, TableWalker } from '@kanaries/graphic-walker';
 import { themeContext } from '../context';
 import { useFetch, IDataSource } from '../util';
 
 export default function GraphicWalkerComponent() {
     const { theme } = useContext(themeContext);
     const { dataSource, fields } = useFetch<IDataSource>('https://pub-2422ed4100b443659f588f2382cfc7b1.r2.dev/datasets/ds-students-service.json');
-    const tableRef = useRef<{ getFilters: () => IFilterField[] }>(null);
+    const tableRef = useRef<{ getFilters: () => IVisFilter[] }>(null);
 
     const downloadCSV = async () => {
-        const filters = (tableRef.current?.getFilters() ?? []).filter((x) => x.rule);
+        const filters = tableRef.current?.getFilters() ?? [];
 
-        const result = await getComputation(dataSource)({
+        // or use a remote computation service
+        // const computation = async (workflow) => fetch(endPoint, { body: JSON.stringify(workflow) }).then(resp => resp.json())
+        const computation = getComputation(dataSource);
+
+        const result = await computation({
             workflow: [
-                ...(filters.length > 0 ? [{ type: 'filter' as const, filters: filters.map((x): IVisFilter => ({ ...x, rule: x.rule! })) }] : []),
+                { type: 'filter', filters },
                 {
                     type: 'view',
                     query: [


### PR DESCRIPTION
Added tableFilterRef prop for TableWalker.
Added a example for using tableFilterRef to export csv with filters.
![image](https://github.com/user-attachments/assets/adcc99ef-9ab6-4a8f-9bab-1c16586f64c4)