### PR TITLE
fix(test): replace nanoid jest mapping with local CJS shim

### DIFF
--- a/packages/graphic-walker/jest.config.js
+++ b/packages/graphic-walker/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     testEnvironment: 'node',
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/src/$1',
-        '^nanoid$': '<rootDir>/../../node_modules/nanoid/index.cjs',
+        '^nanoid$': '<rootDir>/tests/shims/nanoid.cjs',
     },
     testPathIgnorePatterns: ['<rootDir>/dist/'],
 };

--- a/packages/graphic-walker/tests/shims/nanoid.cjs
+++ b/packages/graphic-walker/tests/shims/nanoid.cjs
@@ -1,0 +1,31 @@
+/**
+ * CommonJS stand-in for `nanoid` used only by Jest (see moduleNameMapper).
+ * nanoid >= 4 ships pure ESM, which Jest's CJS runtime cannot require, and
+ * mapping into node_modules broke whenever hoisting changed the installed
+ * version. Mirrors the upstream secure implementation.
+ */
+const crypto = require('crypto');
+
+const urlAlphabet = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict';
+
+const nanoid = (size = 21) => {
+    const bytes = crypto.randomBytes(size);
+    let id = '';
+    while (size--) {
+        id += urlAlphabet[bytes[size] & 63];
+    }
+    return id;
+};
+
+const customAlphabet = (alphabet, defaultSize = 21) => {
+    return (size = defaultSize) => {
+        const bytes = crypto.randomBytes(size);
+        let id = '';
+        while (size--) {
+            id += alphabet[bytes[size] % alphabet.length];
+        }
+        return id;
+    };
+};
+
+module.exports = { nanoid, customAlphabet, urlAlphabet };


### PR DESCRIPTION
## Problem

`packages/graphic-walker/jest.config.js` mapped `nanoid` to `<rootDir>/../../node_modules/nanoid/index.cjs`. That file only exists when yarn happens to hoist a **nanoid 3.x** copy (a transitive dependency of postcss/styled-components) to the workspace root. graphic-walker itself depends on **nanoid ^4**, which is pure ESM and ships no `index.cjs`.

On a fresh `yarn install`, 4.x wins the root hoist and **11 test suites fail** with:

```
Configuration error: Could not locate module nanoid mapped as: .../node_modules/nanoid/index.cjs
```

Existing checkouts with older `node_modules` pass by accident, which is why this went unnoticed.

## Fix

Map `nanoid` to a local CommonJS shim (`tests/shims/nanoid.cjs`) that mirrors the upstream secure implementation (`crypto.randomBytes` + the upstream url alphabet, exports `nanoid`, `customAlphabet`, `urlAlphabet`). Tests no longer depend on hoisting luck or a specific nanoid major.

## Verification

- Fresh-install worktree (nanoid 4.x hoisted to root, previously 11 suites failing): **23/23 suites, 284 tests, 4 snapshots pass**
- Long-lived checkout (nanoid 3.3.7 at root): **23/23 suites, 284 tests pass**
- Source only uses `import { nanoid } from 'nanoid'` (`src/models/utils.ts`, `src/lib/vl2gw.ts`), covered by the shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)