### PR TITLE
Add legend support to observable plot renderer

### DIFF
--- a/packages/graphic-walker/src/lib/observablePlot.ts
+++ b/packages/graphic-walker/src/lib/observablePlot.ts
@@ -401,6 +401,7 @@ function vegaLiteToPlot(spec: any): any {
         },
         color: {
             label: enc.color?.title || undefined,
+            legend: colorField ? true : undefined,
         },
         // fx: {
         //     label: enc.column?.title || undefined,


### PR DESCRIPTION
## Summary
- show color legends in observable plots

## Testing
- `npx jest -c packages/graphic-walker/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_683d3d75af2483229b277d8b391d705e