### PR TITLE
[Bug] Fix primary color setting crash by validating RGBA components

### DIFF
--- a/packages/graphic-walker/src/components/visualConfig/colorScheme.tsx
+++ b/packages/graphic-walker/src/components/visualConfig/colorScheme.tsx
@@ -98,5 +98,10 @@ export const extractRGBA = (defaultValue: { r: number; g: number; b: number; a: 
 
     const arr = rgba.match(/\d+/g) || [];
     const [r = 0, g = 0, b = 0, a = 0] = arr.map(Number);
-    return { r, g, b, a };
+    return {
+        r: Number.isFinite(r) ? r : defaultValue.r,
+        g: Number.isFinite(g) ? g : defaultValue.g,
+        b: Number.isFinite(b) ? b : defaultValue.b,
+        a: Number.isFinite(a) ? a : defaultValue.a,
+    };
 };


### PR DESCRIPTION
## Summary

When the primary color picker receives a malformed `rgba()` value (e.g. corrupted or non-numeric), `extractRGBA()` parses it via `rgba.match(/\d+/g)` and converts to numbers. If the parsed values are `NaN`, they propagate into `rgba(NaN,NaN,NaN,NaN)` in style strings, causing React to crash.

This fix adds `Number.isFinite()` validation for each extracted RGBA component, falling back to `defaultValue` when the parsed value is not a finite number.

## Related Issue

Closes #179

## Type of Change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] My code follows the existing style.
- [x] CI is green (passing all checks).