### PR TITLE
Fix zero timestamp bug in newOffsetDate

### DIFF
--- a/packages/graphic-walker/src/lib/op/offset.test.ts
+++ b/packages/graphic-walker/src/lib/op/offset.test.ts
@@ -89,4 +89,10 @@ describe('getOffsetDate', () => {
         const W = Math.floor((date.getTime() - SundayOfFirstWeek.getTime()) / (7 * 24 * 60 * 60 * 1_000)) + 1;
         expect(W).toBe(48);
     });
+
+    test('timestamp zero', () => {
+        const date = utcOffsetDate(0);
+        expect(date).not.toBeNull();
+        expect(date!.getTime()).toBe(0);
+    });
 });

--- a/packages/graphic-walker/src/lib/op/offset.ts
+++ b/packages/graphic-walker/src/lib/op/offset.ts
@@ -57,7 +57,7 @@ export function newOffsetDate(offset = new Date().getTimezoneOffset()) {
                 const utcDate = currentDate.getTime() - currentDate.getTimezoneOffset() * 60000;
                 return getOffsetDate(new Date(utcDate + offset * 60000), offset);
             }
-            if (!v) {
+            if (v === null || v === undefined) {
                 return null
             }
             return getOffsetDate(new Date(v), offset);


### PR DESCRIPTION
## Summary
- handle `0` correctly when constructing offset date
- add test covering zero timestamp case

## Testing
- `npx jest packages/graphic-walker/src/lib/op/offset.test.ts packages/graphic-walker/src/lib/op/dateTime.test.ts packages/graphic-walker/src/models/withHistory.test.ts packages/graphic-walker/src/visualSettings/utils.test.ts packages/graphic-walker/src/components/dataTable/pagination.test.ts -c packages/graphic-walker/jest.config.js`