### PR TITLE
fix: paint info

### DIFF
--- a/packages/graphic-walker/src/components/painter/index.tsx
+++ b/packages/graphic-walker/src/components/painter/index.tsx
@@ -1024,6 +1024,8 @@ const Painter = ({ themeConfig, themeKey }: { themeConfig?: GWGlobalConfig; them
                                 });
                             } else {
                                 // editing the existing paint map
+                                paintMapRef.current = await decompressBitMap(lastFacet.map);
+
                                 const x = lastFacet.dimensions.at(-1)?.fid;
                                 const y = lastFacet.dimensions.at(-2)?.fid;
                                 const xf = allFields.find((a) => a.fid === x);

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -301,6 +301,27 @@ export class VizSpecStore {
 
     get paintInfo() {
         const existPaintField = this.currentEncodings.dimensions.find((x) => x.fid === PAINT_FIELD_ID);
+        const { columns, rows } = this.currentEncodings;
+        if (columns.length !== 1 || rows.length !== 1) {
+            return { type: 'error', key: 'count' } as const;
+        }
+        const col = columns[0];
+        const row = rows[0];
+        if (col.semanticType === 'temporal' || row.semanticType === 'temporal') {
+            return { type: 'error', key: 'temporal' } as const;
+        }
+        if (
+            col.aggName === 'expr' ||
+            row.aggName === 'expr' ||
+            col.fid === MEA_KEY_ID ||
+            col.fid === MEA_VAL_ID ||
+            row.fid === MEA_KEY_ID ||
+            row.fid === MEA_VAL_ID ||
+            col.fid === PAINT_FIELD_ID ||
+            row.fid === PAINT_FIELD_ID
+        ) {
+            return { type: 'error', key: 'count' } as const;
+        }
         if (existPaintField) {
             const param = existPaintField.expression?.params.find((x) => x.type === 'map')?.value;
             if (param) {

--- a/packages/graphic-walker/src/utils/vegaApiExport.ts
+++ b/packages/graphic-walker/src/utils/vegaApiExport.ts
@@ -90,6 +90,9 @@ export const useVegaExportApi = (
                         nRows: 0,
                         charts: [],
                         chartType: 'vega',
+                        container() {
+                            return null;
+                        },
                     };
                 }
                 if (ctx.renderStatus !== 'idle') {
@@ -116,6 +119,9 @@ export const useVegaExportApi = (
                             nRows: 0,
                             charts: [],
                             chartType: 'vega',
+                            container() {
+                                return null;
+                            },
                         };
                     } finally {
                         dispose?.();


### PR DESCRIPTION
fix the issue when editing the paintMap with same dimensions but tranversed, the map will not be loaded and user cannot see correct result in the page.