### PR TITLE
Use Vega Lite as default renderer

### DIFF
--- a/packages/graphic-walker/src/components/visualConfig/index.tsx
+++ b/packages/graphic-walker/src/components/visualConfig/index.tsx
@@ -145,7 +145,7 @@ const VisualConfigPanel: React.FC = () => {
     const [svg, setSvg] = useState<boolean>(layout.useSvg ?? false);
     const [scaleIncludeUnmatchedChoropleth, setScaleIncludeUnmatchedChoropleth] = useState<boolean>(layout.scaleIncludeUnmatchedChoropleth ?? false);
     const [showAllGeoshapeInChoropleth, setShowAllGeoshapeInChoropleth] = useState<boolean>(layout.showAllGeoshapeInChoropleth ?? false);
-    const [renderer, setRenderer] = useState<'vega-lite' | 'observable-plot'>(layout.renderer ?? 'observable-plot');
+    const [renderer, setRenderer] = useState<'vega-lite' | 'observable-plot'>(layout.renderer ?? 'vega-lite');
     const [background, setBackground] = useState({ r: 255, g: 255, b: 255, a: 0 });
     const [defaultColor, setDefaultColor] = useState({ r: 91, g: 143, b: 249, a: 1 });
     const [primaryColorEdited, setPrimaryColorEdited] = useState(false);
@@ -174,7 +174,7 @@ const VisualConfigPanel: React.FC = () => {
     useEffect(() => {
         setZeroScale(layout.zeroScale);
         setSvg(layout.useSvg ?? false);
-        setRenderer(layout.renderer ?? 'observable-plot');
+        setRenderer(layout.renderer ?? 'vega-lite');
         setBackground(
             extractRGBA(
                 {

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -442,7 +442,7 @@ export interface IVisualLayout {
     /** @default false */
     scaleIncludeUnmatchedChoropleth?: boolean;
     showAllGeoshapeInChoropleth?: boolean;
-    /** @default "observable-plot" */
+    /** @default "vega-lite" */
     renderer?: 'vega-lite' | 'observable-plot';
 }
 

--- a/packages/graphic-walker/src/renderer/specRenderer.tsx
+++ b/packages/graphic-walker/src/renderer/specRenderer.tsx
@@ -177,7 +177,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                     scale={scale}
                 />
             )}
-            {!isSpatial && layout.renderer === 'vega-lite' && (
+            {!isSpatial && (!layout.renderer || layout.renderer === 'vega-lite') && (
                 <ReactVega
                     name={name}
                     vegaConfig={vegaConfig}
@@ -211,7 +211,7 @@ const SpecRenderer = forwardRef<IReactVegaHandler, SpecRendererProps>(function (
                     displayOffset={timezoneDisplayOffset}
                 />
             )}
-            {!isSpatial && (!layout.renderer || layout.renderer === 'observable-plot') && (
+            {!isSpatial && layout.renderer === 'observable-plot' && (
                 <ObservablePlotRenderer
                     name={name}
                     vegaConfig={vegaConfig}

--- a/packages/graphic-walker/src/utils/save.ts
+++ b/packages/graphic-walker/src/utils/save.ts
@@ -92,7 +92,7 @@ export const emptyVisualLayout: IVisualLayout = {
         shape: false,
         size: false,
     },
-    renderer: 'observable-plot',
+    renderer: 'vega-lite',
 };
 
 export const emptyVisualConfig: IVisualConfigNew = {

--- a/packages/playground/src/examples/pages/renderer.stories.tsx
+++ b/packages/playground/src/examples/pages/renderer.stories.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import spec from '../specs/student-chart-filter.json';
 import { GraphicRenderer, IChart } from '@kanaries/graphic-walker';
 import { themeContext } from '../context';
@@ -7,6 +7,21 @@ import { useFetch, IDataSource } from '../util';
 export default function GraphicWalkerComponent() {
     const { theme } = useContext(themeContext);
     const { dataSource, fields } = useFetch<IDataSource>('https://pub-2422ed4100b443659f588f2382cfc7b1.r2.dev/datasets/ds-students-service.json');
+    const [renderer, setRenderer] = useState<'vega-lite' | 'observable-plot'>('vega-lite');
 
-    return <GraphicRenderer fields={fields} chart={spec as IChart[]} data={dataSource} appearance={theme} />;
+    return (
+        <div className="space-y-2">
+            <select value={renderer} onChange={(e) => setRenderer(e.target.value as 'vega-lite' | 'observable-plot')}>
+                <option value="vega-lite">VegaLite</option>
+                <option value="observable-plot">Observable Plot</option>
+            </select>
+            <GraphicRenderer
+                fields={fields}
+                chart={spec as IChart[]}
+                data={dataSource}
+                appearance={theme}
+                defaultRenderer={renderer}
+            />
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
- default renderer is Vega Lite across editor and renderer components
- allow renderer to be switched in playground example

## Testing
- `yarn workspace @kanaries/graphic-walker test`

------
https://chatgpt.com/codex/tasks/task_e_683f0b3e05148322bf9050d0323671a6