### PR TITLE
fix(#507): support non-ASCII field names in computed expressions + UTF-8 BOM in CSV export

### DIFF
--- a/packages/graphic-walker/src/components/computedField/index.tsx
+++ b/packages/graphic-walker/src/components/computedField/index.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useMemo, useEffect } from 'react';
 import { useVizStore } from '../../store';
 import { isNotEmpty, parseErrorMessage } from '../../utils';
 import { highlightField } from '../highlightField';
-import { aggFuncs, reservedKeywords, sqlFunctions } from '../../lib/sql';
+import { aggFuncs, reservedKeywords, sqlFunctions, quoteNonAsciiIdents } from '../../lib/sql';
 import { COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID, PAINT_FIELD_ID } from '../../constants';
 import { unstable_batchedUpdates } from 'react-dom';
 import { Dialog, DialogContent } from '../ui/dialog';
@@ -29,7 +29,12 @@ const ComputedFieldDialog: React.FC = observer(() => {
             .filter((x) => ![COUNT_FIELD_ID, MEA_KEY_ID, MEA_VAL_ID, PAINT_FIELD_ID].includes(x.fid))
             .map((x) => x.name.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
             .join('|');
-        const fieldRegex = fields.length > 0 ? new RegExp(`\\b(${fields})\\b`, 'gi') : null;
+        // Use Unicode-aware lookahead/lookbehind instead of \b so that
+        // non-ASCII field names (e.g. Korean, CJK) are matched and highlighted.
+        const fieldRegex =
+            fields.length > 0
+                ? new RegExp(`(?<![\\w\\u00C0-\\uFFFF])(${fields})(?![\\w\\u00C0-\\uFFFF])`, 'gi')
+                : null;
         return highlightField((sql: string) => {
             // highlight field
             if (fieldRegex) {
@@ -130,7 +135,10 @@ const ComputedFieldDialog: React.FC = observer(() => {
                             children={editingComputedFieldFid === '' ? 'Add' : 'Edit'}
                             onClick={() => {
                                 try {
-                                    vizStore.upsertComputedField(editingComputedFieldFid!, name, sql);
+                                    // Pre-process: wrap non-ASCII field names in double-quotes so
+                                    // pgsql-ast-parser can parse them as delimited identifiers.
+                                    const processedSql = quoteNonAsciiIdents(sql, vizStore.allFields);
+                                    vizStore.upsertComputedField(editingComputedFieldFid!, name, processedSql);
                                     vizStore.setComputedFieldFid();
                                 } catch (e) {
                                     setError(parseErrorMessage(e));

--- a/packages/graphic-walker/src/lib/sql.ts
+++ b/packages/graphic-walker/src/lib/sql.ts
@@ -609,6 +609,54 @@ export function replaceFid(sql: string, fields: IMutField[]): string {
     return parser.toSql.expr(mapper.expr(item)!);
 }
 
+/**
+ * Pre-processes a SQL expression string so that field names containing
+ * non-ASCII characters (e.g. Korean, CJK, Arabic) are wrapped in
+ * double-quotes before the string is handed to pgsql-ast-parser.
+ *
+ * Background: pgsql-ast-parser's tokeniser follows the SQL standard and
+ * only recognises ASCII letters, digits and underscores as unquoted
+ * identifier characters.  Any non-ASCII character causes a parse error.
+ * Wrapping the name in double-quotes makes it a "delimited identifier",
+ * which the parser accepts and emits as a `ref` node with the raw name
+ * (quotes stripped) – so replaceFid / getSQLItemAnalyticType continue to
+ * work without modification.
+ *
+ * Names that are already double-quoted in the expression are left untouched.
+ * Longer names are processed before shorter ones to avoid partial matches.
+ *
+ * @param sql    Raw SQL expression as typed by the user.
+ * @param fields All dataset fields (used to build the replacement set).
+ * @returns      The expression with non-ASCII bare identifiers quoted.
+ */
+export function quoteNonAsciiIdents(sql: string, fields: IMutField[]): string {
+    // Collect names that contain at least one non-ASCII character
+    const nonAsciiNames = fields
+        .map((f) => f.name ?? f.fid)
+        .filter((name) => /[^\x00-\x7F]/.test(name))
+        // Longest first – prevents a shorter prefix from being replaced inside a longer name
+        .sort((a, b) => b.length - a.length);
+
+    if (nonAsciiNames.length === 0) return sql;
+
+    let result = sql;
+    for (const name of nonAsciiNames) {
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        // Skip occurrences that are already quoted
+        const alreadyQuoted = new RegExp(`"${escaped}"`);
+        // Work on a temporary copy to test for existing quotes, then replace bare form
+        const barePattern = new RegExp(escaped, 'g');
+        result = result.replace(barePattern, (match, offset, str) => {
+            // Check if the match is surrounded by double-quotes already
+            if (str[offset - 1] === '"' && str[offset + match.length] === '"') {
+                return match; // already quoted – leave as-is
+            }
+            return `"${match}"`;
+        });
+    }
+    return result;
+}
+
 function fmap<T>(x: T | T[], mapper: (i: T) => T) {
     if (x instanceof Array) {
         return x.map(mapper);

--- a/packages/graphic-walker/src/renderer/index.tsx
+++ b/packages/graphic-walker/src/renderer/index.tsx
@@ -108,8 +108,10 @@ const Renderer = forwardRef<IReactVegaHandler, RendererProps>(function (props, r
                         }
                         return { fid: x.fid, name: x.name };
                     });
-                    const result = `${headers.map((x) => x.name).join(',')}\n${data.map((x) => headers.map((f) => x[f.fid]).join(',')).join('\n')}`;
-                    download(result, `${chart.name}.csv`, 'text/plain');
+                    const csvBody = `${headers.map((x) => x.name).join(',')}\n${data.map((x) => headers.map((f) => x[f.fid]).join(',')).join('\n')}`;
+                    // Prepend UTF-8 BOM (\uFEFF) so Excel auto-detects UTF-8 and renders
+                    // non-ASCII column names (e.g. Korean / CJK) without mojibake.
+                    download('\uFEFF' + csvBody, `${chart.name}.csv`, 'text/csv;charset=utf-8');
                 },
             };
         }


### PR DESCRIPTION
## Problem

Two related bugs affecting users whose dataset has non-ASCII column names (Korean / CJK / Arabic / any Unicode outside ASCII):

### 1 — Computed field expressions fail with non-ASCII column names

`pgsql-ast-parser` follows the SQL standard and only recognises ASCII letters, digits and underscores as unquoted identifier characters. When a user types an expression like `판매량 * 2` (Korean for "sales volume × 2") in the computed-field dialog, the parser throws:

```
Unexpected token: 판
```

and the field cannot be saved at all.

Additionally the syntax-highlight regex in `computedField/index.tsx` used `\b…\b` word-boundary anchors, which are ASCII-only (`\b` only transitions between `[A-Za-z0-9_]` and non-word). Non-ASCII field names are therefore never highlighted in the editor.

### 2 — CSV export garbled in Excel for non-ASCII column headers

The `download()` call in `renderer/index.tsx` used `'text/plain'` as the MIME type and emitted no BOM. Excel on Windows defaults to the system code-page (e.g. CP1252) when no BOM is present, causing Korean / CJK column headers to be displayed as mojibake.

---

## Changes

### `packages/graphic-walker/src/lib/sql.ts`

- **Add `quoteNonAsciiIdents(sql, fields)`** — a pre-processing helper that wraps bare non-ASCII field names in SQL double-quotes before the expression string is handed to `pgsql-ast-parser`.
  - Quoted identifiers (e.g. `"판매량"`) are valid in standard SQL; `pgsql-ast-parser` emits them as `ref` nodes with the raw unquoted name, so `replaceFid` / `getSQLItemAnalyticType` continue to work unchanged.
  - Names that are already double-quoted in the expression are left untouched (checked via a character-offset guard in the replacer callback).
  - Longer names are processed before shorter ones to prevent partial matches on name prefixes.

### `packages/graphic-walker/src/components/computedField/index.tsx`

- **Import and call `quoteNonAsciiIdents`** on the raw SQL string just before passing it to `vizStore.upsertComputedField()`. The stored value is therefore always the pre-processed (parser-safe) form, consistent with what `workflow.ts → replaceFid` expects.
- **Fix `fieldRegex` Unicode boundary** — replace the ASCII-only `\b(…)\b` pattern with the Unicode-aware lookahead/lookbehind `(?<![\w\u00C0-\uFFFF])(…)(?![\w\u00C0-\uFFFF])`. This ensures Korean (and other non-ASCII) field names are correctly syntax-highlighted in the editor.

### `packages/graphic-walker/src/renderer/index.tsx`

- **Prepend UTF-8 BOM (`\uFEFF`)** to the CSV body string.
- **Change MIME type** from `'text/plain'` → `'text/csv;charset=utf-8'`.
  Excel reads the BOM byte-order-mark and correctly auto-detects UTF-8, eliminating mojibake on Korean / CJK column headers. Other consumers (browsers, pandas `read_csv`, etc.) are unaffected — the BOM is either ignored or handled transparently.

---

## Testing

1. Load a dataset with Korean column names (e.g. `{ 판매량: 100, 지역: 'Seoul' }`).
2. Click **Add Computed Field** → enter `판매량 * 1.1` → click **Add**. Previously: parse error. Now: field is created with correct `quantitative` semantic type.
3. Verify the Korean field name is highlighted in blue in the SQL editor.
4. Click the CSV download button and open the file in Microsoft Excel. Previously: garbled headers. Now: Korean column names display correctly.

Fixes #507