### PR TITLE
fix: support opacity and shape in observable plot renderer

### DIFF
--- a/packages/graphic-walker/src/lib/observablePlot.ts
+++ b/packages/graphic-walker/src/lib/observablePlot.ts
@@ -37,9 +37,12 @@ function vegaLiteToPlot(spec: any): any {
     const yFacetField = enc.row?.field || null;
     const colorField = enc.color?.field || null;
     const sizeField = enc.size?.field || null;
+    const shapeField = enc.shape?.field || null;
+    const opacityField = enc.opacity?.field || null;
+    const opacityValue = enc.opacity?.value ?? null;
     const tooltipEnc = enc.tooltip;
 
-    console.log({ xField, yField, xFacetField, yFacetField, colorField, sizeField, tooltipEnc });
+    console.log({ xField, yField, xFacetField, yFacetField, colorField, sizeField, shapeField, opacityField, opacityValue, tooltipEnc });
     // etc. shape, opacity, text, etc. if present
 
     // Helper function to determine mark direction based on axis types
@@ -97,7 +100,7 @@ function vegaLiteToPlot(spec: any): any {
 
     // Helper function to create base configuration for any mark type
     const createBaseConfig = (markType: string, enc: any, fields: any) => {
-        const { xField, yField, colorField, sizeField, xFacetField, yFacetField } = fields;
+        const { xField, yField, colorField, sizeField, shapeField, opacityField, opacityValue, xFacetField, yFacetField } = fields;
         
         // Base configuration that works for most marks
         const baseConfig: any = {
@@ -106,6 +109,12 @@ function vegaLiteToPlot(spec: any): any {
             fx: xFacetField || undefined,
             fy: yFacetField || undefined,
         };
+
+        if (opacityField) {
+            baseConfig.opacity = opacityField;
+        } else if (opacityValue !== null && opacityValue !== undefined) {
+            baseConfig.opacity = opacityValue;
+        }
         
         // Add mark-specific channels
         switch (markType) {
@@ -124,12 +133,14 @@ function vegaLiteToPlot(spec: any): any {
                 baseConfig.stroke = colorField || undefined;
                 baseConfig.fill = 'none';
                 baseConfig.r = sizeField || undefined;
+                baseConfig.symbol = shapeField || undefined;
                 break;
             case 'circle':
             case 'dot':
                 baseConfig.fill = colorField || undefined;
                 baseConfig.stroke = undefined;
                 baseConfig.r = sizeField || undefined;
+                baseConfig.symbol = shapeField || undefined;
                 break;
             case 'text':
                 baseConfig.text = yField || xField || undefined; // Use the quantitative field for text
@@ -340,7 +351,7 @@ function vegaLiteToPlot(spec: any): any {
     };
 
     // 5) Build the Plot mark using the universal function
-    const fields = { xField, yField, colorField, sizeField, xFacetField, yFacetField };
+    const fields = { xField, yField, colorField, sizeField, shapeField, opacityField, opacityValue, xFacetField, yFacetField };
     let mark: Plot.Mark = createMark(markType, data, enc, fields);
 
     // 6) Title / tooltip


### PR DESCRIPTION
### Motivation
- The Observable Plot renderer did not map Vega-Lite `shape` and `opacity` encodings, so plotted marks could miss symbol and transparency information.
- Both encoded opacity (`enc.opacity.field`) and constant opacity (`enc.opacity.value`) should be supported for accurate rendering.
- Point-like marks need to map Vega-Lite shape to Plot's symbol channel to reflect different marker shapes.

### Description
- Extract `shapeField`, `opacityField`, and `opacityValue` from the Vega-Lite `encoding` and add them to the `fields` passed into `createMark`.
- Add opacity handling in `createBaseConfig` so `baseConfig.opacity` is set from either a field or a constant value (`enc.opacity.field` or `enc.opacity.value`).
- Map `shapeField` to the Plot `symbol` channel for `point`, `circle`, and `dot` marks by setting `baseConfig.symbol`.
- Added logging of the new fields and updated the `fields` object to include `shapeField`, `opacityField`, and `opacityValue`.

### Testing
- No automated tests were run against this change.
- Existing unit tests were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563745be248322b1fc8cff7b2d5fbf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing channel mappings to better reflect Vega-Lite specs in Observable Plot.
> 
> - Extracts `shapeField`, `opacityField`, and `opacityValue` from `encoding` and threads them through `fields`
> - Sets `baseConfig.opacity` from either `enc.opacity.field` or `enc.opacity.value`
> - Maps `shapeField` to Plot `symbol` for `point`, `circle`, and `dot` marks
> - Updates debug logging to include new fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49cac5a74affbe5ad2ccf1502f9895d347545cc4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->