### PR TITLE
feat: add arc/pie support to observable-plot renderer

### DIFF
--- a/packages/graphic-walker/src/lib/observablePlot.test.ts
+++ b/packages/graphic-walker/src/lib/observablePlot.test.ts
@@ -32,6 +32,7 @@ jest.mock('@observablehq/plot', () => {
         ruleY: factory('rule'),
         boxX: factory('box'),
         boxY: factory('box'),
+        geo: factory('geo'),
         stackY: () => (opts: any) => ({ ...opts, stack: 'y' }),
         stackX: () => (opts: any) => ({ ...opts, stack: 'x' }),
     };
@@ -86,5 +87,20 @@ describe('vegaLiteToPlot', () => {
         const plot = __test__vegaLiteToPlot(vlSpec);
         expect(plot.x.type).toBe('band');
         expect(plot.marks[0].ariaLabel).toBe('bar');
+    });
+
+    test('arc chart renders with geo mark', () => {
+        const vlSpec = {
+            mark: 'arc',
+            data: { values: [ { category: 'A', value: 30 }, { category: 'B', value: 70 } ] },
+            encoding: {
+                theta: { field: 'value', type: 'quantitative' },
+                color: { field: 'category', type: 'nominal' },
+            },
+        };
+        const plot = __test__vegaLiteToPlot(vlSpec);
+        expect(plot.marks[0].ariaLabel).toBe('geo');
+        expect(plot.x.axis).toBeNull();
+        expect(plot.y.axis).toBeNull();
     });
 });


### PR DESCRIPTION
### Motivation
- The Observable Plot renderer did not support `arc`/pie charts while Vega-Lite produced such specs, causing inconsistent renderer parity.
- Pie/arc charts require custom geometry (slice polygons) rather than x/y marks, so the conversion needs to generate slice geometry and normalize radii.

### Description
- Added `createArcGeometry` to tessellate an arc slice into a polygon suitable for Plot’s `geo` mark.
- Added `createArcMark` which converts `theta` and optional `radius` encodings into per-row slice geometries and returns a `Plot.geo` mark, and wired it into `createMark` for `markType === 'arc'`.
- For arc charts, adjusted top-level `plotOptions` to hide axes and set `x`/`y` domains to `[-1, 1]` to normalize the radial layout.
- Extended `packages/graphic-walker/src/lib/observablePlot.test.ts` with a new unit test asserting the `geo` mark is produced and axes are hidden for arc specs.

### Testing
- No automated test suite was executed as part of this change.
- A unit test `arc chart renders with geo mark` was added to `packages/graphic-walker/src/lib/observablePlot.test.ts` to cover the conversion logic but it was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956390feb4883229b4dcb51a0917a87)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables pie/arc charts in the Observable Plot renderer by generating polygonal slices and normalizing radial scales.
> 
> - Introduces `createArcGeometry` to tessellate slice polygons and `createArcMark` to map `theta`/`radius` to `Plot.geo`
> - Wires `markType === 'arc'` through `createMark`, producing a `geo` mark with optional color-driven fill and white stroke
> - Adjusts top-level `x`/`y` for arc charts: `axis: null` and `domain: [-1, 1]` for centered radial layout
> - Updates tests: extends Plot mock with `geo` and adds `arc chart renders with geo mark` asserting `geo` mark and hidden axes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4113d05d7ae5eab903399462d1b55164f627dc19. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->