### PR TITLE
feat: add hideEmbedMenu prop to VizEmbedMenu for conditional rendering

### DIFF
--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -80,6 +80,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
         vlSpec,
         onError,
         hideSegmentNav,
+        hideEmbedMenu
     } = props;
 
     const { t, i18n } = useTranslation();
@@ -273,7 +274,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                                                 scales={props.scales ?? props.channelScales}
                                                             />
                                                         )}
-                                                        <VizEmbedMenu />
+                                                        <VizEmbedMenu hideEmbedMenu={hideEmbedMenu} />
                                                     </div>
                                                 </div>
                                             </div>

--- a/packages/graphic-walker/src/components/embedMenu.tsx
+++ b/packages/graphic-walker/src/components/embedMenu.tsx
@@ -6,8 +6,10 @@ import { useTranslation } from 'react-i18next';
 import React from 'react';
 import { GLOBAL_CONFIG } from '../config';
 import { Transition } from '@headlessui/react';
+import { VizEmbedMenuProps } from '@/interfaces';
 
-export const VizEmbedMenu = observer(function VizEmbedMenu() {
+export const VizEmbedMenu = observer(function VizEmbedMenu(props: VizEmbedMenuProps) {
+    if (props.hideEmbedMenu === true) return null;
     const vizStore = useVizStore();
     const { t } = useTranslation();
     const { vizEmbededMenu } = vizStore;
@@ -25,6 +27,8 @@ export const VizEmbedMenu = observer(function VizEmbedMenu() {
         >
             <ClickMenu x={vizEmbededMenu.position[0]} y={vizEmbededMenu.position[1]}>
                 {GLOBAL_CONFIG.EMBEDED_MENU_LIST.map((key) => {
+                const isItemHidden = Array.isArray(props.hideEmbedMenu) && props.hideEmbedMenu.includes(key);
+                if (isItemHidden) return null;
                     switch (key) {
                         case 'data_interpretation':
                             return (

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -23,6 +23,9 @@ export interface IRow {
 export type IAggregator = 'sum' | 'count' | 'max' | 'min' | 'mean' | 'median' | 'variance' | 'stdev' | 'distinctCount' | 'expr';
 
 export type IEmbedMenuItem = 'data_interpretation' | 'data_view';
+export interface VizEmbedMenuProps {
+    hideEmbedMenu?: boolean | IEmbedMenuItem[];
+}
 export interface Specification {
     position?: string[];
     color?: string[];
@@ -914,6 +917,8 @@ export interface IVizProps {
     hideChartNav?: boolean;
     /** hide the segment navigation so make user can only edit on the only segment. */
     hideSegmentNav?: boolean;
+    /** hide the embedded menu */
+    hideEmbedMenu?: boolean | IEmbedMenuItem[];
     geographicData?: IGeographicData & {
         key: string;
     };


### PR DESCRIPTION
This commit introduces a new prop `hideEmbedMenu` to the `VizEmbedMenu` component, allowing consumers to conditionally hide the entire menu or specific menu items.  
The prop accepts either a boolean (`true` to hide completely) or a list of menu item keys to selectively disable them.

This enables more flexible UI configurations when embedding or integrating the visualization component.