### PR TITLE
Log library version at runtime

### DIFF
--- a/packages/graphic-walker/src/index.tsx
+++ b/packages/graphic-walker/src/index.tsx
@@ -1,3 +1,7 @@
+import { version } from '../package.json';
+
+console.log(`Graphic Walker version: ${version}`);
+
 export * from './root';
 export { default as PureRenderer } from './renderer/pureRenderer';
 export type { ILocalPureRendererProps, IRemotePureRendererProps } from './renderer/pureRenderer';


### PR DESCRIPTION
## Summary
- output the Graphic Walker version from package.json when the library module loads

## Testing
- `yarn workspace @kanaries/graphic-walker test` *(fails: package doesn't seem to be present in lockfile)*