### PR TITLE
feat: field settings dialog (title override, custom sort, format) + release 0.5.1

### DIFF
--- a/packages/duckdb-wasm-computation/package.json
+++ b/packages/duckdb-wasm-computation/package.json
@@ -15,7 +15,7 @@
     },
     "devDependencies": {
         "@duckdb/duckdb-wasm": "^1.28.0",
-        "@kanaries/graphic-walker": "0.5.0",
+        "@kanaries/graphic-walker": "0.5.1",
         "@kanaries/gw-dsl-parser": "^0.1.48-rc3",
         "apache-arrow": "^17.0.0",
         "nanoid": "^5.0.1",

--- a/packages/graphic-walker/package.json
+++ b/packages/graphic-walker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanaries/graphic-walker",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "dev:front_end": "vite --host",
     "dev": "npm run dev:front_end",

--- a/packages/graphic-walker/src/App.tsx
+++ b/packages/graphic-walker/src/App.tsx
@@ -37,6 +37,7 @@ import { getComputation } from './computation/clientComputation';
 import LogPanel from './fields/datasetFields/logPanel';
 import BinPanel from './fields/datasetFields/binPanel';
 import RenamePanel from './components/renameField';
+import FieldConfigDialog from './components/fieldConfigDialog';
 import { ErrorContext } from './utils/reportError';
 import { ErrorBoundary } from 'react-error-boundary';
 import Errorpanel from './components/errorpanel';
@@ -235,6 +236,7 @@ export const VizApp = observer(function VizApp(props: BaseVizProps) {
                                             <LogPanel />
                                             <BinPanel />
                                             <RenamePanel />
+                                            <FieldConfigDialog />
                                             <ComputedFieldDialog />
                                             <Painter themeConfig={appliedThemeConfig} themeKey={appliedThemeKey} />
                                             {vizStore.showGeoJSONConfigPanel && <GeoConfigPanel geoList={props.geoList} />}

--- a/packages/graphic-walker/src/components/fieldConfigDialog/index.tsx
+++ b/packages/graphic-walker/src/components/fieldConfigDialog/index.tsx
@@ -1,0 +1,463 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Textarea } from '@/components/ui/textarea';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import Spinner from '@/components/spinner';
+import Tooltip from '@/components/tooltip';
+import { useCompututaion, useVizStore } from '@/store';
+import { fieldStat } from '@/computation';
+import { GLOBAL_CONFIG } from '@/config';
+import { IAnalyticType, IAggregator, ICustomSortType, IManualSortValue, ISemanticType, IViewField, ISortMode } from '@/interfaces';
+import { DragDropContext, Draggable, Droppable, DropResult } from '@kanaries/react-beautiful-dnd';
+
+type ManualListItem = {
+    value: IManualSortValue;
+    id: string;
+};
+
+const DEFAULT_SORT_ORDER: Exclude<ISortMode, 'none'> = 'ascending';
+type AggregatorSelectValue = IAggregator;
+
+function asDisplayValue(value: IManualSortValue) {
+    if (value === null) return 'null';
+    if (value === undefined) return '';
+    if (typeof value === 'boolean') return value ? 'true' : 'false';
+    return String(value);
+}
+
+const FieldConfigDialog = observer(() => {
+    const vizStore = useVizStore();
+    const computation = useCompututaion();
+    const { t } = useTranslation();
+
+    const target = vizStore.fieldConfigTarget;
+    const isOpen = vizStore.showFieldConfigPanel && Boolean(target);
+    const currentField: IViewField | null = useMemo(() => {
+        if (!target) return null;
+        return vizStore.currentEncodings[target.channel]?.[target.index] ?? null;
+    }, [target, vizStore.currentEncodings]);
+
+    const [titleOverride, setTitleOverride] = useState('');
+    const [sortType, setSortType] = useState<ICustomSortType>('measure');
+    const [sortOrder, setSortOrder] = useState<ISortMode>('none');
+    const [manualValues, setManualValues] = useState<ManualListItem[]>([]);
+    const [loadingValues, setLoadingValues] = useState(false);
+    const [fetchError, setFetchError] = useState<string | null>(null);
+    const [aggValue, setAggValue] = useState<AggregatorSelectValue>('sum');
+    const [semanticTypeState, setSemanticTypeState] = useState<ISemanticType>('nominal');
+    const [analyticTypeState, setAnalyticTypeState] = useState<IAnalyticType>('dimension');
+    const [customFormat, setCustomFormat] = useState('');
+    const [manualSortDisabled, setManualSortDisabled] = useState(false);
+    const [manualSortDisabledReason, setManualSortDisabledReason] = useState('');
+    const [manualValuesFetched, setManualValuesFetched] = useState(false);
+    const manualSortRequestIdRef = useRef(0);
+
+    const allowSort = useMemo(() => {
+        if (!target || !currentField) return false;
+        if (analyticTypeState !== 'dimension') return false;
+        if (semanticTypeState !== 'nominal' && semanticTypeState !== 'ordinal') return false;
+        return target.channel === 'rows' || target.channel === 'columns';
+    }, [target, analyticTypeState, semanticTypeState]);
+
+    const aggregatorOptions = useMemo(() => GLOBAL_CONFIG.AGGREGATOR_LIST, []);
+    const semanticTypeOptions: ISemanticType[] = ['nominal', 'ordinal', 'quantitative', 'temporal'];
+    const analyticTypeOptions: IAnalyticType[] = ['dimension', 'measure'];
+
+    useEffect(() => {
+        manualSortRequestIdRef.current += 1;
+        if (!currentField) {
+            setTitleOverride('');
+            setSortType('measure');
+            setSortOrder('none');
+            setManualValues([]);
+            setFetchError(null);
+            setAggValue('sum');
+            setSemanticTypeState('nominal');
+            setAnalyticTypeState('dimension');
+            setCustomFormat('');
+            setManualSortDisabled(false);
+            setManualSortDisabledReason('');
+            setManualValuesFetched(false);
+            return;
+        }
+        setTitleOverride(currentField.titleOverride ?? '');
+        setSortType(currentField.sortType ?? 'measure');
+        setSortOrder(currentField.sort ?? 'none');
+        setManualValues((currentField.sortList ?? []).map((value, idx) => ({ value, id: `${currentField.fid}_${idx}` })));
+        setFetchError(null);
+        setAggValue((currentField.aggName as AggregatorSelectValue) ?? 'sum');
+        setSemanticTypeState(currentField.semanticType);
+        setAnalyticTypeState(currentField.analyticType);
+        setCustomFormat(currentField.customFormat ?? '');
+        setManualSortDisabled(false);
+        setManualSortDisabledReason('');
+        setManualValuesFetched(false);
+    }, [currentField?.fid, target?.channel, target?.index]);
+
+    const handleAnalyticTypeChange = useCallback(
+        (value: IAnalyticType) => {
+            setAnalyticTypeState(value);
+            if (value === 'dimension') {
+                setAggValue('sum');
+            } else if (value === 'measure') {
+                setAggValue((GLOBAL_CONFIG.AGGREGATOR_LIST[0] as AggregatorSelectValue) ?? 'sum');
+            }
+        },
+        [aggValue]
+    );
+
+    const hydrateValues = useCallback(async () => {
+        if (!currentField || !allowSort) return;
+        const requestId = ++manualSortRequestIdRef.current;
+        setManualValuesFetched(true);
+        setLoadingValues(true);
+        setFetchError(null);
+        try {
+            const stats = await fieldStat(
+                computation,
+                currentField,
+                {
+                    values: true,
+                    range: false,
+                    valuesMeta: true,
+                    valuesLimit: 100,
+                },
+                vizStore.meta
+            );
+            if (requestId !== manualSortRequestIdRef.current) {
+                return;
+            }
+            const distinctTotal = stats.valuesMeta?.distinctTotal ?? stats.values.length;
+            const limitExceeded = distinctTotal > 100;
+            setManualSortDisabled(limitExceeded);
+            setManualSortDisabledReason(limitExceeded ? `Manual sort supports up to 100 distinct values. ${distinctTotal} values detected.` : '');
+            if (limitExceeded) {
+                setManualValues([]);
+                setSortType((prev) => (prev === 'manual' ? 'measure' : prev));
+                return;
+            }
+            if (stats.values.length) {
+                setManualValues((prev) => {
+                    if (prev.length > 0) return prev;
+                    return stats.values.map((v, idx) => ({
+                        value: v.value as IManualSortValue,
+                        id: `${currentField.fid}_auto_${idx}`,
+                    }));
+                });
+            }
+        } catch (err) {
+            if (requestId === manualSortRequestIdRef.current) {
+                setFetchError(err instanceof Error ? err.message : String(err));
+            }
+        } finally {
+            if (requestId === manualSortRequestIdRef.current) {
+                setLoadingValues(false);
+            }
+        }
+    }, [allowSort, computation, currentField, vizStore.meta]);
+
+    useEffect(() => {
+        if (isOpen && allowSort && currentField && !manualValuesFetched && !loadingValues) {
+            hydrateValues();
+        }
+    }, [allowSort, currentField?.fid, hydrateValues, isOpen, loadingValues, manualValuesFetched, target?.channel, target?.index]);
+
+    const handleRetryManualValues = useCallback(() => {
+        if (loadingValues) return;
+        setFetchError(null);
+        setManualValuesFetched(false);
+    }, [loadingValues]);
+
+    const handleClose = useCallback(() => {
+        vizStore.setShowFieldConfigPanel(false);
+    }, [vizStore]);
+
+    const handleSave = useCallback(() => {
+        if (!target || !currentField) return;
+        const trimmedTitle = titleOverride.trim();
+        const trimmedFormat = customFormat.trim();
+        const patch: Partial<IViewField> = {
+            titleOverride: trimmedTitle ? trimmedTitle : undefined,
+            semanticType: semanticTypeState,
+            analyticType: analyticTypeState,
+            customFormat: trimmedFormat ? trimmedFormat : undefined,
+        };
+        if (analyticTypeState === 'measure') {
+            patch.aggName = aggValue;
+        } else if (currentField.aggName) {
+            patch.aggName = undefined;
+        }
+        if (allowSort) {
+            if (sortType === 'manual') {
+                patch.sortType = 'manual';
+                patch.sortList = manualValues.map((item) => item.value);
+                patch.sort = patch.sortList.length ? DEFAULT_SORT_ORDER : 'none';
+            } else if (sortType === 'alphabetical') {
+                patch.sortType = 'alphabetical';
+                patch.sort = sortOrder === 'none' ? DEFAULT_SORT_ORDER : sortOrder;
+                patch.sortList = undefined;
+            } else {
+                patch.sortType = 'measure';
+                patch.sort = sortOrder;
+                patch.sortList = undefined;
+            }
+        }
+        vizStore.editEncodingField(target.channel, target.index, patch);
+        handleClose();
+    }, [
+        allowSort,
+        currentField,
+        handleClose,
+        manualValues,
+        semanticTypeState,
+        analyticTypeState,
+        aggValue,
+        sortOrder,
+        sortType,
+        target,
+        titleOverride,
+        customFormat,
+        vizStore,
+    ]);
+
+    const reorderManualValue = useCallback((from: number, to: number) => {
+        setManualValues((prev) => {
+            if (from === to) return prev;
+            const next = prev.slice();
+            const [item] = next.splice(from, 1);
+            next.splice(to, 0, item);
+            return next;
+        });
+    }, []);
+
+    const renderSortOrderControls = () => (
+        <div className="space-y-2">
+            <Label>Sort Order</Label>
+            <RadioGroup value={sortOrder} onValueChange={(value) => setSortOrder(value as ISortMode)} className="flex space-x-3">
+                <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="ascending" id="order-asc" />
+                    <Label htmlFor="order-asc">Ascending</Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="descending" id="order-desc" />
+                    <Label htmlFor="order-desc">Descending</Label>
+                </div>
+                {sortType === 'measure' && (
+                    <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="none" id="order-none" />
+                        <Label htmlFor="order-none">None</Label>
+                    </div>
+                )}
+            </RadioGroup>
+        </div>
+    );
+
+    const handleManualDragEnd = useCallback(
+        (result: DropResult) => {
+            if (!result.destination) return;
+            reorderManualValue(result.source.index, result.destination.index);
+        },
+        [reorderManualValue]
+    );
+
+    const manualList = (
+        <div className="space-y-3">
+            <div className="flex items-end space-x-2">
+                <div className="flex-1">
+                    <Label htmlFor="manual-input">Custom Value</Label>
+                </div>
+            </div>
+            <div className="rounded border p-2">
+                <div className="flex items-center justify-between mb-2 text-xs text-muted-foreground">
+                    <span>Drag to change order</span>
+                    {loadingValues && (
+                        <span className="flex items-center space-x-1 text-primary">
+                            <Spinner className="h-3 w-3" />
+                            <span>Loading…</span>
+                        </span>
+                    )}
+                </div>
+                {fetchError && (
+                    <div className="flex items-center justify-between mb-2 text-xs text-destructive">
+                        <span className="pr-2">{fetchError}</span>
+                        <button type="button" className="text-primary underline" onClick={handleRetryManualValues}>
+                            Retry
+                        </button>
+                    </div>
+                )}
+                <ScrollArea className="max-h-48">
+                    <DragDropContext onDragEnd={handleManualDragEnd}>
+                        <Droppable droppableId="manual-values" direction="vertical">
+                            {(provided) => (
+                                <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-1">
+                                    {manualValues.map((item, index) => (
+                                        <Draggable key={item.id} draggableId={item.id} index={index}>
+                                            {(dragProvided, snapshot) => (
+                                                <div
+                                                    ref={dragProvided.innerRef}
+                                                    className={`flex items-center justify-between rounded border px-2 py-1 text-sm transition-colors ${
+                                                        snapshot.isDragging ? 'bg-primary/10 border-primary' : 'bg-muted/40'
+                                                    }`}
+                                                    {...dragProvided.draggableProps}
+                                                    {...dragProvided.dragHandleProps}
+                                                >
+                                                    <span className="truncate pr-4">{asDisplayValue(item.value)}</span>
+                                                </div>
+                                            )}
+                                        </Draggable>
+                                    ))}
+                                    {provided.placeholder}
+                                    {manualValues.length === 0 && <p className="text-xs text-muted-foreground">No values captured yet.</p>}
+                                </div>
+                            )}
+                        </Droppable>
+                    </DragDropContext>
+                </ScrollArea>
+            </div>
+        </div>
+    );
+
+    const sortControls = allowSort ? (
+        <div className="space-y-4">
+            <div>
+                <Label>Custom Sort</Label>
+                <RadioGroup value={sortType} onValueChange={(value) => setSortType(value as ICustomSortType)} className="space-y-2 mt-2">
+                    <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="measure" id="sort-measure" />
+                        <Label htmlFor="sort-measure">By opposite axis (default)</Label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                        <RadioGroupItem value="alphabetical" id="sort-alpha" />
+                        <Label htmlFor="sort-alpha">Alphabetical</Label>
+                    </div>
+                    {manualSortDisabled ? (
+                        <Tooltip content={manualSortDisabledReason || 'Manual sort supports up to 100 distinct values.'}>
+                            <div className="flex items-center space-x-2 text-muted-foreground">
+                                <RadioGroupItem value="manual" id="sort-manual" disabled />
+                                <Label htmlFor="sort-manual">Manual order</Label>
+                            </div>
+                        </Tooltip>
+                    ) : (
+                        <div className="flex items-center space-x-2">
+                            <RadioGroupItem value="manual" id="sort-manual" />
+                            <Label htmlFor="sort-manual">Manual order</Label>
+                        </div>
+                    )}
+                </RadioGroup>
+            </div>
+            {(sortType === 'measure' || sortType === 'alphabetical') && renderSortOrderControls()}
+            {sortType === 'manual' && manualList}
+        </div>
+    ) : null;
+
+    return (
+        <Dialog open={isOpen} onOpenChange={(open) => (!open ? handleClose() : undefined)}>
+            <DialogContent className="max-w-xl">
+                <DialogHeader>
+                    <DialogTitle>Field Settings</DialogTitle>
+                    {currentField && <p className="text-sm text-muted-foreground">{currentField.name}</p>}
+                </DialogHeader>
+                {currentField ? (
+                    <div className="space-y-6 my-2">
+                        <div className="space-y-2">
+                            <Label htmlFor="field-title">Title Override</Label>
+                            <Textarea
+                                id="field-title"
+                                value={titleOverride}
+                                onChange={(event) => setTitleOverride(event.target.value)}
+                                placeholder="Leave empty to use the default title"
+                            />
+                        </div>
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label>Analytic Type</Label>
+                                <Select value={analyticTypeState} onValueChange={(value) => handleAnalyticTypeChange(value as IAnalyticType)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select analytic type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {analyticTypeOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                                {option}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Semantic Type</Label>
+                                <Select value={semanticTypeState} onValueChange={(value) => setSemanticTypeState(value as ISemanticType)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select semantic type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {semanticTypeOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                                {option}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Aggregator</Label>
+                                <Select
+                                    value={aggValue}
+                                    onValueChange={(value) => setAggValue(value as AggregatorSelectValue)}
+                                    disabled={analyticTypeState !== 'measure'}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select aggregator" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {aggregatorOptions.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                                {t(`constant.aggregator.${option}`)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                {analyticTypeState !== 'measure' && <p className="text-xs text-muted-foreground">Aggregator only applies to measure fields.</p>}
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="field-format">Custom Format</Label>
+                                <Input
+                                    id="field-format"
+                                    value={customFormat}
+                                    placeholder="e.g. ,.2f or %Y-%m-%d"
+                                    onChange={(event) => setCustomFormat(event.target.value)}
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    {t(`config.formatGuidesDocs`)}:{' '}
+                                    <a target="_blank" className="hover:underline text-primary" href="https://github.com/d3/d3-format#locale_format">
+                                        {t(`config.readHere`)}
+                                    </a>
+                                </p>
+                            </div>
+                        </div>
+                        {sortControls}
+                    </div>
+                ) : (
+                    <p className="text-sm text-muted-foreground">No field selected.</p>
+                )}
+                <DialogFooter>
+                    <Button variant="secondary" onClick={handleClose}>
+                        {t('actions.cancel')}
+                    </Button>
+                    <Button onClick={handleSave} disabled={!currentField}>
+                        {t('actions.confirm')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+});
+
+export default FieldConfigDialog;

--- a/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/multiEncodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { DraggableFieldState, IAggregator, IDraggableStateKey } from '../../interfaces';
 import { observer } from 'mobx-react-lite';
 import { useVizStore } from '../../store';
@@ -49,6 +49,13 @@ const SingleEncodeEditor: React.FC<MultiEncodeEditorProps> = (props) => {
         }));
     }, [allFields]);
 
+    const openFieldConfig = useCallback(
+        (idx: number) => {
+            vizStore.openFieldConfig(dkey.id, idx);
+        },
+        [vizStore, dkey.id]
+    );
+
     return (
         <div className="relative select-none flex flex-col py-0.5 px-1 touch-none" {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             {channelItems.map((channelItem, index) => {
@@ -74,7 +81,14 @@ const SingleEncodeEditor: React.FC<MultiEncodeEditorProps> = (props) => {
                                     >
                                         <TrashIcon className="w-4" />
                                     </div>
-                                    <PillActions className="flex-1 flex items-center border border-l-0 px-2 space-x-2 truncate">
+                                    <PillActions
+                                        className="flex-1 flex items-center border border-l-0 px-2 space-x-2 truncate"
+                                        onDoubleClick={() => openFieldConfig(index)}
+                                        onContextMenu={(event) => {
+                                            event.preventDefault();
+                                            openFieldConfig(index);
+                                        }}
+                                    >
                                         {channelItem.fid === MEA_KEY_ID && (
                                             <SelectContext
                                                 options={foldOptions}

--- a/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
+++ b/packages/graphic-walker/src/fields/encodeFields/singleEncodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { DraggableFieldState, IAggregator, IDraggableStateKey } from '../../interfaces';
 import { observer } from 'mobx-react-lite';
 import { useVizStore } from '../../store';
@@ -49,6 +49,10 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
         }));
     }, [allFields]);
 
+    const openFieldConfig = useCallback(() => {
+        vizStore.openFieldConfig(dkey.id, 0);
+    }, [vizStore, dkey.id]);
+
     return (
         <div className="p-1 select-none relative touch-none" {...provided.droppableProps} ref={refMapper(provided.innerRef)}>
             <div
@@ -80,7 +84,14 @@ const SingleEncodeEditor: React.FC<SingleEncodeEditorProps> = (props) => {
                                 >
                                     <TrashIcon className="w-4" />
                                 </div>
-                                <PillActions className="flex-1 flex items-center border border-l-0 px-2 space-x-2 truncate">
+                                <PillActions
+                                    className="flex-1 flex items-center border border-l-0 px-2 space-x-2 truncate"
+                                    onDoubleClick={openFieldConfig}
+                                    onContextMenu={(event) => {
+                                        event.preventDefault();
+                                        openFieldConfig();
+                                    }}
+                                >
                                     {channelItem.fid === MEA_KEY_ID && (
                                         <SelectContext
                                             options={foldOptions}

--- a/packages/graphic-walker/src/fields/obComponents/obPill.tsx
+++ b/packages/graphic-walker/src/fields/obComponents/obPill.tsx
@@ -1,6 +1,6 @@
 import { BarsArrowDownIcon, BarsArrowUpIcon, ChevronUpDownIcon } from '@heroicons/react/24/outline';
 import { observer } from 'mobx-react-lite';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DraggableProvided } from '@kanaries/react-beautiful-dnd';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID } from '../../constants';
@@ -41,6 +41,10 @@ const OBPill: React.FC<PillProps> = (props) => {
 
     const folds = field.fid === MEA_KEY_ID ? config.folds ?? [] : null;
 
+    const handleOpenFieldConfig = useCallback(() => {
+        vizStore.openFieldConfig(dkey.id, fIndex);
+    }, [vizStore, dkey.id, fIndex]);
+
     return (
         <Pill
             ref={refMapper(provided.innerRef)}
@@ -48,6 +52,11 @@ const OBPill: React.FC<PillProps> = (props) => {
             className={`${field.aggName === 'expr' && !config.defaultAggregated ? '!opacity-50 touch-none' : 'touch-none'}`}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
+            onDoubleClick={handleOpenFieldConfig}
+            onContextMenu={(event) => {
+                event.preventDefault();
+                handleOpenFieldConfig();
+            }}
         >
             {folds && (
                 <SelectContext
@@ -75,12 +84,15 @@ const OBPill: React.FC<PillProps> = (props) => {
                     </span>
                 </DropdownContext>
             )}
-            {field.analyticType === 'dimension' && field.sort === 'ascending' && (
+            {field.analyticType === 'dimension' && field.sortType !== 'manual' && field.sort === 'ascending' && (
                 <BarsArrowUpIcon className="float-right w-3" role="status" aria-label="Sorted in ascending order" />
             )}
-            {field.analyticType === 'dimension' && field.sort === 'descending' && (
+            {field.analyticType === 'dimension' && field.sortType !== 'manual' && field.sort === 'descending' && (
                 <BarsArrowDownIcon className="float-right w-3" role="status" aria-label="Sorted in descending order" />
             )}
+            {field.analyticType === 'dimension' && field.sortType === 'manual' && field.sortList?.length ? (
+                <span className="ml-1 text-[10px] uppercase tracking-wide text-muted-foreground">Manual</span>
+            ) : null}
         </Pill>
     );
 };

--- a/packages/graphic-walker/src/interfaces.ts
+++ b/packages/graphic-walker/src/interfaces.ts
@@ -211,8 +211,15 @@ export interface IField {
     aggergated?: boolean;
 }
 export type ISortMode = 'none' | 'ascending' | 'descending';
+export type ICustomSortType = 'measure' | 'alphabetical' | 'manual';
+export type IManualSortValue = string | number | boolean | null;
+
 export interface IViewField extends IField {
     sort?: ISortMode;
+    sortType?: ICustomSortType;
+    sortList?: IManualSortValue[];
+    titleOverride?: string;
+    customFormat?: string;
 }
 
 // shadow type of identifier of a Field, getting it using "getFieldIdentifier" in "@/utils"

--- a/packages/graphic-walker/src/models/chat.ts
+++ b/packages/graphic-walker/src/models/chat.ts
@@ -294,6 +294,7 @@ const actionMessageMapper: {
     [Methods.editAllField]: () => '',
     [Methods.replaceWithNLPQuery]: () => '',
     [Methods.replaceChart]: (_data, chart) => `Replace the chart with a recommended ${chart.config?.geoms?.[0] ?? ''} chart.`,
+    [Methods.editField]: () => '',
 };
 
 function toMessage<T>(data: IChart, action: VisActionOf<T>) {

--- a/packages/graphic-walker/src/models/visSpecHistory.ts
+++ b/packages/graphic-walker/src/models/visSpecHistory.ts
@@ -63,6 +63,7 @@ export enum Methods {
     replaceWithNLPQuery,
     // appended at the end: enum values are serialized in exported timelines
     replaceChart,
+    editField,
 }
 export type PropsMap = {
     [Methods.setConfig]: KVTuple<IVisualConfigNew>;
@@ -92,6 +93,7 @@ export type PropsMap = {
     [Methods.editAllField]: [string, Partial<IField>];
     [Methods.replaceWithNLPQuery]: [string, string];
     [Methods.replaceChart]: [PartialChart];
+    [Methods.editField]: [normalKeys, number, Partial<IViewField>];
 };
 // ensure propsMap has all keys of methods
 type assertPropsMap = AssertSameKey<PropsMap, { [a in Methods]: any }>;
@@ -193,10 +195,24 @@ const actions: {
         const yField = rows.length > 0 ? rows[rows.length - 1] : null;
         const xField = columns.length > 0 ? columns[columns.length - 1] : null;
         if (xField !== null && xField.analyticType === 'dimension' && yField !== null && yField.analyticType === 'measure') {
-            return mutPath(data, 'encodings.columns', (cols) => replace(cols, cols.length - 1, (x) => ({ ...x, sort })));
+            return mutPath(data, 'encodings.columns', (cols) =>
+                replace(cols, cols.length - 1, (x) => ({
+                    ...x,
+                    sort,
+                    sortType: 'measure' as const,
+                    sortList: undefined,
+                }))
+            );
         }
         if (xField !== null && xField.analyticType === 'measure' && yField !== null && yField.analyticType === 'dimension') {
-            return mutPath(data, 'encodings.rows', (rows) => replace(rows, rows.length - 1, (x) => ({ ...x, sort })));
+            return mutPath(data, 'encodings.rows', (rows) =>
+                replace(rows, rows.length - 1, (x) => ({
+                    ...x,
+                    sort,
+                    sortType: 'measure' as const,
+                    sortList: undefined,
+                }))
+            );
         }
         return data;
     },
@@ -442,6 +458,20 @@ const actions: {
                         return [fname, newFields];
                     })
                 ) as typeof e
+        );
+    },
+    [Methods.editField]: (data, channel, index, newData) => {
+        return mutPath(data, `encodings.${channel}`, (fields) =>
+            replace(fields, index, (field) => {
+                const nextField = { ...field, ...newData } as IViewField;
+                if ((nextField.sortType ?? 'measure') !== 'manual') {
+                    nextField.sortList = undefined;
+                }
+                if ((nextField.sortType ?? 'measure') === 'measure') {
+                    nextField.sort = nextField.sort ?? 'none';
+                }
+                return nextField;
+            })
         );
     },
     [Methods.editAllField]: (data, fid, newData) => {

--- a/packages/graphic-walker/src/store/visualSpecStore.ts
+++ b/packages/graphic-walker/src/store/visualSpecStore.ts
@@ -91,6 +91,8 @@ export class VizSpecStore {
     showAskvizFeedbackIndex: number | undefined = 0;
     lastSpec: string = '';
     editingComputedFieldFid: string | undefined = undefined;
+    showFieldConfigPanel: boolean = false;
+    fieldConfigTarget: { channel: keyof Omit<DraggableFieldState, 'filters'>; index: number } | null = null;
     defaultConfig: IDefaultConfig | undefined;
     /** fields highlighted in the field list (Tableau-style multi-select feeding Auto Viz); UI state, not part of the undo timeline */
     selectedFieldIds: string[] = [];
@@ -555,6 +557,10 @@ export class VizSpecStore {
         this.visList[this.visIndex] = performers.editAllField(this.visList[this.visIndex], origianlField.fid, { name: newName });
     }
 
+    editEncodingField(stateKey: keyof Omit<DraggableFieldState, 'filters'>, index: number, patch: Partial<IViewField>) {
+        this.visList[this.visIndex] = performers.editField(this.visList[this.visIndex], stateKey, index, patch);
+    }
+
     public createDateTimeDrilledField(
         stateKey: keyof Omit<DraggableFieldState, 'filters'>,
         index: number,
@@ -808,6 +814,18 @@ export class VizSpecStore {
 
     setShowRenamePanel(show: boolean) {
         this.showRenamePanel = show;
+    }
+
+    setShowFieldConfigPanel(show: boolean) {
+        this.showFieldConfigPanel = show;
+        if (!show) {
+            this.fieldConfigTarget = null;
+        }
+    }
+
+    openFieldConfig(channel: keyof Omit<DraggableFieldState, 'filters'>, index: number) {
+        this.fieldConfigTarget = { channel, index };
+        this.showFieldConfigPanel = true;
     }
 
     setCreateField(field: ICreateField) {

--- a/packages/graphic-walker/src/utils/index.ts
+++ b/packages/graphic-walker/src/utils/index.ts
@@ -100,19 +100,31 @@ export function getFilterMeaAggKey(field: IFilterField) {
 }
 export function getSort({ rows, columns }: { rows: readonly IViewField[]; columns: readonly IViewField[] }) {
     if (rows.length && !rows.find((x) => x.analyticType === 'measure')) {
-        return rows[rows.length - 1].sort || 'none';
+        const field = rows[rows.length - 1];
+        if ((field.sortType ?? 'measure') !== 'measure') return 'none';
+        return field.sort || 'none';
     }
     if (columns.length && !columns.find((x) => x.analyticType === 'measure')) {
-        return columns[columns.length - 1].sort || 'none';
+        const field = columns[columns.length - 1];
+        if ((field.sortType ?? 'measure') !== 'measure') return 'none';
+        return field.sort || 'none';
     }
     return 'none';
 }
 
 export function getSortedEncoding({ rows, columns }: { rows: readonly IViewField[]; columns: readonly IViewField[] }) {
     if (rows.length && !rows.find((x) => x.analyticType === 'measure')) {
+        const field = rows[rows.length - 1];
+        if ((field.sortType ?? 'measure') !== 'measure' || !field.sort || field.sort === 'none') {
+            return 'none';
+        }
         return 'row';
     }
     if (columns.length && !columns.find((x) => x.analyticType === 'measure')) {
+        const field = columns[columns.length - 1];
+        if ((field.sortType ?? 'measure') !== 'measure' || !field.sort || field.sort === 'none') {
+            return 'none';
+        }
         return 'column';
     }
     return 'none';

--- a/packages/graphic-walker/src/vis/spec/aggregate.ts
+++ b/packages/graphic-walker/src/vis/spec/aggregate.ts
@@ -8,7 +8,6 @@ export function channelAggregate(encoding: { [key: string]: any }, fields: IView
         if (c.aggregate === null) return;
         const targetField = fields.find((f) => encodeFid(f.fid) === c.field && (f.analyticType === 'measure' || f.fid === COUNT_FIELD_ID));
         if (targetField && targetField.fid === COUNT_FIELD_ID) {
-            c.title = 'Count';
             c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName))
         } else if (targetField) {
             c.title = getMeaAggName(targetField.name, targetField.aggName),

--- a/packages/graphic-walker/src/vis/spec/aggregate.ts
+++ b/packages/graphic-walker/src/vis/spec/aggregate.ts
@@ -8,10 +8,15 @@ export function channelAggregate(encoding: { [key: string]: any }, fields: IView
         if (c.aggregate === null) return;
         const targetField = fields.find((f) => encodeFid(f.fid) === c.field && (f.analyticType === 'measure' || f.fid === COUNT_FIELD_ID));
         if (targetField && targetField.fid === COUNT_FIELD_ID) {
-            c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName))
+            if (!targetField.titleOverride) {
+                c.title = 'Count';
+            }
+            c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName));
         } else if (targetField) {
-            c.title = getMeaAggName(targetField.name, targetField.aggName),
-            c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName))
+            if (!targetField.titleOverride) {
+                c.title = getMeaAggName(targetField.name, targetField.aggName);
+            }
+            c.field = encodeFid(getMeaAggKey(targetField.fid, targetField.aggName));
         }
     });
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -21,7 +21,7 @@
     "@headlessui/react": "1.7.12",
     "@heroicons/react": "^2.0.8",
     "@kanaries/duckdb-computation": "0.0.1",
-    "@kanaries/graphic-walker": "0.5.0",
+    "@kanaries/graphic-walker": "0.5.1",
     "@vercel/analytics": "^1.1.1",
     "color-space": "2.0.1",
     "react": "^19.2.0",


### PR DESCRIPTION
## Summary

Ports the **Field Settings** feature from the orphaned `v0.5.0-alpha.4` release line (its source branch was deleted; recovered from the tag) onto current `main`, and bumps the version to **0.5.1** so the feature ships under a proper stable version.

Double-click or right-click any pill in the view to open **Field Settings**:

- **Title Override** — custom axis/legend title per field (`titleOverride`)
- **Custom Sort** — three strategies (`sortType`): by opposite axis (default) / alphabetical / **manual drag-to-order** over the field's distinct values (`sortList`); pills show a `MANUAL` badge
- **Custom Format** — d3 format string per field (`customFormat`), routed to the right channel (axis / legend / facet header / text); overrides the chart-level `numberFormat`
- Analytic/semantic type and aggregator switching from the same dialog

Original work by @islxyqwe (cherry-picked commits preserve authorship).

## Cherry-picked from v0.5.0-alpha.4

- `feat: custom edit for field in view`
- `fix: build error`
- `fix: special fields`
- `fix: row count`
- `fix: aggregate`

Deliberately **not** included from the alpha line: the `npm publish` `--tag` override in release.yml (it published the alpha as `latest` on npm — see note below), version-bump/publish chores, and the `react-resize-detector` 9→12 / `re-resizable` upgrades (orthogonal, should be their own PR).

## Merge-conflict resolutions of note

- `models/visSpecHistory.ts`: both lines appended a member to the serialized `Methods` enum — `editField` (this feature) is placed **after** `replaceChart` (Auto Viz, #515-era) to keep numeric enum values of `main`-exported timelines stable. Timelines exported by the alpha builds that contain `editField` ops are not compatible (accepted: alpha-only audience).
- `models/chat.ts`: kept both new `actionMessageMapper` entries.

## Verification

- Build green; generated `chartinfo.json` schema picks up the four new `IViewField` props automatically
- **23/23 jest suites, 284 tests, 4 snapshots pass** on a fresh install (on top of #516)
- Browser-verified in the playground: title override, manual sort order, MANUAL badge, `$,.2s` axis format; **Auto Viz's `replaceChart` and this feature's `editField` coexist in one session with correct undo/redo across the mixed history**

## Post-merge notes

- npm `latest` dist-tag currently points at `0.5.0-alpha.4` (published via the alpha's release.yml override). Releasing 0.5.1 from this PR via the normal release flow will reclaim `latest`.
- TerseSpec `project()` (chart → terse) does not carry the four new field props (expand direction is unaffected). Lossy by design for now; worth a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)