### PR TITLE
Align GraphicWalker APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ const YourEmbeddingApp: React.FC<IYourEmbeddingAppProps> = props => {
         data={data}
         fields={fields}
         chart={graphicWalkerSpec}
+        pageSize={50}
         i18nLang={langStore.lang}
     />;
 }
@@ -127,13 +128,8 @@ If you have a configuration of GraphicWalker chart, you can use the `PureRendere
 import { PureRenderer } from '@kanaries/graphic-walker';
 
 const YourChart: React.FC<IYourChartProps> = props => {
-    const { rawData, visualState, visualConfig, visualLayout } = props;
-    return <PureRenderer
-        rawData={rawData}
-        visualState={visualState}
-        visualConfig={visualConfig}
-        visualLayout={visualLayout}
-    />;
+    const { data, spec } = props;
+    return <PureRenderer rawData={data} chart={spec} containerStyle={{ height: 300 }} />;
 }
 
 export default YourChart;
@@ -156,7 +152,7 @@ const YourChart: React.FC<IYourChartProps> = props => {
 export default YourChart;
 ```
 
-You can use `TableWalker` component to make a single table view with your data. it accepts same props as `GraphicWalker`, but you don't need to pass the chart prop, and you can control the page size by pageSize prop(default value is 20).
+You can use `TableWalker` component to make a single table view with your data. It accepts the same props as `GraphicWalker`, and both components allow you to control the dataset page size via the `pageSize` prop (default value is 100 for `GraphicWalker` and 20 for `TableWalker`).
 
 ```typescript
 import { TableWalker } from '@kanaries/graphic-walker';

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -49,6 +49,7 @@ export type BaseVizProps = IAppI18nProps &
     ISpecProps &
     IComputationContextProps & {
         darkMode?: 'light' | 'dark';
+        pageSize?: number;
     };
 
 export const VizApp = observer(function VizApp(props: BaseVizProps) {
@@ -68,6 +69,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
         chart,
         vlSpec,
         onError,
+        pageSize = 100,
     } = props;
 
     const { t, i18n } = useTranslation();
@@ -172,7 +174,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                     </TabsList>
                                     <TabsContent value={ISegmentKey.data}>
                                         <div className="mx-4 -mt-px p-4 border rounded-md rounded-t-none">
-                                            <DatasetConfig />
+                                            <DatasetConfig pageSize={pageSize} />
                                         </div>
                                     </TabsContent>
                                     <TabsContent value={ISegmentKey.vis}>
@@ -207,7 +209,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                             />
                                             <CodeExport />
                                             <ExplainData themeKey={themeKey} />
-                                            {vizStore.showDataBoard && <DataBoard />}
+                                            {vizStore.showDataBoard && <DataBoard pageSize={pageSize} />}
                                             <VisualConfig />
                                             <LogPanel />
                                             <BinPanel />

--- a/packages/graphic-walker/src/components/dataBoard.tsx
+++ b/packages/graphic-walker/src/components/dataBoard.tsx
@@ -9,7 +9,7 @@ import { isNotEmpty } from '../utils';
 import { Dialog, DialogContent } from './ui/dialog';
 import { toJS } from "mobx";
 
-const DataBoard = observer(function DataBoardModal() {
+const DataBoard = observer(function DataBoardModal({ pageSize = 100 }: { pageSize?: number }) {
     const vizStore = useVizStore();
     const computation = useCompututaion();
     const { showDataBoard, selectedMarkObject, allFields, config, viewFilters } = vizStore;
@@ -57,7 +57,7 @@ const DataBoard = observer(function DataBoardModal() {
         >
             <DialogContent>
                 <div className="mt-4">
-                    <DataTable size={100} computation={filteredComputation} metas={metas} disableFilter displayOffset={config.timezoneDisplayOffset} />
+                    <DataTable size={pageSize} computation={filteredComputation} metas={metas} disableFilter displayOffset={config.timezoneDisplayOffset} />
                 </div>
             </DialogContent>
         </Dialog>

--- a/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
+++ b/packages/graphic-walker/src/dataSource/datasetConfig/index.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite';
 import { useCompututaion, useVizStore } from '../../store';
 import { toJS } from 'mobx';
 
-const DatasetConfig: React.FC = () => {
+const DatasetConfig: React.FC<{ pageSize?: number }> = ({ pageSize = 100 }) => {
     const vizStore = useVizStore();
     const computation = useCompututaion();
     const metas = toJS(vizStore.meta);
@@ -12,7 +12,7 @@ const DatasetConfig: React.FC = () => {
     return (
         <div className="relative">
             <DatasetTable
-                size={100}
+                size={pageSize}
                 metas={metas}
                 computation={computation}
                 displayOffset={vizStore.config.timezoneDisplayOffset}

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -1002,7 +1002,9 @@ export interface ITableSpecProps {
     }>;
 }
 
-export interface IVizAppProps extends IAppI18nProps, IVizProps, IThemeProps, IErrorHandlerProps, IVizStoreProps, ISpecProps {}
+export interface IVizAppProps extends IAppI18nProps, IVizProps, IThemeProps, IErrorHandlerProps, IVizStoreProps, ISpecProps {
+    pageSize?: number;
+}
 export interface ITableProps extends IAppI18nProps, ITableSpecProps, IThemeProps, IErrorHandlerProps, IVizStoreProps {}
 
 export interface IAskVizFeedback {


### PR DESCRIPTION
## Summary
- support `pageSize` for `GraphicWalker`
- unify `PureRenderer` props with `GraphicRenderer`
- allow chart object and container style in `PureRenderer`
- document new props

## Testing
- `yarn workspace @kanaries/graphic-walker test` *(fails: This package doesn't seem to be present in your lockfile)*