### PR TITLE
fix: let the toolbar wrap in lg screen

### DIFF
--- a/packages/graphic-walker/src/components/toolbar/index.tsx
+++ b/packages/graphic-walker/src/components/toolbar/index.tsx
@@ -15,7 +15,7 @@ const Toolbar = memo<ToolbarProps>(function Toolbar({ items }) {
     const [openedKey, setOpenedKey] = useState<string | null>(null);
 
     return (
-        <div className="flex flex-wrap sm:flex-nowrap border my-1 w-full rounded overflow-hidden">
+        <div className="flex flex-wrap lg:flex-nowrap border my-1 w-full rounded overflow-hidden">
             {items.map((item, i) => {
                 if (item === ToolbarItemSplitter) {
                     return <Separator orientation="vertical" className="mx-1 my-1.5 h-6" key={i} />;


### PR DESCRIPTION
fixed the issue when the width of graphic walker is between 640px and 900px, the width isn't enough to show all buttons in the toolbar.
This PR set the query into 1024px so the toolbar can show completely.