### PR TITLE
fix: null value of temporal

### DIFF
--- a/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
+++ b/packages/graphic-walker/src/lib/op/dateTimeDrill.ts
@@ -26,6 +26,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
     switch (drillLevel) {
         case 'year': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 return formatDate(toOffsetDate(Y, 0, 1));
@@ -37,6 +38,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'quarter': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const Q = Math.floor(date.getMonth() / 3);
@@ -49,6 +51,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'month': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();
@@ -61,6 +64,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'week': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const today = newDate(v);
                 const date = newDate(today.setDate(today.getDate() - today.getDay()));
                 const Y = date.getFullYear();
@@ -75,6 +79,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'day': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();
@@ -88,6 +93,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'iso_year': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const _Y = date.getFullYear();
                 const dayInFirstWeek = toOffsetDate(_Y, 0, 4);
@@ -108,6 +114,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'iso_week': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const today = newDate(v);
                 const date = newDate(today.setDate(today.getDate() - (today.getDay() || 7) + 1));
                 const Y = date.getFullYear();
@@ -122,6 +129,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'hour': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();
@@ -136,6 +144,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'minute': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();
@@ -151,6 +160,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'second': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const M = date.getMonth();

--- a/packages/graphic-walker/src/lib/op/dateTimeFeature.ts
+++ b/packages/graphic-walker/src/lib/op/dateTimeFeature.ts
@@ -17,6 +17,9 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
     const newDate = ((...x: []) => toOffsetDate(prepareDate(...x))) as typeof prepareDate;
     function getISOYear(v: any) {
         const date = newDate(v);
+        if (!date) {
+            return null;
+        }
         const y = date.getFullYear();
         const dayInFirstWeek = toOffsetDate(y, 0, 4);
         const firstMondayOfYear = newDate(newDate(dayInFirstWeek).setDate(dayInFirstWeek.getDate() - (dayInFirstWeek.getDay() || 7) + 1));
@@ -31,6 +34,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
     switch (drillLevel) {
         case 'year': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getFullYear();
             });
@@ -41,6 +45,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'quarter': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Q = Math.floor(date.getMonth() / 3) + 1;
                 return Q;
@@ -52,6 +57,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'month': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getMonth() + 1;
             });
@@ -62,6 +68,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'week': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 const Y = date.getFullYear();
                 const firstDayOfYear = toOffsetDate(Y, 0, 1);
@@ -78,6 +85,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'weekday': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getDay();
             });
@@ -95,8 +103,9 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'iso_week': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
-                const y = getISOYear(v);
+                const y = getISOYear(v)!;
                 const dayInFirstWeek = toOffsetDate(y, 0, 4);
                 const firstMondayOfYear = newDate(newDate(dayInFirstWeek).setDate(dayInFirstWeek.getDate() - (dayInFirstWeek.getDay() || 7) + 1));
                 const W = Math.floor((date.getTime() - firstMondayOfYear.getTime()) / (7 * 24 * 60 * 60 * 1_000)) + 1;
@@ -109,6 +118,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'iso_weekday': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getDay() || 7;
             });
@@ -119,6 +129,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'day': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getDate();
             });
@@ -129,6 +140,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'hour': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getHours();
             });
@@ -139,6 +151,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'minute': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getMinutes();
             });
@@ -149,6 +162,7 @@ function dateTimeDrill(resKey: string, params: IExpParameter[], data: IDataFrame
         }
         case 'second': {
             const newValues = fieldValues.map((v) => {
+                if (!v) return null;
                 const date = newDate(v);
                 return date.getSeconds();
             });

--- a/packages/graphic-walker/src/lib/op/offset.ts
+++ b/packages/graphic-walker/src/lib/op/offset.ts
@@ -30,8 +30,9 @@ export const unexceptedUTCParsedPatternFormats = ['%Y', '%Y-%m', '%Y-%m-%d'];
 export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
     function creator(): OffsetDate;
     function creator(value: number | string | Date): OffsetDate;
+    function creator(value: number | string | Date | null): OffsetDate | null;
     function creator(year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): OffsetDate;
-    function creator(...args): OffsetDate {
+    function creator(...args): OffsetDate | null {
         if (args.length > 1) {
             const timestamp =
                 offset * 60000 +
@@ -56,6 +57,9 @@ export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
                 const utcDate = currentDate.getTime() - currentDate.getTimezoneOffset() * 60000;
                 return getOffsetDate(new Date(utcDate + offset * 60000), offset);
             }
+            if (!v) {
+                return null
+            }
             return getOffsetDate(new Date(v), offset);
         }
         return getOffsetDate(new Date(), offset);
@@ -68,8 +72,9 @@ export function parsedOffsetDate(displayOffset: number | null | undefined, parse
     const parse = newOffsetDate(parseOffset ?? new Date().getTimezoneOffset());
     function creator(): OffsetDate;
     function creator(value: number | string | Date): OffsetDate;
+    function creator(value: number | string | Date | null): OffsetDate | null;
     function creator(year: number, monthIndex: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): OffsetDate;
-    function creator(...args: []): OffsetDate {
+    function creator(...args: []): OffsetDate | null {
         return toOffset(parse(...args));
     }
     return creator;

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -350,7 +350,10 @@ export function parseErrorMessage(errorLike: any): string {
     return String(errorLike);
 }
 
-export const formatDate = (date: Date) => {
+export const formatDate = (date: Date | null) => {
+    if (!date) {
+        return 'null';
+    }
     const Y = date.getFullYear();
     const M = date.getMonth() + 1;
     const D = date.getDate();

--- a/packages/graphic-walker/src/vis/spec/view.ts
+++ b/packages/graphic-walker/src/vis/spec/view.ts
@@ -89,7 +89,7 @@ export function getSingleView(props: SingleViewProps) {
                         return null;
                     }
                     return {
-                        calculate: `toDate(datum[${JSON.stringify(fid)}])${formatOffset(offsetTime)}`,
+                        calculate: `datum[${JSON.stringify(fid)}]!==null?(toDate(datum[${JSON.stringify(fid)}])${formatOffset(offsetTime)}):null`,
                         as: fid,
                     };
                 }
@@ -98,7 +98,7 @@ export function getSingleView(props: SingleViewProps) {
                 return null;
             }
             return {
-                calculate: `datum[${JSON.stringify(fid)}]${formatOffset(offsetTime)}`,
+                calculate: `datum[${JSON.stringify(fid)}]!==null?(datum[${JSON.stringify(fid)}]${formatOffset(offsetTime)}):null`,
                 as: fid,
             };
         })


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0fa0076e-b795-44ab-9979-be71a39b4215)
make the table and chart can deal with null temporal values, not showing 1970-1-1.
non-null value will still show on the chart, and null temporal value will not be shown in the chart.
![image](https://github.com/user-attachments/assets/c976215a-1b72-44fd-9ff3-689de645d09b)
![image](https://github.com/user-attachments/assets/82fe69ba-3fb4-45be-8731-ba0e5a5896fa)
