### PR TITLE
Fix circle mark in observable renderer

### DIFF
--- a/packages/graphic-walker/src/lib/observablePlot.ts
+++ b/packages/graphic-walker/src/lib/observablePlot.ts
@@ -121,9 +121,14 @@ function vegaLiteToPlot(spec: any): any {
                 baseConfig.stroke = colorField || undefined;
                 break;
             case 'point':
+                baseConfig.stroke = colorField || undefined;
+                baseConfig.fill = 'none';
+                baseConfig.r = sizeField || undefined;
+                break;
             case 'circle':
             case 'dot':
                 baseConfig.fill = colorField || undefined;
+                baseConfig.stroke = undefined;
                 baseConfig.r = sizeField || undefined;
                 break;
             case 'text':


### PR DESCRIPTION
## Summary
- fix Observable Plot renderer to draw `point` marks with no fill and `circle` marks with fill

## Testing
- `yarn workspace @kanaries/graphic-walker test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683da073af2c8322af327b7208c95dc2