### PR TITLE
[codex] Cache DataTable profiling requests

### DIFF
--- a/packages/graphic-walker/src/components/dataTable/index.tsx
+++ b/packages/graphic-walker/src/components/dataTable/index.tsx
@@ -353,10 +353,13 @@ const DataTable = forwardRef(
         };
     }, [computationFunction, pageIndex, size, sorting, filters, disableSorting]);
 
+    const filterRules = useMemo(() => filters.filter((f) => f.rule).map(createFilter), [filters]);
+
+    const profilingCacheScopeKey = useMemo(() => JSON.stringify(filterRules), [filterRules]);
+
     const filteredComputation = useMemo((): IComputationFunction => {
-        const filterRules = filters.filter((f) => f.rule).map(createFilter);
         return (query) => computation(addFilterForQuery(query, filterRules));
-    }, [computation, filters]);
+    }, [computation, filterRules]);
 
     const loading = statLoading || dataLoading;
 
@@ -521,6 +524,8 @@ const DataTable = forwardRef(
                                             field={field.fid}
                                             semanticType={field.semanticType}
                                             computation={filteredComputation}
+                                            cacheScope={computation}
+                                            cacheScopeKey={profilingCacheScopeKey}
                                             displayOffset={displayOffset}
                                             offset={field.offset}
                                         />

--- a/packages/graphic-walker/src/components/dataTable/profiling.tsx
+++ b/packages/graphic-walker/src/components/dataTable/profiling.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { IComputationFunction, ISemanticType } from '../../interfaces';
-import { profileNonmialField, profileQuantitativeField, wrapComputationWithTag } from '../../computation';
+import { profileNonmialField, profileNonmialFieldWithCache, profileQuantitativeField, profileQuantitativeFieldWithCache } from '../../computation';
 import React from 'react';
 import { formatDate, isNotEmpty } from '../../utils';
 import Tooltip from '../tooltip';
@@ -13,13 +13,36 @@ import { getTheme } from '../../utils/useTheme';
 export interface FieldProfilingProps {
     field: string;
     computation: IComputationFunction;
+    cacheScope?: object;
+    cacheScopeKey?: string;
 }
 
-function NominalProfiling({ computation, field, valueRenderer = (s) => `${s}` }: FieldProfilingProps & { valueRenderer?: (v: string | number) => string }) {
+function NominalProfiling({
+    computation,
+    field,
+    cacheScope,
+    cacheScopeKey,
+    valueRenderer = (s) => `${s}`,
+}: FieldProfilingProps & { valueRenderer?: (v: string | number) => string }) {
     const [stat, setStat] = useState<Awaited<ReturnType<typeof profileNonmialField>>>();
     useEffect(() => {
-        profileNonmialField(wrapComputationWithTag(computation, "profiling"), field).then(setStat);
-    }, [computation, field]);
+        let canceled = false;
+        setStat(undefined);
+        profileNonmialFieldWithCache(computation, field, { cacheScope, scopeKey: cacheScopeKey })
+            .then((nextStat) => {
+                if (!canceled) {
+                    setStat(nextStat);
+                }
+            })
+            .catch((error) => {
+                if (!canceled) {
+                    console.error(error);
+                }
+            });
+        return () => {
+            canceled = true;
+        };
+    }, [computation, field, cacheScope, cacheScopeKey]);
 
     if (!isNotEmpty(stat)) {
         return <div className="h-24 flex items-center justify-center">Loading...</div>;
@@ -81,11 +104,26 @@ function NominalProfiling({ computation, field, valueRenderer = (s) => `${s}` }:
 
 const formatter = format('~s');
 
-function QuantitativeProfiling({ computation, field }: FieldProfilingProps) {
+function QuantitativeProfiling({ computation, field, cacheScope, cacheScopeKey }: FieldProfilingProps) {
     const [stat, setStat] = useState<Awaited<ReturnType<typeof profileQuantitativeField>>>();
     useEffect(() => {
-        profileQuantitativeField(wrapComputationWithTag(computation, "profiling"), field).then(setStat);
-    }, [computation, field]);
+        let canceled = false;
+        setStat(undefined);
+        profileQuantitativeFieldWithCache(computation, field, { cacheScope, scopeKey: cacheScopeKey })
+            .then((nextStat) => {
+                if (!canceled) {
+                    setStat(nextStat);
+                }
+            })
+            .catch((error) => {
+                if (!canceled) {
+                    console.error(error);
+                }
+            });
+        return () => {
+            canceled = true;
+        };
+    }, [computation, field, cacheScope, cacheScopeKey]);
     if (!isNotEmpty(stat)) {
         return <div className="h-24 flex items-center justify-center">Loading...</div>;
     }
@@ -202,16 +240,20 @@ function LazyLoaded<T>(Component: ComponentType<T>) {
 
 function FieldProfilingElement(props: FieldProfilingProps & { semanticType: ISemanticType; displayOffset?: number; offset?: number }) {
     const { semanticType, displayOffset, offset, ...fieldProps } = props;
+    const profilingProps = {
+        ...fieldProps,
+        cacheScopeKey: JSON.stringify([fieldProps.cacheScopeKey ?? null, semanticType]),
+    };
     switch (semanticType) {
         case 'nominal':
         case 'ordinal':
-            return <NominalProfiling {...fieldProps} />;
+            return <NominalProfiling {...profilingProps} />;
         case 'temporal': {
             const formatter = (date: string | number) => formatDate(parsedOffsetDate(displayOffset, offset)(date));
-            return <NominalProfiling {...fieldProps} valueRenderer={formatter} />;
+            return <NominalProfiling {...profilingProps} valueRenderer={formatter} />;
         }
         case 'quantitative':
-            return <QuantitativeProfiling {...fieldProps} />;
+            return <QuantitativeProfiling {...profilingProps} />;
     }
 }
 

--- a/packages/graphic-walker/src/computation/index.ts
+++ b/packages/graphic-walker/src/computation/index.ts
@@ -549,6 +549,56 @@ export async function profileNonmialField(service: IComputationFunction, field: 
     return Promise.all([meta, tops] as const);
 }
 
+type DataTableProfilingMode = 'nominal' | 'quantitative';
+
+interface DataTableProfilingCacheOptions {
+    cacheScope?: object;
+    scopeKey?: string;
+}
+
+const DATA_TABLE_PROFILING_SCOPE_KEY = 'default';
+const DATA_TABLE_PROFILING_CACHE_LIMIT = 500;
+const DATA_TABLE_PROFILING_CONCURRENCY = 4;
+const dataTableProfilingCache = new WeakMap<object, Map<string, Promise<unknown>>>();
+const dataTableProfilingQueue: Array<() => void> = [];
+let dataTableProfilingActiveCount = 0;
+
+function getDataTableProfilingKey(mode: DataTableProfilingMode, field: string, scopeKey = DATA_TABLE_PROFILING_SCOPE_KEY) {
+    return JSON.stringify([scopeKey, mode, field]);
+}
+
+function profileDataTableFieldWithCache<T>(cacheScope: object, cacheKey: string, getValue: () => Promise<T>): Promise<T> {
+    let scopeCache = dataTableProfilingCache.get(cacheScope);
+    if (!scopeCache) {
+        scopeCache = new Map();
+        dataTableProfilingCache.set(cacheScope, scopeCache);
+    }
+    const cached = scopeCache.get(cacheKey) as Promise<T> | undefined;
+    if (cached) {
+        scopeCache.delete(cacheKey);
+        scopeCache.set(cacheKey, cached);
+        return cached;
+    }
+    const pending = getValue().catch((error) => {
+        scopeCache?.delete(cacheKey);
+        throw error;
+    });
+    scopeCache.set(cacheKey, pending);
+    if (scopeCache.size > DATA_TABLE_PROFILING_CACHE_LIMIT) {
+        const oldestKey = scopeCache.keys().next().value;
+        if (oldestKey) {
+            scopeCache.delete(oldestKey);
+        }
+    }
+    return pending;
+}
+
+export function profileNonmialFieldWithCache(service: IComputationFunction, field: string, options: DataTableProfilingCacheOptions = {}) {
+    const cacheScope = options.cacheScope ?? service;
+    const cacheKey = getDataTableProfilingKey('nominal', field, options.scopeKey);
+    return profileDataTableFieldWithCache(cacheScope, cacheKey, () => profileNonmialField(wrapComputationWithDataTableProfilingQueue(wrapComputationWithTag(service, 'profiling')), field));
+}
+
 export async function profileQuantitativeField(service: IComputationFunction, field: string) {
     const BIN_FIELD = `bin_${field}`;
     const ROW_NUM_FIELD = `${COUNT_FIELD_ID}_sum`;
@@ -639,6 +689,36 @@ export async function profileQuantitativeField(service: IComputationFunction, fi
         max,
         binValues,
     };
+}
+
+export function profileQuantitativeFieldWithCache(service: IComputationFunction, field: string, options: DataTableProfilingCacheOptions = {}) {
+    const cacheScope = options.cacheScope ?? service;
+    const cacheKey = getDataTableProfilingKey('quantitative', field, options.scopeKey);
+    return profileDataTableFieldWithCache(cacheScope, cacheKey, () => profileQuantitativeField(wrapComputationWithDataTableProfilingQueue(wrapComputationWithTag(service, 'profiling')), field));
+}
+
+function scheduleDataTableProfiling<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const run = () => {
+            dataTableProfilingActiveCount++;
+            Promise.resolve()
+                .then(task)
+                .then(resolve, reject)
+                .finally(() => {
+                    dataTableProfilingActiveCount--;
+                    dataTableProfilingQueue.shift()?.();
+                });
+        };
+        if (dataTableProfilingActiveCount < DATA_TABLE_PROFILING_CONCURRENCY) {
+            run();
+        } else {
+            dataTableProfilingQueue.push(run);
+        }
+    });
+}
+
+function wrapComputationWithDataTableProfilingQueue(service: IComputationFunction): IComputationFunction {
+    return (payload) => scheduleDataTableProfiling(() => service(payload));
 }
 
 export function wrapComputationWithTag(service: IComputationFunction, tag: string) {

--- a/packages/graphic-walker/src/computation/profilingCache.test.ts
+++ b/packages/graphic-walker/src/computation/profilingCache.test.ts
@@ -1,0 +1,166 @@
+import { IComputationFunction, IDataQueryPayload } from '../interfaces';
+import {
+    profileNonmialField,
+    profileNonmialFieldWithCache,
+    profileQuantitativeField,
+    profileQuantitativeFieldWithCache,
+    wrapComputationWithTag,
+} from './index';
+
+jest.mock('lodash-es', () => ({
+    range: (start: number, end: number) => Array.from({ length: end - start }, (_, index) => start + index),
+}));
+jest.mock('nanoid', () => ({ nanoid: () => 'mock-id' }));
+
+function createProfilingService(options: { delayMs?: number; onStart?: () => void; onFinish?: () => void } = {}) {
+    const calls: IDataQueryPayload[] = [];
+    const service: IComputationFunction = jest.fn(async (payload: IDataQueryPayload) => {
+        calls.push(payload);
+        options.onStart?.();
+        try {
+            if (options.delayMs) {
+                await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+            }
+            const firstStep = payload.workflow[0];
+            const viewStep = payload.workflow.find((step) => step.type === 'view') as any;
+            const groupBy = viewStep?.query[0]?.groupBy ?? [];
+
+            if (firstStep?.type === 'transform') {
+                const field = String(groupBy[0]).replace(/^bin_/, '');
+                return [
+                    { [`bin_${field}`]: [0, 10], gw_count_fid_sum: 4 },
+                    { [`bin_${field}`]: [10, 20], gw_count_fid_sum: 6 },
+                ];
+            }
+
+            const field = String(groupBy[0]);
+            if (payload.limit === 2) {
+                return [
+                    { [field]: 'A', [`count_${field}`]: 7 },
+                    { [field]: 'B', [`count_${field}`]: 3 },
+                ];
+            }
+            return [{ [`total_distinct_${field}`]: 2, count: 10 }];
+        } finally {
+            options.onFinish?.();
+        }
+    });
+    return { service, calls };
+}
+
+const nominalFields = ['category_0', 'category_1', 'category_2', 'category_3'];
+const quantitativeFields = ['value_0', 'value_1', 'value_2', 'value_3'];
+
+function runProfilingWorkload(service: IComputationFunction) {
+    const taggedService = wrapComputationWithTag(service, 'profiling');
+    return Promise.all([
+        ...nominalFields.map((field) => profileNonmialField(taggedService, field)),
+        ...quantitativeFields.map((field) => profileQuantitativeField(taggedService, field)),
+    ]);
+}
+
+function runCachedProfilingWorkload(service: IComputationFunction, cacheScope: object, scopeKey: string) {
+    return Promise.all([
+        ...nominalFields.map((field) => profileNonmialFieldWithCache(service, field, { cacheScope, scopeKey })),
+        ...quantitativeFields.map((field) => profileQuantitativeFieldWithCache(service, field, { cacheScope, scopeKey })),
+    ]);
+}
+
+describe('data table profiling cache', () => {
+    test('deduplicates in-flight nominal profiles and reuses resolved values in one scope', async () => {
+        const { service } = createProfilingService();
+        const cacheScope = {};
+
+        const [first, second] = await Promise.all([
+            profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[]' }),
+            profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[]' }),
+        ]);
+
+        expect(first).toEqual(second);
+        expect(service).toHaveBeenCalledTimes(2);
+
+        await profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[]' });
+
+        expect(service).toHaveBeenCalledTimes(2);
+    });
+
+    test('keeps different filter scopes isolated', async () => {
+        const { service } = createProfilingService();
+        const cacheScope = {};
+
+        await profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[{"fid":"region","rule":"west"}]' });
+        await profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[{"fid":"region","rule":"east"}]' });
+        await profileNonmialFieldWithCache(service, 'category', { cacheScope, scopeKey: '[{"fid":"region","rule":"west"}]' });
+
+        expect(service).toHaveBeenCalledTimes(4);
+    });
+
+    test('keeps nominal and quantitative profile modes isolated for the same field', async () => {
+        const { service } = createProfilingService();
+        const cacheScope = {};
+
+        await profileNonmialFieldWithCache(service, 'value', { cacheScope, scopeKey: '[]' });
+        await profileQuantitativeFieldWithCache(service, 'value', { cacheScope, scopeKey: '[]' });
+        await profileNonmialFieldWithCache(service, 'value', { cacheScope, scopeKey: '[]' });
+        await profileQuantitativeFieldWithCache(service, 'value', { cacheScope, scopeKey: '[]' });
+
+        expect(service).toHaveBeenCalledTimes(3);
+    });
+
+    test('reuses a complete profiling workload across duplicate mounts', async () => {
+        const before = createProfilingService();
+
+        await Promise.all([runProfilingWorkload(before.service), runProfilingWorkload(before.service)]);
+
+        expect(before.service).toHaveBeenCalledTimes(24);
+
+        const after = createProfilingService();
+        const cacheScope = {};
+
+        await Promise.all([runCachedProfilingWorkload(after.service, cacheScope, '[]'), runCachedProfilingWorkload(after.service, cacheScope, '[]')]);
+        await runCachedProfilingWorkload(after.service, cacheScope, '[]');
+
+        expect(after.service).toHaveBeenCalledTimes(12);
+    });
+
+    test('limits profiling computation concurrency for wide tables', async () => {
+        let active = 0;
+        let maxActive = 0;
+        const { service } = createProfilingService({
+            delayMs: 5,
+            onStart: () => {
+                active++;
+                maxActive = Math.max(maxActive, active);
+            },
+            onFinish: () => {
+                active--;
+            },
+        });
+        const cacheScope = {};
+
+        await Promise.all(
+            Array.from({ length: 12 }, (_, index) => profileQuantitativeFieldWithCache(service, `wide_value_${index}`, { cacheScope, scopeKey: '[]' }))
+        );
+
+        expect(service).toHaveBeenCalledTimes(12);
+        expect(maxActive).toBeLessThanOrEqual(4);
+    });
+
+    test('releases profiling queue slots after synchronous computation errors', async () => {
+        const cacheScope = {};
+        const error = new Error('sync failure');
+        const throwingService: IComputationFunction = jest.fn(() => {
+            throw error;
+        });
+
+        await expect(profileQuantitativeFieldWithCache(throwingService, 'broken', { cacheScope, scopeKey: '[]' })).rejects.toThrow('sync failure');
+
+        const { service } = createProfilingService();
+        await Promise.all(
+            Array.from({ length: 6 }, (_, index) => profileQuantitativeFieldWithCache(service, `recovered_${index}`, { cacheScope, scopeKey: '[]' }))
+        );
+
+        expect(throwingService).toHaveBeenCalledTimes(1);
+        expect(service).toHaveBeenCalledTimes(6);
+    });
+});


### PR DESCRIPTION
## Why

PyGWalker uses Graphic Walker's DataTable/Data Panel to show database-backed datasets. DataTable header profiling renders a small distribution for each visible field, but the existing `FieldProfiling` path issued profiling computation calls independently on every mount.

That creates avoidable database pressure in enterprise backends:

- nominal, ordinal, and temporal fields issue two computation requests each
- quantitative fields issue one computation request each
- remounts, tab switches, scroll/lazy-load replay, and duplicate visible fields can repeat the same backend work
- concurrent first-load fan-out can send many profiling requests at once

## How

This PR adds a DataTable-specific profiling cache in `packages/graphic-walker/src/computation/index.ts` and wires `FieldProfiling` through it.

The cache key includes:

- computation/filter scope supplied by DataTable
- semantic type
- profiling mode (`nominal` or `quantitative`)
- field id

The implementation also:

- deduplicates in-flight identical profiling requests by sharing the same promise
- reuses resolved results for repeated mounts in the same DataTable/filter scope
- evicts failed requests so transient backend errors are not cached permanently
- caps each computation scope cache at 500 entries with LRU-style refresh
- limits DataTable profiling computation concurrency to 4 requests at a time
- preserves existing `tag: "profiling"` behavior
- avoids setting React state after unmount or prop changes

## Analysis and performance

The first profile of a new filter/data scope still needs one profile per unique field, so the total first-load work for unique fields is intentionally unchanged. The improvement is that duplicate/remounted requests are collapsed, repeated scopes are served from cache, and wide-table first-load fan-out is throttled before it hits a backend.

Measured in `src/computation/profilingCache.test.ts`:

| Scenario | Before | After |
| --- | ---: | ---: |
| Duplicate mount workload, 4 nominal + 4 quantitative fields | 24 computation calls | 12 computation calls |
| Repeat same table scope after initial profile | 12 additional calls | 0 additional calls |
| Same nominal field across west/east/west filter scopes | 6 computation calls | 4 computation calls, with filter isolation |
| Same field profiled as nominal and quantitative | incompatible modes could recompute independently | 3 first-use calls, repeats cached separately |
| 12 concurrent quantitative profile requests | up to 12 simultaneous backend calls | max 4 simultaneous backend calls |

For a representative 100-column table with 50 nominal-like fields and 50 quantitative fields:

- first profile remains 150 total computation calls, but max backend concurrency is capped at 4
- duplicate concurrent mount drops from 300 total calls to 150
- reopening the same DataTable/filter scope after profiling completes drops from 150 new calls to 0

## Validation

- `yarn workspace @kanaries/graphic-walker test --runTestsByPath src/computation/profilingCache.test.ts` - 6 tests passed
- `yarn workspace @kanaries/graphic-walker test` - 9 suites / 73 tests passed
- `yarn workspace @kanaries/graphic-walker build` - passed

Build emitted existing warnings about outdated Browserslist data and ignored `"use client"` directives from dependencies.

## Notes

The cache assumes data changes are represented by a changed computation identity or changed DataTable scope key. Custom external computation functions that mutate backing data without changing identity can serve a cached profile until the computation identity or filter scope changes.
